### PR TITLE
fix: close SQLite connections in finally blocks in evolution_cycle, kg_populate, and migrate_embeddings

### DIFF
--- a/src/evolution_cycle.py
+++ b/src/evolution_cycle.py
@@ -120,52 +120,54 @@ def save_objective(obj: dict):
 def get_week_data(db_path: str) -> dict:
     """Gather last 7 days of learnings, decisions, changes, diaries."""
     conn = sqlite3.connect(db_path, timeout=10)
-    conn.row_factory = sqlite3.Row
-    cutoff_epoch = time.time() - 7 * 86400
-    cutoff_date = (date.today() - timedelta(days=7)).isoformat()
+    try:
+        conn.row_factory = sqlite3.Row
+        cutoff_epoch = time.time() - 7 * 86400
+        cutoff_date = (date.today() - timedelta(days=7)).isoformat()
 
-    data = {}
+        data = {}
 
-    rows = conn.execute(
-        "SELECT category, title, content FROM learnings WHERE created_at > ? ORDER BY created_at DESC LIMIT 50",
-        (cutoff_epoch,)
-    ).fetchall()
-    data["learnings"] = [dict(r) for r in rows]
+        rows = conn.execute(
+            "SELECT category, title, content FROM learnings WHERE created_at > ? ORDER BY created_at DESC LIMIT 50",
+            (cutoff_epoch,)
+        ).fetchall()
+        data["learnings"] = [dict(r) for r in rows]
 
-    rows = conn.execute(
-        "SELECT domain, decision, alternatives, based_on, confidence, outcome FROM decisions "
-        "WHERE created_at > ? ORDER BY created_at DESC LIMIT 20",
-        (cutoff_date,)
-    ).fetchall()
-    data["decisions"] = [dict(r) for r in rows]
+        rows = conn.execute(
+            "SELECT domain, decision, alternatives, based_on, confidence, outcome FROM decisions "
+            "WHERE created_at > ? ORDER BY created_at DESC LIMIT 20",
+            (cutoff_date,)
+        ).fetchall()
+        data["decisions"] = [dict(r) for r in rows]
 
-    rows = conn.execute(
-        "SELECT files, what_changed, why, affects, risks FROM change_log "
-        "WHERE created_at > ? ORDER BY created_at DESC LIMIT 30",
-        (cutoff_date,)
-    ).fetchall()
-    data["changes"] = [dict(r) for r in rows]
+        rows = conn.execute(
+            "SELECT files, what_changed, why, affects, risks FROM change_log "
+            "WHERE created_at > ? ORDER BY created_at DESC LIMIT 30",
+            (cutoff_date,)
+        ).fetchall()
+        data["changes"] = [dict(r) for r in rows]
 
-    rows = conn.execute(
-        "SELECT summary, decisions as diary_decisions, pending, mental_state, domain, user_signals "
-        "FROM session_diary WHERE created_at > ? ORDER BY created_at DESC LIMIT 20",
-        (cutoff_date,)
-    ).fetchall()
-    data["diaries"] = [dict(r) for r in rows]
+        rows = conn.execute(
+            "SELECT summary, decisions as diary_decisions, pending, mental_state, domain, user_signals "
+            "FROM session_diary WHERE created_at > ? ORDER BY created_at DESC LIMIT 20",
+            (cutoff_date,)
+        ).fetchall()
+        data["diaries"] = [dict(r) for r in rows]
 
-    rows = conn.execute(
-        "SELECT * FROM evolution_log ORDER BY id DESC LIMIT 20"
-    ).fetchall()
-    data["evolution_history"] = [dict(r) for r in rows]
+        rows = conn.execute(
+            "SELECT * FROM evolution_log ORDER BY id DESC LIMIT 20"
+        ).fetchall()
+        data["evolution_history"] = [dict(r) for r in rows]
 
-    rows = conn.execute(
-        "SELECT dimension, score, delta, measured_at FROM evolution_metrics "
-        "WHERE id IN (SELECT MAX(id) FROM evolution_metrics GROUP BY dimension)"
-    ).fetchall()
-    data["current_metrics"] = {r["dimension"]: dict(r) for r in rows}
+        rows = conn.execute(
+            "SELECT dimension, score, delta, measured_at FROM evolution_metrics "
+            "WHERE id IN (SELECT MAX(id) FROM evolution_metrics GROUP BY dimension)"
+        ).fetchall()
+        data["current_metrics"] = {r["dimension"]: dict(r) for r in rows}
 
-    conn.close()
-    return data
+        return data
+    finally:
+        conn.close()
 
 
 def create_snapshot(files_to_backup: list) -> str:

--- a/src/kg_populate.py
+++ b/src/kg_populate.py
@@ -147,25 +147,27 @@ def backfill_decisions() -> int:
 def backfill_somatic() -> int:
     """Read somatic_markers from cognitive.db → create file/area nodes with risk."""
     cdb = _cognitive_db()
-    rows = cdb.execute(
-        "SELECT target, target_type, risk_score, incident_count FROM somatic_markers"
-    ).fetchall()
-    count = 0
-    for row in rows:
-        target_type = row["target_type"] or "file"
-        node_ref = f"{target_type}:{row['target']}"
-        kg.upsert_node(
-            node_type=target_type,
-            node_ref=node_ref,
-            label=os.path.basename(row["target"]) or row["target"],
-            properties={
-                "risk_score": row["risk_score"],
-                "incident_count": row["incident_count"],
-            },
-        )
-        count += 1
-    cdb.close()
-    return count
+    try:
+        rows = cdb.execute(
+            "SELECT target, target_type, risk_score, incident_count FROM somatic_markers"
+        ).fetchall()
+        count = 0
+        for row in rows:
+            target_type = row["target_type"] or "file"
+            node_ref = f"{target_type}:{row['target']}"
+            kg.upsert_node(
+                node_type=target_type,
+                node_ref=node_ref,
+                label=os.path.basename(row["target"]) or row["target"],
+                properties={
+                    "risk_score": row["risk_score"],
+                    "incident_count": row["incident_count"],
+                },
+            )
+            count += 1
+        return count
+    finally:
+        cdb.close()
 
 
 def run_full_backfill() -> dict:

--- a/src/migrate_embeddings.py
+++ b/src/migrate_embeddings.py
@@ -30,15 +30,17 @@ MODELS = {
 def verify():
     """Check current embedding dimensions in the database."""
     conn = sqlite3.connect(DB_PATH)
-    for table in ["stm_memories", "ltm_memories"]:
-        count = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
-        if count == 0:
-            print(f"  {table}: {count} rows (empty)")
-            continue
-        row = conn.execute(f"SELECT embedding FROM {table} LIMIT 1").fetchone()
-        vec = np.frombuffer(row[0], dtype=np.float32)
-        print(f"  {table}: {count} rows, embedding dim = {len(vec)}")
-    conn.close()
+    try:
+        for table in ["stm_memories", "ltm_memories"]:
+            count = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+            if count == 0:
+                print(f"  {table}: {count} rows (empty)")
+                continue
+            row = conn.execute(f"SELECT embedding FROM {table} LIMIT 1").fetchone()
+            vec = np.frombuffer(row[0], dtype=np.float32)
+            print(f"  {table}: {count} rows, embedding dim = {len(vec)}")
+    finally:
+        conn.close()
 
 
 def upgrade():
@@ -62,31 +64,31 @@ def upgrade():
     model = TextEmbedding(model_name)
 
     conn = sqlite3.connect(DB_PATH)
+    try:
+        for table in ["stm_memories", "ltm_memories"]:
+            rows = conn.execute(f"SELECT id, content FROM {table}").fetchall()
+            if not rows:
+                print(f"\n{table}: empty, skipping")
+                continue
 
-    for table in ["stm_memories", "ltm_memories"]:
-        rows = conn.execute(f"SELECT id, content FROM {table}").fetchall()
-        if not rows:
-            print(f"\n{table}: empty, skipping")
-            continue
+            print(f"\n{table}: re-embedding {len(rows)} memories...")
+            t0 = time.time()
 
-        print(f"\n{table}: re-embedding {len(rows)} memories...")
-        t0 = time.time()
+            # Batch embed for speed
+            contents = [r[1] for r in rows]
+            ids = [r[0] for r in rows]
 
-        # Batch embed for speed
-        contents = [r[1] for r in rows]
-        ids = [r[0] for r in rows]
+            embeddings = list(model.embed(contents))
 
-        embeddings = list(model.embed(contents))
+            for mem_id, emb in zip(ids, embeddings):
+                blob = np.array(emb, dtype=np.float32).tobytes()
+                conn.execute(f"UPDATE {table} SET embedding = ? WHERE id = ?", (blob, mem_id))
 
-        for mem_id, emb in zip(ids, embeddings):
-            blob = np.array(emb, dtype=np.float32).tobytes()
-            conn.execute(f"UPDATE {table} SET embedding = ? WHERE id = ?", (blob, mem_id))
-
-        conn.commit()
-        elapsed = time.time() - t0
-        print(f"  Done: {len(rows)} memories in {elapsed:.1f}s ({elapsed/len(rows)*1000:.0f}ms/memory)")
-
-    conn.close()
+            conn.commit()
+            elapsed = time.time() - t0
+            print(f"  Done: {len(rows)} memories in {elapsed:.1f}s ({elapsed/len(rows)*1000:.0f}ms/memory)")
+    finally:
+        conn.close()
 
     print("\nAfter upgrade:")
     verify()


### PR DESCRIPTION
Three files use direct sqlite3.connect() calls where conn.close() is placed after the work but not inside a finally block. If any query or processing step raises an exception, the connection leaks. This is the same class of bug fixed in PRs #32, #38, and #39 for other modules.

Summary:
Wrapped sqlite3 connection usage in try/finally blocks in: (1) evolution_cycle.py:get_week_data — 6 sequential queries that could fail mid-way, (2) kg_populate.py:backfill_somatic — iterates rows with KG upserts that could raise, (3) migrate_embeddings.py:verify and upgrade — table scans and batch updates that could fail. Each conn.close() is now guaranteed to run regardless of exceptions.

Tests:
- python3 -m pytest tests/test_evolution.py -x -q
- python3 -m pytest tests/test_cron_recovery.py -x -q
- python3 -c "import ast; ast.parse(open('src/evolution_cycle.py').read()); ast.parse(open('src/kg_populate.py').read()); ast.parse(open('src/migrate_embeddings.py').read()); print('OK')"

Risks:
- Minimal — only structural change is moving conn.close() into finally blocks; no logic changes

Source: automated public core evolution from an opt-in machine.
