### PR TITLE
fix: replace deprecated datetime.utcnow() in cognitive memory/search

### DIFF
--- a/src/cognitive/_memory.py
+++ b/src/cognitive/_memory.py
@@ -1,7 +1,14 @@
 """NEXO Cognitive — Memory operations: format, stats, consolidation, somatic."""
 import json, math, re
 import numpy as np
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
+
+
+def _utcnow_naive() -> datetime:
+    """Timezone-aware UTC clock returned as a naive datetime to preserve
+    the legacy ``datetime.utcnow()`` string format on disk.
+    """
+    return datetime.now(timezone.utc).replace(tzinfo=None)
 from cognitive._core import _get_db, embed, cosine_similarity, _blob_to_array, _array_to_blob, EMBEDDING_DIM, DISCRIMINATING_ENTITIES
 from cognitive._ingest import _sanitize_memory_content
 
@@ -74,7 +81,7 @@ def get_metrics(days: int = 7) -> dict:
         score_distribution: histogram buckets [<0.5, 0.5-0.6, 0.6-0.7, 0.7-0.8, >0.8]
     """
     db = _get_db()
-    cutoff = (datetime.utcnow() - timedelta(days=days)).isoformat()
+    cutoff = (_utcnow_naive() - timedelta(days=days)).isoformat()
 
     rows = db.execute(
         "SELECT top_score FROM retrieval_log WHERE created_at >= ?", (cutoff,)
@@ -130,7 +137,7 @@ def check_repeat_errors() -> dict:
     Returns count of new learnings that are semantically duplicate (cosine > 0.8).
     """
     db = _get_db()
-    cutoff_7d = (datetime.utcnow() - timedelta(days=7)).isoformat()
+    cutoff_7d = (_utcnow_naive() - timedelta(days=7)).isoformat()
 
     # Recent learning STM entries
     new_learnings = db.execute(
@@ -192,7 +199,7 @@ def rehearse_by_content(content_keywords: str, source_type: str = ""):
         if np.linalg.norm(query_vec) == 0:
             return
 
-        now = datetime.utcnow().isoformat()
+        now = _utcnow_naive().isoformat()
 
         # Search both stores for matches >= 0.7
         for table in ("stm_memories", "ltm_memories"):
@@ -803,7 +810,7 @@ def security_scan(content: str) -> dict:
 def somatic_accumulate(target: str, target_type: str, delta: float):
     """Increase risk_score for a target (file or area). Capped at 1.0."""
     db = _get_db()
-    now = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S")
+    now = _utcnow_naive().strftime("%Y-%m-%dT%H:%M:%S")
     existing = db.execute(
         "SELECT id, risk_score, incident_count FROM somatic_markers WHERE target = ? AND target_type = ?",
         (target, target_type)
@@ -827,8 +834,8 @@ def somatic_accumulate(target: str, target_type: str, delta: float):
 def somatic_guard_decay(target: str, target_type: str):
     """Validated recovery: multiplicative x0.7 on successful guard check. Max once/day/target."""
     db = _get_db()
-    today = datetime.utcnow().strftime("%Y-%m-%d")
-    now = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S")
+    today = _utcnow_naive().strftime("%Y-%m-%d")
+    now = _utcnow_naive().strftime("%Y-%m-%dT%H:%M:%S")
     row = db.execute(
         "SELECT id, risk_score, last_guard_decay_date FROM somatic_markers WHERE target = ? AND target_type = ?",
         (target, target_type)

--- a/src/cognitive/_search.py
+++ b/src/cognitive/_search.py
@@ -3,7 +3,14 @@ import math
 import re
 import sqlite3
 import numpy as np
-from datetime import datetime
+from datetime import datetime, timezone
+
+
+def _utcnow_naive() -> datetime:
+    """Timezone-aware UTC clock returned as a naive datetime to preserve
+    the legacy ``datetime.utcnow()`` string format on disk.
+    """
+    return datetime.now(timezone.utc).replace(tzinfo=None)
 from cognitive._core import (
     _get_db, embed, cosine_similarity, _blob_to_array, _array_to_blob,
     _get_model, _get_reranker, rerank_results, EMBEDDING_DIM,
@@ -461,7 +468,7 @@ def record_co_activation(memory_ids: list[tuple[str, int]]):
         return
 
     db = _get_db()
-    now = datetime.utcnow().isoformat()
+    now = _utcnow_naive().isoformat()
 
     hashes = [_canonical_co_id(store, mid) for store, mid in memory_ids]
 
@@ -571,7 +578,7 @@ def _match_triggers(
         text_vec = embed(text)
 
     matched_triggers = []
-    now = datetime.utcnow().isoformat()
+    now = _utcnow_naive().isoformat()
 
     for trigger in armed:
         pattern = trigger["trigger_pattern"].lower()
@@ -667,7 +674,7 @@ def rearm_trigger(trigger_id: int) -> str:
 
 def _auto_restore_snoozed(db: sqlite3.Connection):
     """Restore snoozed memories whose snooze_until date has passed."""
-    now = datetime.utcnow().isoformat()
+    now = _utcnow_naive().isoformat()
     for table in ("stm_memories", "ltm_memories"):
         db.execute(
             f"UPDATE {table} SET lifecycle_state = 'active', snooze_until = NULL "
@@ -682,7 +689,7 @@ def _rehearse_results(results: list[dict], skip_ids: set = None):
     if not results:
         return
     db = _get_db()
-    now = datetime.utcnow().isoformat()
+    now = _utcnow_naive().isoformat()
     skip = skip_ids or set()
     for r in results:
         if (r["store"], r["id"]) in skip:


### PR DESCRIPTION
src/cognitive/_search.py and src/cognitive/_memory.py still call datetime.utcnow(), which is deprecated in Python 3.12+ and emits DeprecationWarning at runtime. The v3.0.1 backlog flagged this as a post-release polish item, but the calls remained in place.

Summary:
Added a small _utcnow_naive() helper in both modules that returns datetime.now(timezone.utc).replace(tzinfo=None), then replaced every datetime.utcnow() call site in src/cognitive/_search.py (4 sites) and src/cognitive/_memory.py (6 sites) with the helper. The helper deliberately strips tzinfo so existing isoformat()/strftime() outputs written to SQLite remain byte-identical to the legacy format, keeping DB behavior stable.

Tests:
- python3 -W error::DeprecationWarning -m py_compile src/cognitive/_search.py src/cognitive/_memory.py
- python3 -m pytest tests/test_cognitive.py -W error::DeprecationWarning -x -q

Risks:
- Other cognitive modules (_decay.py, _trust.py, _ingest.py) still use datetime.utcnow() and will keep emitting deprecation warnings until a follow-up applies the same pattern.
- Any external caller importing the now-removed datetime.utcnow paths via reflection would break, but no such consumer exists in this repo.

Source: automated public core evolution from an opt-in machine.
