### PR TITLE
fix: AttributeError in maintenance.py from wrong timezone import

### DIFF
--- a/src/maintenance.py
+++ b/src/maintenance.py
@@ -1,7 +1,7 @@
 """Opportunistic maintenance — run overdue tasks on MCP startup."""
 
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from db import get_db
 
 
@@ -16,7 +16,7 @@ def check_and_run_overdue():
         if last_run:
             try:
                 last_dt = datetime.strptime(last_run, "%Y-%m-%dT%H:%M:%S")
-                hours_since = (datetime.now(datetime.timezone.utc).replace(tzinfo=None) - last_dt).total_seconds() / 3600
+                hours_since = (datetime.now(timezone.utc).replace(tzinfo=None) - last_dt).total_seconds() / 3600
                 if hours_since < interval:
                     continue
             except (ValueError, TypeError):
@@ -28,7 +28,7 @@ def check_and_run_overdue():
             conn.execute(
                 "UPDATE maintenance_schedule SET last_run_at = ?, last_duration_ms = ?, "
                 "run_count = run_count + 1 WHERE task_name = ?",
-                (datetime.now(datetime.timezone.utc).replace(tzinfo=None).strftime("%Y-%m-%dT%H:%M:%S"), duration_ms, task))
+                (datetime.now(timezone.utc).replace(tzinfo=None).strftime("%Y-%m-%dT%H:%M:%S"), duration_ms, task))
             conn.commit()
             ran.append({"task": task, "duration_ms": duration_ms})
         except Exception as e:


### PR DESCRIPTION
maintenance.py imported only `datetime` class (`from datetime import datetime`) but referenced `datetime.timezone.utc` on lines 19 and 31. The `timezone` class lives in the `datetime` module, not as an attribute of the `datetime` class, so every call to `check_and_run_overdue()` would raise `AttributeError: type object 'datetime.datetime' has no attribute 'timezone'`. This meant opportunistic maintenance tasks (cognitive_decay, somatic_decay, weight_learning, etc.) never ran on MCP startup.

Summary:
Added `timezone` to the import (`from datetime import datetime, timezone`) and replaced both `datetime.timezone.utc` references with `timezone.utc`.

Tests:
- python3 -c "import sys; sys.path.insert(0, 'src'); from maintenance import check_and_run_overdue; print('import OK')"
- python3 -m pytest tests/test_cli_scripts.py -x -q

Risks:
- None — pure bugfix, no behavior change beyond making the function actually work

Source: automated public core evolution from an opt-in machine.
