### PR TITLE
doctor: validate all critical config files at boot tier

### DIFF
--- a/src/doctor/providers/boot.py
+++ b/src/doctor/providers/boot.py
@@ -148,36 +148,78 @@ def check_python_runtime() -> DoctorCheck:
     )
 
 
+CRITICAL_CONFIG_FILES = (
+    ("schedule.json", ("config", "schedule.json")),
+    ("optionals.json", ("config", "optionals.json")),
+    ("crons/manifest.json", ("crons", "manifest.json")),
+)
+
+
 def check_config_parse() -> DoctorCheck:
-    """Check schedule.json parses correctly if present."""
-    schedule_file = NEXO_HOME / "config" / "schedule.json"
-    if not schedule_file.exists():
-        return DoctorCheck(
-            id="boot.config_parse",
-            tier="boot",
-            status="healthy",
-            severity="info",
-            summary="No schedule.json (using defaults)",
-        )
-    try:
-        import json
-        json.loads(schedule_file.read_text())
-        return DoctorCheck(
-            id="boot.config_parse",
-            tier="boot",
-            status="healthy",
-            severity="info",
-            summary="schedule.json parses OK",
-        )
-    except Exception as e:
+    """Validate that critical JSON config files parse correctly.
+
+    Covers schedule.json, optionals.json, and crons/manifest.json. A broken
+    manifest.json silently disables the entire cron catch-up pipeline
+    (load_enabled_crons swallows the parse error and returns []), so
+    catching corruption at boot tier prevents hours of silent reliability
+    loss. Missing files are fine — they fall back to code defaults.
+    """
+    import json
+
+    errors: list[str] = []
+    checked: list[str] = []
+    missing: list[str] = []
+
+    for label, relative in CRITICAL_CONFIG_FILES:
+        path = NEXO_HOME.joinpath(*relative)
+        if not path.exists():
+            missing.append(label)
+            continue
+        try:
+            data = json.loads(path.read_text())
+        except Exception as e:
+            errors.append(f"{label}: {e}")
+            continue
+        if not isinstance(data, dict):
+            errors.append(
+                f"{label}: expected JSON object, got {type(data).__name__}"
+            )
+            continue
+        checked.append(label)
+
+    if errors:
         return DoctorCheck(
             id="boot.config_parse",
             tier="boot",
             status="degraded",
             severity="warn",
-            summary=f"schedule.json parse error: {e}",
-            repair_plan=["Fix JSON syntax in schedule.json or delete to use defaults"],
+            summary=(
+                f"{len(errors)} config file parse error"
+                + ("s" if len(errors) != 1 else "")
+            ),
+            evidence=errors,
+            repair_plan=[
+                "Fix JSON syntax in the listed config files, or delete them to fall back to defaults",
+            ],
         )
+
+    if not checked:
+        return DoctorCheck(
+            id="boot.config_parse",
+            tier="boot",
+            status="healthy",
+            severity="info",
+            summary="No config files present (using defaults)",
+        )
+
+    return DoctorCheck(
+        id="boot.config_parse",
+        tier="boot",
+        status="healthy",
+        severity="info",
+        summary=f"{len(checked)} config file{'s' if len(checked) != 1 else ''} parse OK",
+        evidence=checked,
+    )
 
 
 def run_boot_checks(fix: bool = False) -> list[DoctorCheck]:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -89,6 +89,30 @@ class TestBootChecks:
         assert dir_check.fixed
         assert (nexo_home / "coordination").is_dir()
 
+    def test_config_parse_catches_broken_manifest(self, nexo_home):
+        (nexo_home / "crons" / "manifest.json").write_text("{not valid json")
+        from doctor.providers.boot import check_config_parse
+        check = check_config_parse()
+        assert check.status == "degraded"
+        assert any("crons/manifest.json" in ev for ev in check.evidence)
+
+    def test_config_parse_catches_broken_optionals(self, nexo_home):
+        (nexo_home / "config").mkdir(parents=True, exist_ok=True)
+        (nexo_home / "config" / "optionals.json").write_text("[]")  # wrong type
+        from doctor.providers.boot import check_config_parse
+        check = check_config_parse()
+        assert check.status == "degraded"
+        assert any("optionals.json" in ev for ev in check.evidence)
+
+    def test_config_parse_healthy_when_all_valid(self, nexo_home):
+        (nexo_home / "config").mkdir(parents=True, exist_ok=True)
+        (nexo_home / "config" / "schedule.json").write_text('{"automation_enabled": true}')
+        (nexo_home / "config" / "optionals.json").write_text('{"automation": true}')
+        from doctor.providers.boot import check_config_parse
+        check = check_config_parse()
+        assert check.status == "healthy"
+        assert set(check.evidence) == {"schedule.json", "optionals.json", "crons/manifest.json"}
+
 
 class TestRuntimeChecks:
     def test_fresh_immune(self, nexo_home):


### PR DESCRIPTION
The boot tier config check only parsed schedule.json. A corrupted crons/manifest.json or optionals.json would go undetected at boot, yet load_enabled_crons swallows the parse error and returns [], silently disabling the entire cron catch-up pipeline for hours. optionals.json corruption similarly turns off optional features without surfacing any diagnostic.

Summary:
Generalized boot.config_parse in src/doctor/providers/boot.py to validate all three critical JSON config files (schedule.json, optionals.json, crons/manifest.json), report per-file parse errors as evidence, and also reject non-object JSON (wrong top-level type) which would break downstream consumers. Added three new tests in tests/test_doctor.py covering broken manifest, wrong-typed optionals, and the all-valid healthy path.

Tests:
- python3 -m pytest tests/test_doctor.py::TestBootChecks -x -q
- python3 -m pytest tests/test_doctor.py tests/test_cron_recovery.py -q

Risks:
- Summary text for boot.config_parse changed (e.g. 'schedule.json parses OK' → 'N config files parse OK'); any external monitoring that string-matches the old summary would need to update.
- Stricter type validation (expects a JSON object at the top level) would now flag a user who intentionally wrote a JSON array into one of these files as degraded, though current code paths already assume dict and would crash or misbehave in that case.

Source: automated public core evolution from an opt-in machine.
