### PR TITLE
fix: ensure catchup lock is released on early crash

### DIFF
--- a/src/scripts/nexo-catchup.py
+++ b/src/scripts/nexo-catchup.py
@@ -197,14 +197,14 @@ def main():
         log("Catch-Up already running; skipping overlapping invocation.")
         return
 
-    _heal_personal_schedules()
-    state = load_state()
-    tasks = catchup_candidates()
-
     ran = 0
     skipped = 0
     skipped_out_of_window = 0
     try:
+        _heal_personal_schedules()
+        state = load_state()
+        tasks = catchup_candidates()
+
         for candidate in tasks:
             name = candidate["cron_id"]
             if not candidate.get("missed"):
@@ -221,19 +221,19 @@ def main():
             log(f"  {name} — missed scheduled run due at {due_at}, catching up...")
             if run_task(candidate, state):
                 ran += 1
+
+        if ran == 0 and skipped_out_of_window == 0:
+            log("All tasks up to date, nothing to catch up.")
+        elif ran >= 3:
+            # Many tasks caught up — ask CLI to assess system state
+            _cli_post_catchup_assessment(ran, skipped, state)
+        else:
+            suffix = f", {skipped_out_of_window} outside recovery window" if skipped_out_of_window else ""
+            log(f"Caught up {ran} tasks, {skipped} already current{suffix}.")
+
+        log("=== Catch-Up complete ===")
     finally:
         lock_handle.close()
-
-    if ran == 0 and skipped_out_of_window == 0:
-        log("All tasks up to date, nothing to catch up.")
-    elif ran >= 3:
-        # Many tasks caught up — ask CLI to assess system state
-        _cli_post_catchup_assessment(ran, skipped, state)
-    else:
-        suffix = f", {skipped_out_of_window} outside recovery window" if skipped_out_of_window else ""
-        log(f"Caught up {ran} tasks, {skipped} already current{suffix}.")
-
-    log("=== Catch-Up complete ===")
 
 
 def _cli_post_catchup_assessment(ran: int, skipped: int, state: dict):

--- a/tests/test_cron_recovery.py
+++ b/tests/test_cron_recovery.py
@@ -233,6 +233,67 @@ def test_catchup_script_runs_directly_from_runtime_root(tmp_path):
     assert "ModuleNotFoundError" not in result.stderr
 
 
+def test_catchup_script_releases_lock_on_early_crash(tmp_path):
+    """Lock must be released even if _heal_personal_schedules or catchup_candidates crashes."""
+    repo_src = Path(__file__).resolve().parent.parent / "src"
+    runtime_root = tmp_path / "runtime"
+    (runtime_root / "scripts").mkdir(parents=True)
+    (runtime_root / "crons").mkdir(parents=True)
+    (runtime_root / "operations").mkdir(parents=True)
+    shutil.copy2(repo_src / "cron_recovery.py", runtime_root / "cron_recovery.py")
+    shutil.copy2(repo_src / "runtime_power.py", runtime_root / "runtime_power.py")
+    shutil.copy2(repo_src / "client_preferences.py", runtime_root / "client_preferences.py")
+    shutil.copy2(repo_src / "agent_runner.py", runtime_root / "agent_runner.py")
+    shutil.copy2(repo_src / "scripts" / "nexo-catchup.py", runtime_root / "scripts" / "nexo-catchup.py")
+    # Write a broken manifest that will cause catchup_candidates to fail
+    (runtime_root / "crons" / "manifest.json").write_text('{"crons":[{"id":"boom"}]}')
+    # Inject a cron_recovery that crashes in catchup_candidates
+    crash_module = runtime_root / "cron_recovery.py"
+    crash_module.write_text(
+        "def catchup_candidates(now=None):\n"
+        "    raise RuntimeError('simulated crash in catchup_candidates')\n"
+    )
+
+    home = tmp_path / "home"
+    home.mkdir()
+    lock_file = runtime_root / "operations" / ".catchup.lock"
+
+    # First run — should crash but release the lock
+    result = subprocess.run(
+        [sys.executable, str(runtime_root / "scripts" / "nexo-catchup.py")],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        env={
+            **os.environ,
+            "HOME": str(home),
+            "NEXO_HOME": str(runtime_root),
+            "NEXO_CODE": str(runtime_root),
+        },
+    )
+    assert result.returncode != 0  # crashed
+
+    # Restore the real module for the second run
+    shutil.copy2(repo_src / "cron_recovery.py", runtime_root / "cron_recovery.py")
+    (runtime_root / "crons" / "manifest.json").write_text('{"crons":[]}')
+
+    # Second run — must NOT say "already running" (lock must have been released)
+    result2 = subprocess.run(
+        [sys.executable, str(runtime_root / "scripts" / "nexo-catchup.py")],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        env={
+            **os.environ,
+            "HOME": str(home),
+            "NEXO_HOME": str(runtime_root),
+            "NEXO_CODE": str(runtime_root),
+        },
+    )
+    assert result2.returncode == 0, result2.stderr
+    assert "already running" not in result2.stdout
+
+
 def test_catchup_script_self_heals_personal_schedules(tmp_path):
     repo_src = Path(__file__).resolve().parent.parent / "src"
     runtime_root = tmp_path / "runtime"


### PR DESCRIPTION
In nexo-catchup.py, _heal_personal_schedules(), load_state(), and catchup_candidates() ran outside the try/finally block that releases the file lock. If any of those functions crashed, the lock handle was never closed within the process. Additionally, the summary logging and CLI post-catchup assessment ran after the lock was released, allowing a concurrent catchup instance to start while the first was still completing its assessment.

Summary:
Moved all catchup logic (heal, load, candidate resolution, task execution, summary, and assessment) inside the try/finally that guards lock_handle.close(). This ensures the lock is always released on crash and held until all work (including post-assessment) is complete. Added a regression test that injects a crash in catchup_candidates and verifies a subsequent run is not blocked by a stale lock.

Tests:
- python3 -m pytest tests/test_cron_recovery.py -v
- python3 -m pytest tests/test_cron_recovery.py tests/test_file_migrations.py tests/test_doctor.py -v

Risks:
- The summary log line and CLI assessment now run while the lock is held, which marginally extends the lock window — acceptable since the lock is specifically designed to prevent overlapping catchup runs

Source: automated public core evolution from an opt-in machine.
