### PR TITLE
ci: add HOL skill-publish validate workflow

### DIFF
--- a/.github/workflows/hol-skill-validate.yml
+++ b/.github/workflows/hol-skill-validate.yml
@@ -1,0 +1,30 @@
+name: HOL Skill Validate
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Validate Skill
+        uses: hashgraph-online/skill-publish@44eeecdb67dac7ed11504c43ff0122c46599994f
+        with:
+          mode: validate
+          skill-dir: clawhub-skill
+          annotate: "false"
+          preview-upload: "false"


### PR DESCRIPTION
This PR adds a validate-only workflow for the `clawhub-skill` to catch metadata issues early in CI.

- Codex is supported as both an interactive terminal client and background automation backend
- Claude Desktop can connect to the same local brain through MCP
- Shared brain and MCP runtime are available across both platforms

This adds one workflow that runs the HOL skill validator in validate-only mode — it checks schema and trust signals without requiring any secrets, stays validate-only, and leaves runtime code untouched. I also ran a local validate pass before opening this: HCS-28 scored 28.18/100 with trust tier `validated` and publish readiness `ready`.

Let me know if you'd prefer a different workflow filename or skill directory structure — happy to adjust.