### PR TITLE
fix: close SQLite connections in finally blocks during DB backup/restore

### DIFF
--- a/src/auto_update.py
+++ b/src/auto_update.py
@@ -311,14 +311,21 @@ def _backup_dbs() -> str | None:
 
     backup_dir.mkdir(parents=True, exist_ok=True)
     for db_file in db_files:
+        src_conn = None
+        dst_conn = None
         try:
             src_conn = sqlite3.connect(str(db_file))
             dst_conn = sqlite3.connect(str(backup_dir / db_file.name))
             src_conn.backup(dst_conn)
-            dst_conn.close()
-            src_conn.close()
         except Exception as e:
             _log(f"DB backup warning ({db_file.name}): {e}")
+        finally:
+            for conn in (dst_conn, src_conn):
+                if conn is not None:
+                    try:
+                        conn.close()
+                    except Exception:
+                        pass
     return str(backup_dir)
 
 
@@ -331,15 +338,22 @@ def _restore_dbs(backup_dir: str):
     for db_backup in bdir.glob("*.db"):
         for candidate in [DATA_DIR / db_backup.name, NEXO_HOME / db_backup.name, SRC_DIR / db_backup.name]:
             if candidate.is_file():
+                src_conn = None
+                dst_conn = None
                 try:
                     src_conn = sqlite3.connect(str(db_backup))
                     dst_conn = sqlite3.connect(str(candidate))
                     src_conn.backup(dst_conn)
-                    dst_conn.close()
-                    src_conn.close()
                     _log(f"Restored DB: {db_backup.name}")
                 except Exception as e:
                     _log(f"DB restore warning ({db_backup.name}): {e}")
+                finally:
+                    for conn in (dst_conn, src_conn):
+                        if conn is not None:
+                            try:
+                                conn.close()
+                            except Exception:
+                                pass
                 break
 
 

--- a/src/plugins/backup.py
+++ b/src/plugins/backup.py
@@ -21,10 +21,14 @@ def handle_backup_now() -> str:
     # Use SQLite backup API for consistency
     import sqlite3
     src_conn = sqlite3.connect(DB_PATH)
-    dst_conn = sqlite3.connect(dest)
-    src_conn.backup(dst_conn)
-    dst_conn.close()
-    src_conn.close()
+    try:
+        dst_conn = sqlite3.connect(dest)
+        try:
+            src_conn.backup(dst_conn)
+        finally:
+            dst_conn.close()
+    finally:
+        src_conn.close()
 
     size_kb = os.path.getsize(dest) / 1024
     _cleanup_old()
@@ -63,17 +67,25 @@ def handle_backup_restore(filename: str) -> str:
     safety = os.path.join(BACKUP_DIR, f"nexo-pre-restore-{time.strftime('%Y%m%d%H%M%S')}.db")
     import sqlite3
     src_conn = sqlite3.connect(DB_PATH)
-    dst_conn = sqlite3.connect(safety)
-    src_conn.backup(dst_conn)
-    dst_conn.close()
-    src_conn.close()
+    try:
+        dst_conn = sqlite3.connect(safety)
+        try:
+            src_conn.backup(dst_conn)
+        finally:
+            dst_conn.close()
+    finally:
+        src_conn.close()
 
     # Restore
     restore_conn = sqlite3.connect(src)
-    target_conn = sqlite3.connect(DB_PATH)
-    restore_conn.backup(target_conn)
-    target_conn.close()
-    restore_conn.close()
+    try:
+        target_conn = sqlite3.connect(DB_PATH)
+        try:
+            restore_conn.backup(target_conn)
+        finally:
+            target_conn.close()
+    finally:
+        restore_conn.close()
 
     # Invalidate shared connection so db.py reconnects to restored data
     import db

--- a/src/plugins/update.py
+++ b/src/plugins/update.py
@@ -149,14 +149,21 @@ def _backup_databases() -> tuple[str, str | None]:
 
     for db_file in db_files:
         dest = backup_dir / db_file.name
+        src_conn = None
+        dst_conn = None
         try:
             src_conn = sqlite3.connect(str(db_file))
             dst_conn = sqlite3.connect(str(dest))
             src_conn.backup(dst_conn)
-            dst_conn.close()
-            src_conn.close()
         except Exception as e:
             return str(backup_dir), f"Failed to backup {db_file.name}: {e}"
+        finally:
+            for conn in (dst_conn, src_conn):
+                if conn is not None:
+                    try:
+                        conn.close()
+                    except Exception:
+                        pass
 
     return str(backup_dir), None
 
@@ -170,14 +177,21 @@ def _restore_databases(backup_dir: str):
         # Try to find original location
         for candidate in [DATA_DIR / db_backup.name, NEXO_HOME / db_backup.name, SRC_DIR / db_backup.name]:
             if candidate.is_file():
+                src_conn = None
+                dst_conn = None
                 try:
                     src_conn = sqlite3.connect(str(db_backup))
                     dst_conn = sqlite3.connect(str(candidate))
                     src_conn.backup(dst_conn)
-                    dst_conn.close()
-                    src_conn.close()
                 except Exception:
                     pass
+                finally:
+                    for conn in (dst_conn, src_conn):
+                        if conn is not None:
+                            try:
+                                conn.close()
+                            except Exception:
+                                pass
                 break
 
 

--- a/tests/test_file_migrations.py
+++ b/tests/test_file_migrations.py
@@ -1,5 +1,6 @@
-"""Tests for file-based migration runner in auto_update."""
+"""Tests for file-based migration runner and DB backup/restore in auto_update."""
 import os
+import sqlite3
 import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
@@ -100,3 +101,96 @@ def test_run_file_migrations_all_succeed(tmp_path, monkeypatch):
     assert len(results) == 3
     assert all(r["status"] == "ok" for r in results)
     assert version_file.read_text().strip() == "3"
+
+
+# ── DB backup/restore connection safety ─────────────────────────────
+
+
+def test_backup_dbs_closes_connections_on_success(tmp_path, monkeypatch):
+    """_backup_dbs must close all SQLite connections even on success."""
+    import auto_update
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    db_file = data_dir / "nexo.db"
+    conn = sqlite3.connect(str(db_file))
+    conn.execute("CREATE TABLE t (x INTEGER)")
+    conn.close()
+
+    monkeypatch.setattr(auto_update, "DATA_DIR", data_dir)
+    monkeypatch.setattr(auto_update, "NEXO_HOME", tmp_path)
+    monkeypatch.setattr(auto_update, "SRC_DIR", tmp_path / "src_nonexistent")
+
+    backup_dir = auto_update._backup_dbs()
+
+    assert backup_dir is not None
+    backup_db = os.path.join(backup_dir, "nexo.db")
+    assert os.path.isfile(backup_db)
+
+    # Verify the backup is a valid DB (connections were closed properly)
+    verify = sqlite3.connect(backup_db)
+    tables = verify.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+    verify.close()
+    assert any(row[0] == "t" for row in tables)
+
+
+def test_backup_dbs_closes_connections_on_corrupt_source(tmp_path, monkeypatch):
+    """_backup_dbs must close connections even when the source DB is corrupt."""
+    import auto_update
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    # Write garbage to simulate a corrupt DB file
+    db_file = data_dir / "nexo.db"
+    db_file.write_bytes(b"this is not a valid sqlite database" * 100)
+
+    monkeypatch.setattr(auto_update, "DATA_DIR", data_dir)
+    monkeypatch.setattr(auto_update, "NEXO_HOME", tmp_path)
+    monkeypatch.setattr(auto_update, "SRC_DIR", tmp_path / "src_nonexistent")
+
+    # Should not raise — errors are logged and swallowed
+    backup_dir = auto_update._backup_dbs()
+    assert backup_dir is not None
+
+    # The key assertion: after returning, the source DB should not be locked.
+    # If connections leaked, this would fail on some platforms.
+    verify = sqlite3.connect(str(db_file))
+    verify.close()
+
+
+def test_restore_dbs_handles_missing_gracefully(tmp_path, monkeypatch):
+    """_restore_dbs must not crash and must close connections properly."""
+    import auto_update
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    backup_dir = tmp_path / "backup"
+    backup_dir.mkdir()
+
+    # Create valid source and backup DBs
+    db_file = data_dir / "nexo.db"
+    conn = sqlite3.connect(str(db_file))
+    conn.execute("CREATE TABLE t (x INTEGER)")
+    conn.execute("INSERT INTO t VALUES (42)")
+    conn.commit()
+    conn.close()
+
+    backup_file = backup_dir / "nexo.db"
+    src = sqlite3.connect(str(db_file))
+    dst = sqlite3.connect(str(backup_file))
+    src.backup(dst)
+    dst.close()
+    src.close()
+
+    monkeypatch.setattr(auto_update, "DATA_DIR", data_dir)
+    monkeypatch.setattr(auto_update, "NEXO_HOME", tmp_path)
+    monkeypatch.setattr(auto_update, "SRC_DIR", tmp_path / "src_nonexistent")
+
+    # Should not raise
+    auto_update._restore_dbs(str(backup_dir))
+
+    # Verify the restore actually worked and connections are clean
+    verify = sqlite3.connect(str(db_file))
+    row = verify.execute("SELECT x FROM t").fetchone()
+    verify.close()
+    assert row[0] == 42


### PR DESCRIPTION
In auto_update.py, plugins/update.py, and plugins/backup.py, SQLite connections opened for backup() and restore operations were only closed on the success path. If backup() raised (e.g., database locked, corruption), both source and destination connections leaked. During auto-updates this could worsen database locking because the leaked connections hold shared locks on nexo.db while the update pipeline tries to run migrations.

Summary:
Wrapped all sqlite3.connect/backup/close sequences in try/finally blocks across three files so connections are always closed, even when backup() raises. Added three new tests in test_file_migrations.py covering: successful backup with verification, backup against a corrupt DB source, and restore round-trip correctness.

Tests:
- python3 -m pytest tests/test_file_migrations.py -v

Risks:
- The finally blocks add a close() call that was previously never reached on error — theoretically a close() on a half-initialized connection could raise, but this is suppressed with try/except inside the finally

Source: automated public core evolution from an opt-in machine.
