### PR TITLE
fix: stop file migrations on first failure to prevent permanent skips

### DIFF
--- a/src/auto_update.py
+++ b/src/auto_update.py
@@ -626,6 +626,10 @@ def _run_file_migration(path: Path) -> tuple[bool, str]:
 def run_file_migrations() -> list[dict]:
     """Run any pending file-based migrations from the migrations/ directory.
 
+    Migrations are ordered and sequential: if migration N fails, all subsequent
+    migrations are skipped so that N is retried on the next startup and no
+    migration is permanently skipped by a version-pointer gap.
+
     Returns list of results: [{"version": N, "file": "...", "status": "ok"|"failed", "message": "..."}]
     """
     current_version = _get_applied_migration_version()
@@ -655,8 +659,7 @@ def run_file_migrations() -> list[dict]:
                 "message": message,
             })
             _log(f"Migration {path.name}: FAILED — {message}")
-            # Don't advance version past a failure, but continue trying others
-            # so independent migrations still run. Version stays at last success.
+            break  # Stop on first failure so it retries next startup
 
     return results
 

--- a/tests/test_file_migrations.py
+++ b/tests/test_file_migrations.py
@@ -1,0 +1,102 @@
+"""Tests for file-based migration runner in auto_update."""
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+
+def test_run_file_migrations_stops_on_first_failure(tmp_path, monkeypatch):
+    """When migration N fails, subsequent migrations must NOT run so that
+    N is retried on next startup and no migration is permanently skipped."""
+    import auto_update
+
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    version_file = tmp_path / "migration_version"
+
+    # Migration 1: succeeds
+    (migrations_dir / "001_ok.py").write_text(
+        "import sys; sys.exit(0)\n"
+    )
+    # Migration 2: fails
+    (migrations_dir / "002_fail.py").write_text(
+        "import sys; sys.exit(1)\n"
+    )
+    # Migration 3: would succeed but should never run
+    marker = tmp_path / "003_ran.txt"
+    (migrations_dir / "003_should_not_run.py").write_text(
+        f"from pathlib import Path; Path({str(marker)!r}).write_text('ran')\n"
+    )
+
+    monkeypatch.setattr(auto_update, "MIGRATIONS_DIR", migrations_dir)
+    monkeypatch.setattr(auto_update, "MIGRATION_VERSION_FILE", version_file)
+    monkeypatch.setattr(auto_update, "SRC_DIR", tmp_path)
+    monkeypatch.setattr(auto_update, "REPO_DIR", tmp_path)
+
+    results = auto_update.run_file_migrations()
+
+    assert len(results) == 2
+    assert results[0]["status"] == "ok"
+    assert results[0]["version"] == 1
+    assert results[1]["status"] == "failed"
+    assert results[1]["version"] == 2
+
+    # Version pointer should be at 1 (last success before the failure)
+    assert version_file.read_text().strip() == "1"
+
+    # Migration 3 must NOT have run
+    assert not marker.exists(), "Migration 3 ran despite migration 2 failing"
+
+
+def test_run_file_migrations_retries_failed_on_next_run(tmp_path, monkeypatch):
+    """A failed migration should be retried on the next invocation."""
+    import auto_update
+
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    version_file = tmp_path / "migration_version"
+
+    # Write a failing migration
+    script = migrations_dir / "001_initially_fails.py"
+    script.write_text("import sys; sys.exit(1)\n")
+
+    monkeypatch.setattr(auto_update, "MIGRATIONS_DIR", migrations_dir)
+    monkeypatch.setattr(auto_update, "MIGRATION_VERSION_FILE", version_file)
+    monkeypatch.setattr(auto_update, "SRC_DIR", tmp_path)
+    monkeypatch.setattr(auto_update, "REPO_DIR", tmp_path)
+
+    results1 = auto_update.run_file_migrations()
+    assert len(results1) == 1
+    assert results1[0]["status"] == "failed"
+
+    # Now "fix" the migration
+    script.write_text("import sys; sys.exit(0)\n")
+
+    results2 = auto_update.run_file_migrations()
+    assert len(results2) == 1
+    assert results2[0]["status"] == "ok"
+    assert version_file.read_text().strip() == "1"
+
+
+def test_run_file_migrations_all_succeed(tmp_path, monkeypatch):
+    """When all migrations succeed, version advances to the last one."""
+    import auto_update
+
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    version_file = tmp_path / "migration_version"
+
+    (migrations_dir / "001_first.py").write_text("import sys; sys.exit(0)\n")
+    (migrations_dir / "002_second.py").write_text("import sys; sys.exit(0)\n")
+    (migrations_dir / "003_third.py").write_text("import sys; sys.exit(0)\n")
+
+    monkeypatch.setattr(auto_update, "MIGRATIONS_DIR", migrations_dir)
+    monkeypatch.setattr(auto_update, "MIGRATION_VERSION_FILE", version_file)
+    monkeypatch.setattr(auto_update, "SRC_DIR", tmp_path)
+    monkeypatch.setattr(auto_update, "REPO_DIR", tmp_path)
+
+    results = auto_update.run_file_migrations()
+
+    assert len(results) == 3
+    assert all(r["status"] == "ok" for r in results)
+    assert version_file.read_text().strip() == "3"


### PR DESCRIPTION
In run_file_migrations(), when migration N failed, the loop continued running subsequent migrations. If migration N+1 succeeded, _set_migration_version(N+1) advanced the version pointer past N, permanently skipping the failed migration on all future startups. The comment said 'version stays at last success' but the code contradicted this by allowing later successes to leap-frog over the failure.

Summary:
Changed run_file_migrations() to break on first failure instead of continuing. This ensures: (1) the version pointer stays at the last successful migration, (2) the failed migration is retried on next startup, (3) no migration is permanently skipped by a version-pointer gap. Added 3 targeted tests covering stop-on-failure, retry-on-next-run, and all-succeed scenarios.

Tests:
- python3 -m pytest tests/test_file_migrations.py -v
- python3 -m pytest tests/test_startup_preflight.py tests/test_migrations.py -v

Risks:
- Migrations that were intentionally independent and could run out of order will now be blocked by an earlier failure. This is the standard behavior for ordered numbered migrations and is the safer default.

Source: automated public core evolution from an opt-in machine.
