### PR TITLE
fix: make doctor orchestrator resilient to tier crashes and invalid input

### DIFF
--- a/src/doctor/orchestrator.py
+++ b/src/doctor/orchestrator.py
@@ -1,9 +1,11 @@
 """Doctor orchestrator — runs providers by tier, aggregates results."""
 from __future__ import annotations
 
+import sys
 import time
+import traceback
 
-from doctor.models import DoctorReport
+from doctor.models import DoctorCheck, DoctorReport
 from doctor.providers.boot import run_boot_checks
 from doctor.providers.runtime import run_runtime_checks
 from doctor.providers.deep import run_deep_checks
@@ -17,6 +19,8 @@ _TIER_RUNNERS = {
 
 _TIER_ORDER = ["boot", "runtime", "deep"]
 
+VALID_TIERS = frozenset(_TIER_ORDER) | {"all"}
+
 
 def run_doctor(tier: str = "boot", fix: bool = False) -> DoctorReport:
     """Run diagnostic checks for the specified tier(s).
@@ -28,14 +32,40 @@ def run_doctor(tier: str = "boot", fix: bool = False) -> DoctorReport:
     report = DoctorReport(overall_status="healthy")
     start = time.monotonic()
 
+    if tier not in VALID_TIERS:
+        report.add(DoctorCheck(
+            id="orchestrator.invalid_tier",
+            tier="orchestrator",
+            status="critical",
+            severity="error",
+            summary=f"Unknown tier '{tier}' — valid options: {', '.join(sorted(VALID_TIERS))}",
+        ))
+        report.compute_status()
+        report.duration_ms = int((time.monotonic() - start) * 1000)
+        return report
+
     tiers = _TIER_ORDER if tier == "all" else [tier]
 
     for t in tiers:
         runner = _TIER_RUNNERS.get(t)
-        if runner:
+        if not runner:
+            continue
+        try:
             checks = runner(fix=fix)
             for check in checks:
                 report.add(check)
+        except Exception as exc:
+            tb = traceback.format_exception(type(exc), exc, exc.__traceback__)
+            last_frame = tb[-1].strip() if tb else str(exc)
+            report.add(DoctorCheck(
+                id=f"orchestrator.{t}_crashed",
+                tier=t,
+                status="critical",
+                severity="error",
+                summary=f"{t} tier checks crashed: {type(exc).__name__}: {exc}",
+                evidence=[last_frame],
+                repair_plan=[f"Investigate {t} provider — exception during check execution"],
+            ))
 
     report.compute_status()
     report.duration_ms = int((time.monotonic() - start) * 1000)

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1462,6 +1462,44 @@ class TestOrchestrator:
         assert "runtime" in tiers
         assert "deep" in tiers
 
+    def test_invalid_tier_returns_critical(self, nexo_home):
+        from doctor.orchestrator import run_doctor
+        report = run_doctor(tier="nonexistent")
+        assert report.overall_status == "critical"
+        assert len(report.checks) == 1
+        assert report.checks[0].id == "orchestrator.invalid_tier"
+        assert "nonexistent" in report.checks[0].summary
+
+    def test_tier_crash_is_caught_and_reported(self, nexo_home, monkeypatch):
+        from doctor import orchestrator
+
+        def exploding_runner(fix=False):
+            raise RuntimeError("provider exploded")
+
+        monkeypatch.setitem(orchestrator._TIER_RUNNERS, "boot", exploding_runner)
+
+        report = orchestrator.run_doctor(tier="boot")
+        assert report.overall_status == "critical"
+        crash_checks = [c for c in report.checks if c.id == "orchestrator.boot_crashed"]
+        assert len(crash_checks) == 1
+        assert "RuntimeError" in crash_checks[0].summary
+        assert "provider exploded" in crash_checks[0].summary
+
+    def test_partial_tier_crash_preserves_other_tiers(self, nexo_home, monkeypatch):
+        from doctor import orchestrator
+
+        def exploding_runtime(fix=False):
+            raise ValueError("runtime blew up")
+
+        monkeypatch.setitem(orchestrator._TIER_RUNNERS, "runtime", exploding_runtime)
+
+        report = orchestrator.run_doctor(tier="all")
+        tiers = {c.tier for c in report.checks}
+        assert "boot" in tiers
+        assert "deep" in tiers
+        crash_checks = [c for c in report.checks if c.id == "orchestrator.runtime_crashed"]
+        assert len(crash_checks) == 1
+
 
 class TestFormatters:
     def test_json_format(self, nexo_home):


### PR DESCRIPTION
The doctor orchestrator had two silent failure modes: (1) passing an invalid tier name (e.g. run_doctor(tier='foo')) silently returned a healthy report with zero checks, giving false confidence that the system was healthy; (2) if any tier's provider raised an unhandled exception, the entire run_doctor call crashed instead of degrading gracefully — meaning a bug in one tier's checks could prevent all diagnostic output.

Summary:
Added input validation for the tier parameter — invalid tiers now produce a critical-status report with a clear error check instead of an empty healthy report. Wrapped each tier runner in try/except so that if a provider crashes, the orchestrator captures the exception as a critical DoctorCheck (with traceback evidence) and continues running remaining tiers. This ensures partial diagnostic results are always available even when one tier is broken. Added 3 new tests: invalid tier detection, single-tier crash capture, and partial crash with cross-tier preservation.

Tests:
- python3 -m pytest tests/test_doctor.py::TestOrchestrator -xvs
- python3 -m pytest tests/test_doctor.py -x

Risks:
- The traceback in evidence could contain file paths — acceptable for diagnostic output but worth noting for log-sensitive environments

Source: automated public core evolution from an opt-in machine.
