### PR TITLE
Add docker-compose setup with persistent storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,6 +669,31 @@ The installer handles everything and syncs the same `nexo` MCP brain into Claude
   +----------------------------------------------------------+
 ```
 
+### Docker Compose
+
+If you want to run the MCP server in a container and keep the brain persistent across rebuilds and restarts, mount `NEXO_HOME` to a named volume instead of using the image filesystem:
+
+```yaml
+services:
+  nexo:
+    build: .
+    environment:
+      NEXO_HOME: /nexo-home
+    volumes:
+      - nexo_data:/nexo-home
+
+volumes:
+  nexo_data:
+```
+
+Then run the server with:
+
+```bash
+docker compose run --rm -T nexo
+```
+
+The `nexo_data` volume keeps `nexo.db`, `cognitive.db`, backups, and other runtime state persistent across container runs. For the full managed install, client sync, and `nexo chat` flow, use `npx nexo-brain` on the host.
+
 ### Starting a Session
 
 After install, use the runtime CLI:


### PR DESCRIPTION
## What
Adds a docker-compose example for persistent setups.

## Why
The README mentions Docker support but does not provide a compose example for persistent usage.

## Change made
- Added docker-compose example using a named volume
- Configured NEXO_HOME for persistence

## Summary
Brief description of changes.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Plugin
- [ ] Documentation
- [ ] Performance improvement

## Testing
How was this tested?

## Checklist
- [ ] Code follows project conventions
- [ ] No secrets or private data included
- [ ] Tests pass locally
- [ ] Documentation updated if needed
- [ ] Runtime/parity impact considered if this touches bootstrap, hooks, clients, automation, Deep Sleep, doctor, or public contribution
- [ ] Public contribution path respected if this came from an opt-in Draft PR

## Runtime Evidence
- `python3 scripts/verify_client_parity.py`:
- Relevant `pytest`:
- `nexo doctor --tier runtime --json` or equivalent:
