### PR TITLE
fix: isolate individual doctor checks so one crash does not take down an entire tier

### DIFF
--- a/src/doctor/models.py
+++ b/src/doctor/models.py
@@ -1,7 +1,9 @@
 """Doctor data models — check results and report structure."""
 from __future__ import annotations
 
+import traceback
 from dataclasses import dataclass, field
+from typing import Callable
 
 
 @dataclass
@@ -42,3 +44,26 @@ class DoctorReport:
             "critical": statuses.count("critical"),
             "total": len(statuses),
         }
+
+
+def safe_check(fn: Callable[..., DoctorCheck], *args, **kwargs) -> DoctorCheck:
+    """Run a single check function, returning a crash DoctorCheck on exception.
+
+    This isolates individual checks so one failure doesn't take down
+    all sibling checks within a tier.
+    """
+    try:
+        return fn(*args, **kwargs)
+    except Exception as exc:
+        tb = traceback.format_exception(type(exc), exc, exc.__traceback__)
+        last_frame = tb[-1].strip() if tb else str(exc)
+        check_name = getattr(fn, "__name__", "unknown")
+        return DoctorCheck(
+            id=f"check.{check_name}_crashed",
+            tier="unknown",
+            status="critical",
+            severity="error",
+            summary=f"Check {check_name} crashed: {type(exc).__name__}: {exc}",
+            evidence=[last_frame],
+            repair_plan=[f"Investigate {check_name} — exception during check execution"],
+        )

--- a/src/doctor/providers/boot.py
+++ b/src/doctor/providers/boot.py
@@ -6,7 +6,7 @@ import shutil
 import sys
 from pathlib import Path
 
-from doctor.models import DoctorCheck
+from doctor.models import DoctorCheck, safe_check
 
 NEXO_HOME = Path(os.environ.get("NEXO_HOME", str(Path.home() / ".nexo")))
 
@@ -209,12 +209,12 @@ def check_config_parse() -> DoctorCheck:
 def run_boot_checks(fix: bool = False) -> list[DoctorCheck]:
     """Run all boot-tier checks."""
     checks = [
-        check_db_exists(),
-        check_required_dirs(),
-        check_disk_space(),
-        check_wrapper_scripts(),
-        check_python_runtime(),
-        check_config_parse(),
+        safe_check(check_db_exists),
+        safe_check(check_required_dirs),
+        safe_check(check_disk_space),
+        safe_check(check_wrapper_scripts),
+        safe_check(check_python_runtime),
+        safe_check(check_config_parse),
     ]
 
     if fix:

--- a/src/doctor/providers/deep.py
+++ b/src/doctor/providers/deep.py
@@ -6,7 +6,7 @@ import os
 import time
 from pathlib import Path
 
-from doctor.models import DoctorCheck
+from doctor.models import DoctorCheck, safe_check
 
 NEXO_HOME = Path(os.environ.get("NEXO_HOME", str(Path.home() / ".nexo")))
 
@@ -284,9 +284,9 @@ def check_learning_count() -> DoctorCheck:
 def run_deep_checks(fix: bool = False) -> list[DoctorCheck]:
     """Run all deep-tier checks. Read-only."""
     return [
-        check_self_audit_summary(),
-        check_schema_version(),
-        check_preflight_summary(),
-        check_watchdog_smoke(),
-        check_learning_count(),
+        safe_check(check_self_audit_summary),
+        safe_check(check_schema_version),
+        safe_check(check_preflight_summary),
+        safe_check(check_watchdog_smoke),
+        safe_check(check_learning_count),
     ]

--- a/src/doctor/providers/runtime.py
+++ b/src/doctor/providers/runtime.py
@@ -25,7 +25,7 @@ from client_preferences import (
     resolve_client_runtime_profile,
 )
 from cron_recovery import should_run_at_load
-from doctor.models import DoctorCheck
+from doctor.models import DoctorCheck, safe_check
 
 NEXO_HOME = Path(os.environ.get("NEXO_HOME", str(Path.home() / ".nexo")))
 NEXO_CODE = Path(os.environ.get("NEXO_CODE", str(Path(__file__).resolve().parents[2])))
@@ -2623,22 +2623,22 @@ def check_automation_telemetry(days: int = 7) -> DoctorCheck:
 def run_runtime_checks(fix: bool = False) -> list[DoctorCheck]:
     """Run all runtime-tier checks. Read-only by default."""
     return [
-        check_immune_status(),
-        check_watchdog_status(),
-        check_stale_sessions(),
-        check_cron_freshness(),
-        check_client_backend_preferences(),
-        check_client_bootstrap_parity(fix=fix),
-        check_codex_session_parity(),
-        check_codex_conditioned_file_discipline(),
-        check_claude_desktop_shared_brain(),
-        check_transcript_source_parity(),
-        check_client_assumption_regressions(),
-        check_protocol_compliance(),
-        check_automation_telemetry(),
-        check_state_watchers(),
-        check_release_artifact_sync(),
-        check_launchagent_integrity(fix=fix),
-        check_personal_script_registry(fix=fix),
-        check_skill_health(fix=fix),
+        safe_check(check_immune_status),
+        safe_check(check_watchdog_status),
+        safe_check(check_stale_sessions),
+        safe_check(check_cron_freshness),
+        safe_check(check_client_backend_preferences),
+        safe_check(check_client_bootstrap_parity, fix=fix),
+        safe_check(check_codex_session_parity),
+        safe_check(check_codex_conditioned_file_discipline),
+        safe_check(check_claude_desktop_shared_brain),
+        safe_check(check_transcript_source_parity),
+        safe_check(check_client_assumption_regressions),
+        safe_check(check_protocol_compliance),
+        safe_check(check_automation_telemetry),
+        safe_check(check_state_watchers),
+        safe_check(check_release_artifact_sync),
+        safe_check(check_launchagent_integrity, fix=fix),
+        safe_check(check_personal_script_registry, fix=fix),
+        safe_check(check_skill_health, fix=fix),
     ]

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1518,3 +1518,75 @@ class TestFormatters:
         output = format_report(report, fmt="text")
         assert "NEXO Doctor" in output
         assert "BOOT" in output
+
+
+class TestSafeCheck:
+    def test_safe_check_passes_through_normal_result(self):
+        from doctor.models import DoctorCheck, safe_check
+
+        def good_check():
+            return DoctorCheck(
+                id="test.good", tier="boot", status="healthy",
+                severity="info", summary="All fine",
+            )
+
+        result = safe_check(good_check)
+        assert result.id == "test.good"
+        assert result.status == "healthy"
+
+    def test_safe_check_catches_exception(self):
+        from doctor.models import safe_check
+
+        def bad_check():
+            raise RuntimeError("kaboom")
+
+        result = safe_check(bad_check)
+        assert result.status == "critical"
+        assert "bad_check" in result.id
+        assert "kaboom" in result.summary
+        assert result.evidence
+
+    def test_safe_check_forwards_args_and_kwargs(self):
+        from doctor.models import DoctorCheck, safe_check
+
+        def check_with_args(fix=False):
+            return DoctorCheck(
+                id="test.args", tier="boot", status="healthy",
+                severity="info", summary=f"fix={fix}",
+            )
+
+        result = safe_check(check_with_args, fix=True)
+        assert "fix=True" in result.summary
+
+    def test_boot_tier_survives_single_check_crash(self, nexo_home, monkeypatch):
+        from doctor.providers import boot
+
+        original_check_disk = boot.check_disk_space
+
+        def exploding_disk_check():
+            raise OSError("disk check exploded")
+
+        monkeypatch.setattr(boot, "check_disk_space", exploding_disk_check)
+        checks = boot.run_boot_checks()
+
+        ids = [c.id for c in checks]
+        assert "boot.db_exists" in ids
+        assert "boot.required_dirs" in ids
+        crash = [c for c in checks if "crashed" in c.id]
+        assert len(crash) == 1
+        assert "exploding_disk_check" in crash[0].id
+        assert crash[0].status == "critical"
+
+    def test_deep_tier_survives_single_check_crash(self, nexo_home, monkeypatch):
+        from doctor.providers import deep
+
+        def exploding_schema_check():
+            raise ValueError("schema check failed")
+
+        monkeypatch.setattr(deep, "check_schema_version", exploding_schema_check)
+        checks = deep.run_deep_checks()
+
+        crash = [c for c in checks if "crashed" in c.id]
+        assert len(crash) == 1
+        non_crash = [c for c in checks if "crashed" not in c.id]
+        assert len(non_crash) >= 3


### PR DESCRIPTION
If any single check_* function within a doctor tier (boot/runtime/deep) raised an unhandled exception, it crashed the entire tier runner. The orchestrator caught this as one 'tier crashed' error, but all sibling checks in that tier were lost. With 18 checks in the runtime tier, this meant a single broken check could mask 17 healthy/degraded results.

Summary:
Added safe_check() to doctor.models — a wrapper that runs each check function in isolation and converts exceptions into a crash DoctorCheck with traceback evidence. Updated all three tier runners (boot, runtime, deep) to invoke each check via safe_check() instead of calling directly. Added 5 tests: unit tests for safe_check behavior (normal pass-through, exception catch, arg forwarding) and integration tests proving boot and deep tiers survive a single check crash while preserving all other results.

Tests:
- python3 -m pytest tests/test_doctor.py -x
- python3 scripts/verify_client_parity.py

Risks:
- safe_check adds a try/except per check — minimal overhead but a crashed check now returns status='critical' with tier='unknown' instead of the expected tier name (the orchestrator crash handler set the correct tier)

Source: automated public core evolution from an opt-in machine.
