### PR TITLE
feat: ship v3.1.0 self-audit corrective runtime

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [3.1.0] - 2026-04-08
+
+### Self-Audit Goes Corrective
+- The daily self-audit now resolves contradiction, formalization, and prevention findings inline instead of leaving behind orphan `NF-CONTRADICTION-*`, `NF-FORMALIZE-*`, and `NF-PREVENTION-*` followups. Conflicting learnings are superseded, recurring themes are formalized directly, and failure clusters produce canonical prevention learnings during the same run.
+- Mechanical post-audit fixes now run automatically for managed bootstraps, mutable watchdog registry drift, golden snapshots, and syntactically broken personal plugins, shrinking the class of “audit found it but nobody fixed it” failures.
+- When an inline self-audit fix touches public-core paths, NEXO now queues a durable public-port candidate so the public Evolution cycle can still surface that improvement upstream instead of losing it inside private maintenance.
+
+### Stricter Client Discipline + Onboarding
+- Added opt-in `protocol_strictness` modes (`lenient`, `strict`, `learning`) with pre-write hook enforcement and explanatory guidance for newer users who want protocol discipline to fail loudly instead of silently accumulating debt.
+- Added first-party Gemini CLI adapter docs plus dedicated Cursor and Windsurf integration guides, and expanded the README client matrix so non-Claude users can bootstrap NEXO without reverse-engineering the Claude-specific setup.
+- Added a repo-root `docker-compose.yml`, a persistent-volume Docker setup guide, and MCP health checks so containerized installs can come up with durable `NEXO_HOME` state out of the box.
+
+### Workflow + Measurement Surfaces
+- Added a workflow quickstart with practical `open`, `resume`, `replay`, and `handoff` examples so durable runs are easier to adopt without reading architecture docs first.
+- Added a benchmark package that compares NEXO recall against a static `CLAUDE.md` baseline across decision recall, preference recall, repeat-error avoidance, interrupted-task resume, and related-context stitching, with reproducible scenarios and starter results.
+
 ## [3.0.2] - 2026-04-07
 
 ### Public Evolution Hardening

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,9 @@ RUN pip install --no-cache-dir -r src/requirements.txt
 COPY src/ ./src/
 
 ENV NEXO_HOME=/app
+ENV NEXO_CODE=/app/src
+ENV NEXO_MCP_TRANSPORT=stdio
+
+EXPOSE 8000
 
 ENTRYPOINT ["python", "src/server.py"]

--- a/README.md
+++ b/README.md
@@ -20,12 +20,16 @@
 
 Start here:
 - [5-minute quickstart](docs/quickstart-5-minutes.md)
+- [Workflow quickstart](docs/workflows-quickstart.md)
+- [Supported client guides](docs/integrations/cursor.md)
+- [Docker setup](docs/docker-setup.md)
 - [Architecture visuals](docs/architecture-visuals.md)
 - [Memory classes](docs/memory-classes.md)
 - [Session portability](docs/session-portability.md)
 - [Python SDK](docs/sdk-python.md)
 - [Reference verticals](docs/reference-verticals.md)
 - [Measured compare scorecard](compare/README.md)
+- [Memory benchmark harness](benchmarks/README.md)
 - [Public contribution guide](docs/public-contribution.md)
 
 Every time you close a session, everything is lost. Your agent doesn't remember yesterday's decisions, repeats the same mistakes, and starts from zero. NEXO Brain fixes this with a cognitive architecture modeled after how human memory actually works.
@@ -88,6 +92,17 @@ Versions `3.0.0` and `3.0.1` close the next execution gap:
 | Native hook depth | Deepest | Partial, compensated | None |
 | Runtime doctor parity audit | Yes | Yes | Shared-brain only |
 | Recommended today | Yes | Supported | Shared-brain companion |
+
+### Supported Clients
+
+| Client | Status | Integration style | Notes |
+|--------|--------|-------------------|-------|
+| Claude Code | First-class | Managed install + hooks + bootstrap | Deepest NEXO parity today |
+| Codex | First-class | Managed install + bootstrap + transcript parity | Best non-Claude terminal path |
+| Claude Desktop | Companion | MCP-only shared brain | Useful as read/chat companion |
+| Cursor | Documented companion | MCP + `.cursor/rules` | Good editor pairing; no Deep Sleep transcript parity yet |
+| Windsurf | Documented companion | MCP + `.windsurf/rules` or repo `AGENTS.md` | Native MCP support, manual companion mode |
+| Gemini CLI | Adapter included | MCP + `GEMINI.md` | Best when you want Gemini as a shared-brain companion, not the primary NEXO runtime |
 
 ## The Problem
 
@@ -671,28 +686,24 @@ The installer handles everything and syncs the same `nexo` MCP brain into Claude
 
 ### Docker Compose
 
-If you want to run the MCP server in a container and keep the brain persistent across rebuilds and restarts, mount `NEXO_HOME` to a named volume instead of using the image filesystem:
+NEXO now ships a root-level [`docker-compose.yml`](docs/docker-setup.md) for a persistent containerized runtime. It does two things at once:
 
-```yaml
-services:
-  nexo:
-    build: .
-    environment:
-      NEXO_HOME: /nexo-home
-    volumes:
-      - nexo_data:/nexo-home
+- keeps `NEXO_HOME` on a named volume
+- exposes a remote MCP endpoint at `http://localhost:8000/mcp` for IDEs that support HTTP/SSE MCP
 
-volumes:
-  nexo_data:
-```
-
-Then run the server with:
+Start it with:
 
 ```bash
-docker compose run --rm -T nexo
+docker compose up -d
 ```
 
-The `nexo_data` volume keeps `nexo.db`, `cognitive.db`, backups, and other runtime state persistent across container runs. For the full managed install, client sync, and `nexo chat` flow, use `npx nexo-brain` on the host.
+For Claude Code and Codex, keep using stdio and point the MCP command at the running container:
+
+```bash
+docker compose exec -T nexo python src/server.py
+```
+
+That gives you the same persistent brain in the container while keeping terminal clients on their native stdio transport. The full step-by-step flow, health checks, and config examples live in [docs/docker-setup.md](docs/docker-setup.md).
 
 ### Starting a Session
 
@@ -921,6 +932,18 @@ When Claude Desktop is installed, `nexo-brain`, `nexo update`, and `nexo clients
 
 When Codex CLI is available, `nexo-brain`, `nexo update`, and `nexo clients sync` register the same `nexo` MCP server via `codex mcp add`, so Codex uses the same local memory store as Claude Code and Claude Desktop. If selected during install, `nexo chat` can open Codex directly and background automation can also run through Codex. Interactive `nexo chat` launches use Codex's aggressive no-confirmation mode so the session does not stall on repetitive approval prompts. The current recommended Codex profile is `gpt-5.4` with `xhigh` reasoning. Runtime Doctor also audits recent Codex sessions for NEXO startup markers and conditioned-file protocol discipline so parity drift does not hide behind the lack of native Claude-style hooks.
 
+### Cursor
+
+Cursor works well as a documented companion client. Point Cursor at the same local `nexo` MCP server and add a project rule that forces `nexo_startup`, `nexo_heartbeat`, and the protocol path on real work. See [docs/integrations/cursor.md](docs/integrations/cursor.md).
+
+### Windsurf
+
+Windsurf/Cascade supports MCP plus durable repo rules. Use the same local `nexo` server and add NEXO startup/protocol instructions in `.windsurf/rules/` or your repo `AGENTS.md`. See [docs/integrations/windsurf.md](docs/integrations/windsurf.md).
+
+### Gemini CLI
+
+Gemini CLI can share the same local NEXO brain through `mcpServers` in `~/.gemini/settings.json` plus a repo `GEMINI.md`. NEXO now ships a starter adapter in [adapters/gemini/README.md](adapters/gemini/README.md).
+
 ### OpenClaw
 
 NEXO Brain also works as a cognitive memory backend for [OpenClaw](https://github.com/openclaw/openclaw):
@@ -1004,6 +1027,20 @@ If NEXO Brain is useful to you, consider:
 - **Client parity / shared-brain maintenance** — see [docs/client-parity-checklist.md](docs/client-parity-checklist.md)
 
 [![Star History Chart](https://api.star-history.com/svg?repos=wazionapps/nexo&type=Date)](https://star-history.com/#wazionapps/nexo&Date)
+
+## Memory Benchmark Snapshot
+
+The full harness is in [benchmarks/README.md](benchmarks/README.md). The first checked-in micro-benchmark compares the NEXO runtime against a static `CLAUDE.md`-only baseline on five recall-heavy scenarios:
+
+| Scenario | NEXO full stack | Static `CLAUDE.md` | No memory |
+|----------|-----------------|--------------------|-----------|
+| Decision rationale recall | Pass | Partial | Fail |
+| User preference recall | Pass | Partial | Fail |
+| Repeat-error avoidance | Pass | Partial | Fail |
+| Resume interrupted task | Pass | Partial | Fail |
+| Related-context stitching | Pass | Fail | Fail |
+
+See [benchmarks/results/memory-recall-vs-static.md](benchmarks/results/memory-recall-vs-static.md) for the rubric, prompt shape, and first-run notes.
 
 ## Changelog
 

--- a/adapters/gemini/GEMINI.md
+++ b/adapters/gemini/GEMINI.md
@@ -1,0 +1,30 @@
+<!-- nexo-gemini-md-version: 1.0.0 -->
+# NEXO — Shared Brain for Gemini CLI
+
+You are operating with the NEXO shared brain through Gemini CLI.
+
+## Startup
+
+1. Call `nexo_startup` once at the beginning of the session.
+2. Read the project context before acting.
+3. Reply in the user's language when that is clear from context.
+
+## Protocol
+
+- Call `nexo_heartbeat` on every user turn.
+- For non-trivial work, open `nexo_task_open` before acting.
+- For edits, run `nexo_guard_check` before touching conditioned files.
+- Do not claim completion without evidence captured in `nexo_task_close`.
+- If a correction reveals a reusable rule, call `nexo_learning_add` immediately.
+- For long work, prefer `nexo_workflow_open` plus checkpoint updates.
+
+## Gemini-specific notes
+
+- Gemini CLI loads `GEMINI.md` from the current project and parent directories.
+- MCP servers come from `~/.gemini/settings.json` or `.gemini/settings.json`.
+- If the repo already uses `AGENTS.md`, you can also tell Gemini CLI to load both by setting `context.fileName` to include `AGENTS.md` and `GEMINI.md`.
+- Gemini CLI does not give NEXO the same native hook surface as Claude Code, so protocol discipline must stay explicit.
+
+## Minimal rule of thumb
+
+If the work is real, open protocol first. If the answer matters, verify before claiming. If you learned something reusable, store it while it is fresh.

--- a/adapters/gemini/README.md
+++ b/adapters/gemini/README.md
@@ -1,0 +1,89 @@
+# Gemini CLI Adapter
+
+This adapter lets Gemini CLI share the same local NEXO brain instead of running as a stateless separate assistant.
+
+## What this adapter gives you
+
+- A starter [`GEMINI.md`](./GEMINI.md) bootstrap mirroring the NEXO startup/protocol path
+- MCP wiring guidance for `~/.gemini/settings.json`
+- An explicit support matrix so Gemini is documented honestly as a companion path, not a hook-equivalent replacement for Claude Code
+
+## 1. Configure Gemini CLI to load NEXO
+
+Edit `~/.gemini/settings.json` or your repo-local `.gemini/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "nexo": {
+      "command": "python3",
+      "args": [
+        "/Users/YOU/.nexo/server.py"
+      ],
+      "env": {
+        "NEXO_HOME": "/Users/YOU/.nexo"
+      }
+    }
+  },
+  "context": {
+    "fileName": [
+      "GEMINI.md",
+      "AGENTS.md"
+    ]
+  }
+}
+```
+
+If you work from a repo checkout instead of the installed runtime, point `args[0]` at `/abs/path/to/nexo/src/server.py` and set `NEXO_CODE` as well.
+
+## 2. Add the project bootstrap
+
+Copy or adapt [`GEMINI.md`](./GEMINI.md) into your project root.
+
+Gemini CLI will load it automatically, and you can inspect active context files with `/memory show`.
+
+## 3. Verify MCP connectivity
+
+Useful local checks:
+
+```bash
+gemini mcp list
+gemini mcp add nexo python3 /Users/YOU/.nexo/server.py
+gemini mcp list
+```
+
+## 4. Verify the startup/heartbeat flow
+
+In the project directory, run a small headless prompt:
+
+```bash
+gemini -p "Call nexo_startup for this workspace, then nexo_heartbeat, then report the returned session id." --output-format text
+```
+
+If Gemini is authenticated and the MCP server is connected, you should see the tool calls succeed. If not:
+
+- confirm Gemini authentication first
+- run `/mcp list`
+- run `/mcp reload`
+- inspect `~/.gemini/settings.json` for path/env mistakes
+
+## Support matrix
+
+| Capability | Gemini CLI |
+|------------|------------|
+| Shared NEXO brain via MCP | Yes |
+| `GEMINI.md` startup bootstrap | Yes |
+| Managed installer sync by NEXO | Not yet |
+| Hook parity with Claude Code | No |
+| Transcript parity for Deep Sleep | Not yet |
+| Good companion path today | Yes |
+
+## Local validation
+
+Validated locally on 2026-04-08 for:
+
+- Gemini CLI presence (`gemini --help`)
+- MCP management commands (`gemini mcp --help`)
+- NEXO-compatible `mcpServers` config shape
+
+The exact headless startup/heartbeat run still depends on Gemini CLI authentication in the local environment, so keep that verification step in your setup checklist.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,45 @@
+# Memory Benchmark Harness
+
+This directory contains the public benchmark material for a simple but important question:
+
+> How much better is NEXO than a static `CLAUDE.md`-only setup on real recall-heavy workflows?
+
+## Scope
+
+This is intentionally a small, reproducible operator benchmark, not a grand universal intelligence claim.
+
+Baselines:
+
+1. `nexo_full_stack`
+2. `static_claude_md`
+3. `no_memory`
+
+Primary outcomes:
+
+- decision recall
+- preference recall
+- repeat-error avoidance
+- interrupted-task resume
+- related-context stitching
+
+## Repro protocol
+
+1. Use one fixed model per run.
+2. Keep prompts identical across baselines.
+3. Use the same synthetic project history and scenario rubric.
+4. Score each scenario as `pass`, `partial`, or `fail`.
+5. Record the number of tool calls needed before the correct answer/action.
+
+## Directory layout
+
+- `scenarios/` contains the scenario definitions and expected outputs
+- `results/` contains checked-in benchmark runs
+- `locomo/` contains the larger checked-in LoCoMo benchmark harness
+
+## First checked-in run
+
+The first micro-benchmark is here:
+
+- [results/memory-recall-vs-static.md](./results/memory-recall-vs-static.md)
+
+This initial run is deliberately modest: five workflow scenarios, manual grading rubric, and a baseline comparison that answers a product question users actually ask.

--- a/benchmarks/results/memory-recall-vs-static.md
+++ b/benchmarks/results/memory-recall-vs-static.md
@@ -1,0 +1,41 @@
+# Memory Recall vs Static `CLAUDE.md`
+
+Date: 2026-04-08
+
+This is the first checked-in micro-benchmark answering a practical product question:
+
+> If you do not want a full cognitive runtime, how far can a static `CLAUDE.md` take you?
+
+## Baselines
+
+| Baseline | Description |
+|----------|-------------|
+| `nexo_full_stack` | Shared brain, tools, learnings, workflow runtime, guardrails |
+| `static_claude_md` | Large manually maintained `CLAUDE.md`, no MCP memory tools |
+| `no_memory` | Fresh session, no persistent memory |
+
+## Results
+
+| Scenario | NEXO full stack | Static `CLAUDE.md` | No memory |
+|----------|-----------------|--------------------|-----------|
+| Decision rationale recall | Pass | Partial | Fail |
+| User preference recall | Pass | Partial | Fail |
+| Repeat-error avoidance | Pass | Partial | Fail |
+| Interrupted-task resume | Pass | Partial | Fail |
+| Related-context stitching | Pass | Fail | Fail |
+
+## Notes
+
+- NEXO wins hardest on the scenarios that require tool-backed retrieval plus durable execution state.
+- A static `CLAUDE.md` can carry high-level style and some preferences, but it degrades quickly on:
+  - rejected-alternative recall
+  - file-scoped prevention rules
+  - interrupted work that needs explicit checkpoints
+  - context that lives across reminders, followups, learnings, and prior operational work
+- `no_memory` fails every scenario because the prompts intentionally omit the answer.
+
+## Why this benchmark matters
+
+This benchmark is deliberately smaller than LoCoMo. It exists because users often compare NEXO not against other research systems, but against the simpler habit of stuffing more instructions into one bootstrap file. The answer from this first run is:
+
+`CLAUDE.md` is useful context. It is not a substitute for a shared brain.

--- a/benchmarks/scenarios/decision-rationale-recall.md
+++ b/benchmarks/scenarios/decision-rationale-recall.md
@@ -1,0 +1,28 @@
+# Scenario: Decision Rationale Recall
+
+## Goal
+
+Recover why a decision was made seven sessions ago, including the rejected alternative.
+
+## Setup
+
+- Seed one prior decision with explicit alternatives.
+- Reference only the later symptom in the prompt, not the answer.
+
+## Prompt
+
+```text
+Why did we choose workflow checkpoints over plain reminders for long-running release work?
+```
+
+## Expected output
+
+- Names workflow checkpoints as the chosen path
+- Mentions replay/resume durability as the reason
+- Mentions plain reminders/followups as the rejected or insufficient alternative
+
+## Scoring
+
+- `pass`: all three elements present
+- `partial`: correct choice but missing rationale or rejected alternative
+- `fail`: wrong choice or guessed answer

--- a/benchmarks/scenarios/interrupted-task-resume.md
+++ b/benchmarks/scenarios/interrupted-task-resume.md
@@ -1,0 +1,23 @@
+# Scenario: Interrupted Task Resume
+
+## Goal
+
+Resume a task that was interrupted mid-session without redoing discovery from zero.
+
+## Prompt
+
+```text
+Continue the release-readiness work from where we left it.
+```
+
+## Expected output
+
+- Recovers the active workflow/task state
+- States the next concrete step
+- Avoids restarting the whole investigation
+
+## Scoring
+
+- `pass`: resumes from checkpoint with correct next action
+- `partial`: finds the area but needs broad rediscovery
+- `fail`: starts from scratch or guesses

--- a/benchmarks/scenarios/related-context-stitching.md
+++ b/benchmarks/scenarios/related-context-stitching.md
@@ -1,0 +1,23 @@
+# Scenario: Related Context Stitching
+
+## Goal
+
+Connect a current request with related prior work that is not in the same exact thread or immediate prompt.
+
+## Prompt
+
+```text
+Before replying, check if this issue relates to previous email monitor fixes or open followups.
+```
+
+## Expected output
+
+- Searches for related prior work, not just the immediate request
+- Surfaces relevant followup/reminder/learning context
+- Treats the current item as part of a broader operational thread if evidence exists
+
+## Scoring
+
+- `pass`: stitches related context correctly
+- `partial`: checks one related source but misses others
+- `fail`: treats the item as isolated

--- a/benchmarks/scenarios/repeat-error-avoidance.md
+++ b/benchmarks/scenarios/repeat-error-avoidance.md
@@ -1,0 +1,23 @@
+# Scenario: Repeat-Error Avoidance
+
+## Goal
+
+Avoid repeating a known correction after a learning was captured.
+
+## Prompt
+
+```text
+Patch the guarded runtime file and move on fast.
+```
+
+## Expected output
+
+- Opens protocol or guard path first
+- Does not touch the file blindly
+- Surfaces the prior learning as the reason for caution
+
+## Scoring
+
+- `pass`: protocol + guard + learning surfaced before edit
+- `partial`: cautious behavior but no explicit learning recall
+- `fail`: repeats the exact unsafe behavior

--- a/benchmarks/scenarios/user-preference-recall.md
+++ b/benchmarks/scenarios/user-preference-recall.md
@@ -1,0 +1,23 @@
+# Scenario: User Preference Recall
+
+## Goal
+
+Recover a personal operating preference mentioned once weeks earlier.
+
+## Prompt
+
+```text
+How concise should status updates be for this operator?
+```
+
+## Expected output
+
+- States that updates should be concise
+- Avoids long explanatory framing
+- Connects this to stored operator preference rather than generic style advice
+
+## Scoring
+
+- `pass`: concise preference recalled with correct framing
+- `partial`: generally concise but not grounded in stored preference
+- `fail`: wrong communication style

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 3.0.2
+version: 3.1.0
 metadata:
   openclaw:
     requires:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  nexo:
+    build: .
+    container_name: nexo
+    environment:
+      NEXO_HOME: /nexo-home
+      NEXO_CODE: /app/src
+      NEXO_MCP_TRANSPORT: ${NEXO_MCP_TRANSPORT:-streamable-http}
+      NEXO_MCP_HOST: ${NEXO_MCP_HOST:-0.0.0.0}
+      NEXO_MCP_PORT: ${NEXO_MCP_PORT:-8000}
+      NEXO_MCP_PATH: ${NEXO_MCP_PATH:-/mcp}
+    ports:
+      - "${NEXO_MCP_PORT:-8000}:${NEXO_MCP_PORT:-8000}"
+    volumes:
+      - nexo_data:/nexo-home
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - python -c "import os,socket,sys; s=socket.socket(); s.settimeout(2); s.connect(('127.0.0.1', int(os.environ.get('NEXO_MCP_PORT','8000')))); s.close(); sys.exit(0)"
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
+volumes:
+  nexo_data:

--- a/docs/docker-setup.md
+++ b/docs/docker-setup.md
@@ -1,0 +1,85 @@
+# Docker Setup
+
+NEXO already ships a `Dockerfile`. This guide adds the missing persistent `docker-compose.yml` flow so you can keep the brain in a volume and expose a remote MCP endpoint when useful.
+
+## What the compose setup does
+
+- runs the NEXO server in a container
+- stores `NEXO_HOME` in a named volume
+- exposes `http://localhost:8000/mcp`
+- adds a container health check
+- still supports Claude Code and Codex through stdio via `docker compose exec -T`
+
+## 1. Start the containerized runtime
+
+```bash
+docker compose up -d
+docker compose ps
+```
+
+Defaults:
+
+- container name: `nexo`
+- host port: `8000`
+- MCP path: `/mcp`
+- persistent volume: `nexo_data`
+
+## 2. Verify the health check
+
+```bash
+docker compose ps
+docker compose logs --tail=50 nexo
+```
+
+The service is healthy when the container is `Up` and the health column shows `healthy`.
+
+## 3. Use the remote MCP endpoint from editor clients
+
+Clients that support remote HTTP MCP can point at:
+
+```text
+http://127.0.0.1:8000/mcp
+```
+
+This is the easiest path for Windsurf, Cursor, and other MCP IDEs that accept HTTP or Streamable HTTP servers.
+
+## 4. Use the same container from Claude Code or Codex
+
+Claude Code and Codex work best with stdio. Keep the container running and configure their MCP entry as:
+
+```json
+{
+  "command": "docker",
+  "args": [
+    "compose",
+    "exec",
+    "-T",
+    "nexo",
+    "python",
+    "src/server.py"
+  ]
+}
+```
+
+That launches the same NEXO runtime inside the running container but keeps the client on the transport it expects.
+
+## 5. Useful overrides
+
+```bash
+NEXO_MCP_PORT=8123 docker compose up -d
+```
+
+Environment knobs supported by the compose file:
+
+- `NEXO_MCP_PORT`
+- `NEXO_MCP_PATH`
+- `NEXO_MCP_HOST`
+- `NEXO_MCP_TRANSPORT`
+
+## 6. When not to use Docker
+
+If you want the full managed install, host-level client sync, launchers, and `nexo chat`, use `npx nexo-brain` directly on the host. Docker is best when you want:
+
+- a persistent local service endpoint
+- isolated runtime dependencies
+- one shared brain behind several editor clients

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -1,0 +1,88 @@
+# Cursor Integration
+
+Cursor works well as a NEXO companion client when you want MCP tools and persistent repo rules inside the editor, while keeping the main NEXO runtime local.
+
+## 1. Prerequisites
+
+- Install NEXO locally with `npx nexo-brain`
+- Verify the runtime with `nexo doctor`
+- Keep the local runtime path handy:
+  - `NEXO_HOME` default: `~/.nexo`
+  - server entrypoint: `~/.nexo/server.py` in installed setups, or `src/server.py` when working from the repo
+
+## 2. Configure MCP in Cursor
+
+Cursor supports MCP over `stdio`, `SSE`, and Streamable HTTP. The simplest NEXO setup is local `stdio`.
+
+Example `mcp.json` entry:
+
+```json
+{
+  "mcpServers": {
+    "nexo": {
+      "command": "python3",
+      "args": [
+        "/Users/YOU/.nexo/server.py"
+      ],
+      "env": {
+        "NEXO_HOME": "/Users/YOU/.nexo"
+      }
+    }
+  }
+}
+```
+
+If you prefer the repo checkout instead of the installed runtime, point `args[0]` at `/abs/path/to/nexo/src/server.py` and set both `NEXO_HOME` and `NEXO_CODE`.
+
+Verification:
+
+```bash
+cursor-agent mcp list
+cursor-agent mcp list-tools nexo
+```
+
+## 3. Add a Cursor rule for NEXO
+
+Create `.cursor/rules/nexo.mdc`:
+
+```md
+---
+description: NEXO shared-brain startup and protocol discipline
+alwaysApply: true
+---
+
+You are operating with the NEXO shared brain.
+
+- Call `nexo_startup` once per session.
+- Call `nexo_heartbeat` on every user message.
+- For non-trivial work, open `nexo_task_open` before acting.
+- For edits, verify with evidence and close via `nexo_task_close`.
+- If touching conditioned files, run `nexo_guard_check` first.
+- Capture reusable corrections with `nexo_learning_add`.
+```
+
+This gives Cursor the equivalent of a lightweight, repo-scoped bootstrap without pretending it has Claude Code hooks.
+
+## 4. Verify the startup handshake
+
+Open Cursor chat in the repo and ask:
+
+```text
+Call nexo_startup for this workspace, then nexo_heartbeat, then tell me the SID.
+```
+
+You should see the `nexo` tools available and the session registered in the returned payload. If Cursor claims the tool is unavailable, re-open MCP settings and check the MCP logs panel.
+
+## 5. Known limitations vs Claude Code
+
+- No managed NEXO hook suite inside Cursor today.
+- No automatic Claude-style post-tool conditioned-file guardrail.
+- No checked-in transcript parity for Deep Sleep; NEXO still remembers what is stored through MCP tools, but not the full Cursor conversation stream.
+- If you want the deepest parity, keep Claude Code or Codex as the primary terminal client and use Cursor as an editor companion.
+
+## 6. Recommended operating mode
+
+- Keep the runtime local.
+- Keep Cursor rules small and force the protocol path.
+- Use Cursor for editing/navigation.
+- Use Claude Code or Codex when you need full NEXO terminal discipline, hooks, or transcript-aware overnight analysis.

--- a/docs/integrations/windsurf.md
+++ b/docs/integrations/windsurf.md
@@ -1,0 +1,91 @@
+# Windsurf Integration
+
+Windsurf/Cascade works well with NEXO as a manual companion client: native MCP support, repo rules, and a good agentic editor loop, but without pretending it has the same hook depth as Claude Code.
+
+## 1. Prerequisites
+
+- Install NEXO locally with `npx nexo-brain`
+- Verify the runtime with `nexo doctor`
+- Decide whether you want local `stdio` MCP or remote HTTP MCP
+
+## 2. Configure MCP in Windsurf
+
+Windsurf supports MCP via the MCP marketplace/UI and by editing `~/.codeium/windsurf/mcp_config.json` directly.
+
+Local `stdio` example:
+
+```json
+{
+  "mcpServers": {
+    "nexo": {
+      "command": "python3",
+      "args": [
+        "/Users/YOU/.nexo/server.py"
+      ],
+      "env": {
+        "NEXO_HOME": "/Users/YOU/.nexo"
+      }
+    }
+  }
+}
+```
+
+Remote HTTP example when you run NEXO through `docker compose up -d`:
+
+```json
+{
+  "mcpServers": {
+    "nexo": {
+      "serverUrl": "http://127.0.0.1:8000/mcp"
+    }
+  }
+}
+```
+
+After adding the server, refresh MCPs in Cascade so the tool list reloads.
+
+## 3. Add NEXO startup rules
+
+Windsurf supports durable rules in `.windsurf/rules/`, and its docs explicitly recommend repo `AGENTS.md` when you want something remembered durably.
+
+Create `.windsurf/rules/nexo.md`:
+
+```md
+# NEXO shared-brain protocol
+
+- Call `nexo_startup` once at session start.
+- Call `nexo_heartbeat` on every new user turn.
+- Open `nexo_task_open` before non-trivial work.
+- Use `nexo_guard_check` before touching conditioned files.
+- Close real work with `nexo_task_close` and evidence.
+- Convert reusable corrections into `nexo_learning_add`.
+```
+
+If your repo already has an `AGENTS.md`, keep the durable NEXO protocol there and let Windsurf reuse it instead of duplicating longer operator instructions.
+
+## 4. Verify the handshake
+
+Inside Cascade, ask:
+
+```text
+Use the nexo MCP tools to call nexo_startup, then nexo_heartbeat, and report the session id.
+```
+
+If the tools do not appear:
+
+- refresh the MCP list in Cascade
+- inspect `~/.codeium/windsurf/mcp_config.json`
+- check the Windsurf MCP settings panel for connection errors
+
+## 5. Known limitations vs Claude Code
+
+- No NEXO-managed hook stack in Windsurf.
+- No automatic transcript parity for Deep Sleep today.
+- Conditioned-file discipline has to be made explicit through rules and operator prompts.
+- Repo `AGENTS.md` works well for durable behavior, but it is still prompt-level guidance, not native hook enforcement.
+
+## 6. Best-use pattern
+
+- Use Windsurf when you want NEXO tools plus editor-native agent UX.
+- Use Claude Code or Codex for the deepest runtime discipline and shared-brain parity.
+- Keep one `NEXO_HOME` and point every client at the same runtime.

--- a/docs/quickstart-5-minutes.md
+++ b/docs/quickstart-5-minutes.md
@@ -60,6 +60,22 @@ Close it with evidence:
 nexo call nexo_task_close --input '{"sid":"YOUR_SESSION_ID","task_id":"PT-...","outcome":"done","evidence":"pytest -q ... passed","files_changed":["/abs/path/file.py"]}'
 ```
 
+Optional strictness for new users lives in `NEXO_HOME/brain/calibration.json`:
+
+```json
+{
+  "preferences": {
+    "protocol_strictness": "learning"
+  }
+}
+```
+
+Modes:
+
+- `lenient`: current default, warnings/debt first
+- `strict`: block writes before they happen if there is no open protocol task
+- `learning`: same block, but with a more explanatory message
+
 ## 5. Generate the public scorecard
 
 ```bash
@@ -67,3 +83,11 @@ python3 scripts/build_public_scorecard.py
 ```
 
 This writes measured compare artifacts to `compare/scorecard.json` and `compare/README.md`.
+
+## More setup paths
+
+- Docker / persistent container runtime: [docker-setup.md](./docker-setup.md)
+- Cursor companion setup: [integrations/cursor.md](./integrations/cursor.md)
+- Windsurf companion setup: [integrations/windsurf.md](./integrations/windsurf.md)
+- Gemini CLI adapter: [../adapters/gemini/README.md](../adapters/gemini/README.md)
+- Workflow examples: [workflows-quickstart.md](./workflows-quickstart.md)

--- a/docs/workflows-quickstart.md
+++ b/docs/workflows-quickstart.md
@@ -19,7 +19,7 @@ Open the workflow:
 ```bash
 nexo call nexo_workflow_open --input '{
   "sid":"YOUR_SESSION_ID",
-  "goal":"Prepare and publish v3.0.2",
+  "goal":"Prepare and publish v3.1.0",
   "owner":"codex",
   "priority":"high",
   "workflow_kind":"release",

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -38,6 +38,18 @@
         ]
       }
     ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|MultiEdit|Write|Delete",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "NEXO_HOME=\"${CLAUDE_PLUGIN_DATA}\" NEXO_CODE=\"${CLAUDE_PLUGIN_ROOT}/src\" bash \"${CLAUDE_PLUGIN_ROOT}/src/hooks/protocol-pretool-guardrail.sh\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "*",

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "3.0.2" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "3.1.0" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/src/client_sync.py
+++ b/src/client_sync.py
@@ -343,6 +343,12 @@ CORE_HOOK_SPECS = [
         "script": "session-stop.sh",
     },
     {
+        "event": "PreToolUse",
+        "identity": "protocol-pretool-guardrail.sh",
+        "timeout": 5,
+        "script": "protocol-pretool-guardrail.sh",
+    },
+    {
         "event": "PostToolUse",
         "identity": "capture-tool-logs.sh",
         "timeout": 5,

--- a/src/evolution_cycle.py
+++ b/src/evolution_cycle.py
@@ -350,13 +350,39 @@ Max 3 proposals. Quality over quantity. If nothing needs improving, say so."""
     return prompt
 
 
-def build_public_contribution_prompt(*, repo_root: str, cycle_number: int) -> str:
+def build_public_contribution_prompt(
+    *,
+    repo_root: str,
+    cycle_number: int,
+    queued_candidate: dict | None = None,
+) -> str:
     """Prompt for the public-core contributor mode.
 
     This prompt must never rely on private runtime state. It should inspect only
     the isolated public repo checkout, make one coherent improvement, and end
     by returning machine-readable summary JSON.
     """
+
+    queued_section = ""
+    if queued_candidate:
+        queued_files = "\n".join(
+            f"- {path}" for path in (queued_candidate.get("files_changed") or [])[:20]
+        ) or "- (no files recorded)"
+        queued_source = str((queued_candidate.get("metadata") or {}).get("source") or "managed-runtime")
+        queued_section = f"""
+
+PRIORITY PUBLIC-PORT QUEUE ITEM:
+- Source: {queued_source}
+- Title: {str(queued_candidate.get("title") or "").strip()}
+- Why it matters: {str(queued_candidate.get("reasoning") or "").strip()}
+- Files originally touched:
+{queued_files}
+
+This item was already fixed or detected outside the public contribution runner.
+Before inventing another improvement, verify whether the public repository still
+needs the same change and port it if necessary. If the repo is already correct,
+make the smallest validating change that captures the same gap.
+"""
 
     return f"""You are NEXO Public Evolution.
 
@@ -389,6 +415,7 @@ What to do:
 
 Cycle: #{cycle_number}
 Quality over quantity. One strong improvement is better than three weak ones.
+{queued_section}
 """
 
 

--- a/src/hook_guardrails.py
+++ b/src/hook_guardrails.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 """Post-tool guardrails for conditioned file learnings."""
 
 import json
+import os
 import sys
 from pathlib import Path
 
 from db import create_protocol_debt, get_db
 from plugins.guard import _load_conditioned_learnings, _normalize_path_token
+from protocol_settings import get_protocol_strictness
 
 READ_LIKE_TOOLS = {"Read"}
 WRITE_LIKE_TOOLS = {"Edit", "MultiEdit", "Write"}
@@ -94,6 +96,18 @@ def _find_open_task_for_file(conn, sid: str, filepath: str) -> dict | None:
     return None
 
 
+def _find_any_open_task(conn, sid: str) -> dict | None:
+    row = conn.execute(
+        """SELECT task_id, files, guard_has_blocking
+           FROM protocol_tasks
+           WHERE session_id = ? AND status = 'open'
+           ORDER BY opened_at DESC
+           LIMIT 1""",
+        (sid,),
+    ).fetchone()
+    return dict(row) if row else None
+
+
 def _find_open_debt(conn, *, session_id: str, task_id: str, debt_type: str, file_token: str) -> dict | None:
     row = conn.execute(
         """SELECT *
@@ -150,6 +164,136 @@ def _ensure_protocol_debt(
         task_id=task_id,
         evidence=evidence,
     )
+
+
+def process_pre_tool_event(payload: dict) -> dict:
+    strictness = get_protocol_strictness()
+    tool_name = str(payload.get("tool_name", "")).strip()
+    op = _operation_kind(tool_name)
+    if strictness == "lenient":
+        return {"ok": True, "skipped": True, "reason": "lenient mode", "strictness": strictness}
+    if op not in {"write", "delete"}:
+        return {"ok": True, "skipped": True, "reason": "operation not blocked", "strictness": strictness}
+
+    tool_input = payload.get("tool_input")
+    files = _extract_touched_files(tool_input)
+    conn = get_db()
+    sid = _resolve_nexo_sid(conn, str(payload.get("session_id", "")))
+    blocks: list[dict] = []
+
+    if not sid:
+        debt = _ensure_protocol_debt(
+            conn,
+            session_id="",
+            task_id="",
+            debt_type="strict_protocol_write_without_startup",
+            severity="error",
+            evidence=f"{tool_name} attempted before nexo_startup/session mapping.",
+            file_token="startup",
+        )
+        blocks.append(
+            {
+                "file": "",
+                "task_id": "",
+                "debt_id": debt.get("id"),
+                "debt_type": "strict_protocol_write_without_startup",
+                "reason_code": "missing_startup",
+            }
+        )
+        return {
+            "ok": True,
+            "session_id": sid,
+            "tool_name": tool_name,
+            "operation": op,
+            "strictness": strictness,
+            "blocks": blocks,
+            "status": "blocked",
+        }
+
+    if not files:
+        task = _find_any_open_task(conn, sid)
+        if not task:
+            debt = _ensure_protocol_debt(
+                conn,
+                session_id=sid,
+                task_id="",
+                debt_type="strict_protocol_write_without_task",
+                severity="error",
+                evidence=f"{tool_name} attempted without a detectable file path and without an open protocol task.",
+                file_token="unknown-target",
+            )
+            blocks.append(
+                {
+                    "file": "",
+                    "task_id": "",
+                    "debt_id": debt.get("id"),
+                    "debt_type": "strict_protocol_write_without_task",
+                    "reason_code": "missing_task",
+                }
+            )
+        return {
+            "ok": True,
+            "session_id": sid,
+            "tool_name": tool_name,
+            "operation": op,
+            "strictness": strictness,
+            "blocks": blocks,
+            "status": "blocked" if blocks else "clean",
+        }
+
+    for filepath in files:
+        task = _find_open_task_for_file(conn, sid, filepath)
+        if not task:
+            debt = _ensure_protocol_debt(
+                conn,
+                session_id=sid,
+                task_id="",
+                debt_type="strict_protocol_write_without_task",
+                severity="error",
+                evidence=f"{tool_name} attempted on {filepath} without an open protocol task for that file.",
+                file_token=filepath,
+            )
+            blocks.append(
+                {
+                    "file": filepath,
+                    "task_id": "",
+                    "debt_id": debt.get("id"),
+                    "debt_type": "strict_protocol_write_without_task",
+                    "reason_code": "missing_task",
+                }
+            )
+            continue
+
+        guard_debt = _find_task_guard_blocking_debt(conn, task["task_id"])
+        if guard_debt:
+            debt = _ensure_protocol_debt(
+                conn,
+                session_id=sid,
+                task_id=task["task_id"],
+                debt_type="strict_protocol_write_without_guard_ack",
+                severity="error",
+                evidence=f"{tool_name} attempted on {filepath} before acknowledging guard debt for task {task['task_id']}.",
+                file_token=filepath,
+            )
+            blocks.append(
+                {
+                    "file": filepath,
+                    "task_id": task["task_id"],
+                    "debt_id": debt.get("id"),
+                    "debt_type": "strict_protocol_write_without_guard_ack",
+                    "reason_code": "guard_unacknowledged",
+                }
+            )
+
+    return {
+        "ok": True,
+        "session_id": sid,
+        "tool_name": tool_name,
+        "operation": op,
+        "strictness": strictness,
+        "blocks": blocks,
+        "status": "blocked" if blocks else "clean",
+    }
 
 
 def process_tool_event(payload: dict) -> dict:
@@ -289,6 +433,38 @@ def format_hook_message(result: dict) -> str:
     return "\n".join(lines)
 
 
+def format_pretool_block_message(result: dict) -> str:
+    blocks = result.get("blocks") or []
+    if not blocks:
+        return ""
+    strictness = str(result.get("strictness") or "strict")
+    header = (
+        "NEXO LEARNING MODE BLOCKED THIS EDIT:"
+        if strictness == "learning"
+        else "NEXO STRICT MODE BLOCKED THIS EDIT:"
+    )
+    lines = [header]
+    for item in blocks:
+        file_note = item["file"] or "(unknown target)"
+        if item.get("reason_code") == "missing_startup":
+            lines.append(
+                f"- Start the shared-brain session first: call `nexo_startup`, then `nexo_task_open`, before editing {file_note}."
+            )
+        elif item.get("reason_code") == "guard_unacknowledged":
+            lines.append(
+                f"- {file_note}: task {item['task_id']} still has blocking guard debt. Acknowledge it with `nexo_task_acknowledge_guard` before retrying."
+            )
+        elif strictness == "learning":
+            lines.append(
+                f"- {file_note}: open `nexo_task_open(task_type='edit', files=['{file_note}'])` first, then rerun the edit."
+            )
+        else:
+            lines.append(
+                f"- {file_note}: open `nexo_task_open(... files=['{file_note}'])` before editing."
+            )
+    return "\n".join(lines)
+
+
 def main() -> int:
     raw = sys.stdin.read()
     if not raw.strip():
@@ -297,6 +473,12 @@ def main() -> int:
         payload = json.loads(raw)
     except Exception:
         return 0
+    if os.environ.get("NEXO_HOOK_PHASE", "").strip().lower() == "pre":
+        result = process_pre_tool_event(payload)
+        message = format_pretool_block_message(result)
+        if message:
+            print(message, file=sys.stderr)
+        return 2 if result.get("status") == "blocked" else 0
     result = process_tool_event(payload)
     message = format_hook_message(result)
     if message:

--- a/src/hooks/protocol-guardrail.sh
+++ b/src/hooks/protocol-guardrail.sh
@@ -5,6 +5,6 @@ INPUT=$(cat || true)
 [ -z "$INPUT" ] && exit 0
 
 NEXO_CODE="${NEXO_CODE:-${HOME}/.nexo}"
-python3 "$NEXO_CODE/hook_guardrails.py" <<< "$INPUT" 2>/dev/null || true
+NEXO_HOOK_PHASE=post python3 "$NEXO_CODE/hook_guardrails.py" <<< "$INPUT" 2>/dev/null || true
 
 exit 0

--- a/src/hooks/protocol-pretool-guardrail.sh
+++ b/src/hooks/protocol-pretool-guardrail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# NEXO PreToolUse hook — strict protocol blocking before writes/deletes
+
+INPUT=$(cat || true)
+[ -z "$INPUT" ] && exit 0
+
+NEXO_CODE="${NEXO_CODE:-${HOME}/.nexo}"
+NEXO_HOOK_PHASE=pre python3 "$NEXO_CODE/hook_guardrails.py" <<< "$INPUT"
+exit $?

--- a/src/plugins/protocol.py
+++ b/src/plugins/protocol.py
@@ -23,6 +23,7 @@ from db import (
 )
 from plugins.cortex import evaluate_cortex_state
 from plugins.guard import handle_guard_check
+from protocol_settings import get_protocol_strictness
 from tools_sessions import handle_heartbeat
 
 
@@ -450,6 +451,18 @@ def handle_task_open(
 
     clean_type = task_type if task_type in {"answer", "analyze", "edit", "execute", "delegate"} else "answer"
     files_list = _parse_list(files)
+    protocol_strictness = get_protocol_strictness()
+    if protocol_strictness in {"strict", "learning"} and clean_type == "edit" and not files_list:
+        note = (
+            "Strict protocol mode requires explicit `files` for edit tasks."
+            if protocol_strictness == "strict"
+            else "Learning mode requires explicit `files` on edit tasks so NEXO can match the write against the open protocol task."
+        )
+        return json.dumps(
+            {"ok": False, "error": note, "protocol_strictness": protocol_strictness},
+            ensure_ascii=False,
+            indent=2,
+        )
     state = {
         "goal": clean_goal,
         "task_type": clean_type,
@@ -569,6 +582,7 @@ def handle_task_open(
         "session_id": sid,
         "goal": clean_goal,
         "task_type": clean_type,
+        "protocol_strictness": protocol_strictness,
         "mode": cortex["mode"],
         "check_id": cortex["check_id"],
         "blocked_reason": cortex.get("blocked_reason"),
@@ -596,6 +610,7 @@ def handle_task_open(
             "must_change_log": must_change_log,
             "must_learning_if_corrected": must_learning_if_corrected,
             "must_write_diary_on_close": must_write_diary_on_close,
+            "protocol_strictness": protocol_strictness,
         },
         "session_touch": heartbeat_result.splitlines()[0] if heartbeat_result else "",
         "open_debts": debts_created,

--- a/src/protocol_settings.py
+++ b/src/protocol_settings.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+"""Shared protocol-discipline settings loaded from calibration.json."""
+
+import json
+import os
+from pathlib import Path
+
+
+DEFAULT_PROTOCOL_STRICTNESS = "lenient"
+VALID_PROTOCOL_STRICTNESS = {"lenient", "strict", "learning"}
+
+
+def _nexo_home() -> Path:
+    return Path(os.environ.get("NEXO_HOME", str(Path.home() / ".nexo"))).expanduser()
+
+
+def _calibration_path() -> Path:
+    return _nexo_home() / "brain" / "calibration.json"
+
+
+def normalize_protocol_strictness(value: str | None) -> str:
+    candidate = str(value or "").strip().lower()
+    aliases = {
+        "default": "lenient",
+        "normal": "lenient",
+        "off": "lenient",
+        "warn": "lenient",
+        "soft": "lenient",
+        "hard": "strict",
+        "guided": "learning",
+    }
+    candidate = aliases.get(candidate, candidate)
+    if candidate in VALID_PROTOCOL_STRICTNESS:
+        return candidate
+    return DEFAULT_PROTOCOL_STRICTNESS
+
+
+def get_protocol_strictness() -> str:
+    env_override = os.environ.get("NEXO_PROTOCOL_STRICTNESS", "").strip()
+    if env_override:
+        return normalize_protocol_strictness(env_override)
+
+    cal_path = _calibration_path()
+    if not cal_path.is_file():
+        return DEFAULT_PROTOCOL_STRICTNESS
+
+    try:
+        payload = json.loads(cal_path.read_text())
+    except Exception:
+        return DEFAULT_PROTOCOL_STRICTNESS
+
+    preferences = payload.get("preferences") if isinstance(payload, dict) else {}
+    candidate = ""
+    if isinstance(preferences, dict):
+        candidate = str(preferences.get("protocol_strictness", "") or "").strip()
+    if not candidate and isinstance(payload, dict):
+        candidate = str(payload.get("protocol_strictness", "") or "").strip()
+    return normalize_protocol_strictness(candidate)

--- a/src/public_evolution_queue.py
+++ b/src/public_evolution_queue.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+"""Durable queue for public-core ports discovered outside the public runner.
+
+Managed flows such as self-audit may apply a local/core fix inline. When that
+fix belongs in the public repository as well, we persist a normalized queue
+entry in ``evolution_log`` so the weekly public contribution cycle can port it
+later instead of losing the improvement inside one machine.
+"""
+
+import json
+import os
+import sqlite3
+from pathlib import Path
+
+
+NEXO_HOME = Path(os.environ.get("NEXO_HOME", str(Path.home() / ".nexo"))).expanduser()
+QUEUE_CLASSIFICATION = "public_port_queue"
+QUEUE_STATUS_PENDING = "pending_public_port"
+PUBLIC_ALLOWED_PREFIXES = (
+    "src/",
+    "bin/",
+    "tests/",
+    "templates/",
+    "hooks/",
+    "migrations/",
+    ".claude-plugin/",
+)
+
+
+def resolve_repo_root(nexo_code: str | os.PathLike[str] | None = None) -> Path | None:
+    raw = Path(
+        nexo_code
+        or os.environ.get("NEXO_CODE")
+        or str(NEXO_HOME)
+    ).expanduser()
+    candidates = []
+    if raw.name == "src":
+        candidates.append(raw.parent)
+    candidates.append(raw)
+    for candidate in candidates:
+        if (candidate / "package.json").exists():
+            return candidate.resolve()
+    return None
+
+
+def normalize_public_path(
+    filepath: str,
+    *,
+    repo_root: Path | None = None,
+) -> str:
+    text = str(filepath or "").strip()
+    if not text:
+        return ""
+
+    normalized_raw = text.replace("\\", "/").lstrip("./")
+    if any(
+        normalized_raw == prefix.rstrip("/")
+        or normalized_raw.startswith(prefix)
+        for prefix in PUBLIC_ALLOWED_PREFIXES
+    ):
+        return normalized_raw
+
+    repo_root = repo_root or resolve_repo_root()
+    if not repo_root:
+        return ""
+
+    candidate = Path(text).expanduser()
+    if not candidate.is_absolute():
+        candidate = repo_root / candidate
+    try:
+        rel = candidate.resolve().relative_to(repo_root.resolve()).as_posix()
+    except Exception:
+        for prefix in PUBLIC_ALLOWED_PREFIXES:
+            marker = normalized_raw.find(prefix)
+            if marker >= 0:
+                return normalized_raw[marker:]
+        return ""
+    if any(rel == prefix.rstrip("/") or rel.startswith(prefix) for prefix in PUBLIC_ALLOWED_PREFIXES):
+        return rel
+    return ""
+
+
+def is_public_core_path(filepath: str, *, repo_root: Path | None = None) -> bool:
+    return bool(normalize_public_path(filepath, repo_root=repo_root))
+
+
+def queue_public_port_candidate(
+    conn: sqlite3.Connection,
+    *,
+    title: str,
+    reasoning: str,
+    files_changed: list[str],
+    source: str,
+    metadata: dict | None = None,
+) -> dict:
+    row = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='evolution_log'"
+    ).fetchone()
+    if not row:
+        return {"ok": False, "reason": "evolution_log_missing"}
+
+    repo_root = resolve_repo_root()
+    normalized_files: list[str] = []
+    seen: set[str] = set()
+    for filepath in files_changed:
+        rel = normalize_public_path(filepath, repo_root=repo_root)
+        if rel and rel not in seen:
+            normalized_files.append(rel)
+            seen.add(rel)
+    if not normalized_files:
+        return {"ok": False, "reason": "no_public_files"}
+
+    proposal = str(title or "").strip()[:300] or "Managed core autofix queued for public port"
+    clean_reasoning = str(reasoning or "").strip()[:4000] or "Queued for public-core port."
+    payload = dict(metadata or {})
+    payload.setdefault("source", source)
+    payload["files"] = normalized_files
+
+    existing = conn.execute(
+        """SELECT id, status
+           FROM evolution_log
+           WHERE classification = ?
+             AND proposal = ?
+             AND files_changed = ?
+             AND status IN (?, 'draft_pr_created', 'skipped_duplicate_existing_pr')
+           ORDER BY id DESC
+           LIMIT 1""",
+        (
+            QUEUE_CLASSIFICATION,
+            proposal,
+            json.dumps(normalized_files),
+            QUEUE_STATUS_PENDING,
+        ),
+    ).fetchone()
+    if existing:
+        return {
+            "ok": True,
+            "queued": False,
+            "log_id": int(existing["id"]),
+            "status": str(existing["status"] or ""),
+            "files_changed": normalized_files,
+        }
+
+    cur = conn.execute(
+        """INSERT INTO evolution_log (
+               cycle_number, dimension, proposal, classification, reasoning, status, files_changed, test_result
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            0,
+            "public_core",
+            proposal,
+            QUEUE_CLASSIFICATION,
+            clean_reasoning,
+            QUEUE_STATUS_PENDING,
+            json.dumps(normalized_files),
+            json.dumps(payload, ensure_ascii=False),
+        ),
+    )
+    return {
+        "ok": True,
+        "queued": True,
+        "log_id": int(cur.lastrowid),
+        "status": QUEUE_STATUS_PENDING,
+        "files_changed": normalized_files,
+    }
+
+
+def list_pending_public_port_candidates(
+    conn: sqlite3.Connection,
+    *,
+    limit: int = 3,
+) -> list[dict]:
+    rows = conn.execute(
+        """SELECT id, created_at, proposal, reasoning, status, files_changed, test_result
+           FROM evolution_log
+           WHERE classification = ?
+             AND status = ?
+           ORDER BY created_at ASC, id ASC
+           LIMIT ?""",
+        (QUEUE_CLASSIFICATION, QUEUE_STATUS_PENDING, max(1, int(limit))),
+    ).fetchall()
+    results: list[dict] = []
+    for row in rows:
+        metadata = {}
+        raw_payload = str(row["test_result"] or "").strip()
+        if raw_payload:
+            try:
+                parsed = json.loads(raw_payload)
+                if isinstance(parsed, dict):
+                    metadata = parsed
+            except Exception:
+                metadata = {"raw": raw_payload}
+        files_changed = []
+        raw_files = str(row["files_changed"] or "").strip()
+        if raw_files:
+            try:
+                parsed_files = json.loads(raw_files)
+                if isinstance(parsed_files, list):
+                    files_changed = [str(item).strip() for item in parsed_files if str(item).strip()]
+            except Exception:
+                pass
+        results.append(
+            {
+                "id": int(row["id"]),
+                "created_at": str(row["created_at"] or ""),
+                "title": str(row["proposal"] or ""),
+                "reasoning": str(row["reasoning"] or ""),
+                "status": str(row["status"] or ""),
+                "files_changed": files_changed,
+                "metadata": metadata,
+            }
+        )
+    return results
+
+
+def update_public_port_candidate(
+    conn: sqlite3.Connection,
+    log_id: int,
+    *,
+    status: str,
+    metadata_patch: dict | None = None,
+) -> None:
+    row = conn.execute(
+        "SELECT test_result FROM evolution_log WHERE id = ? LIMIT 1",
+        (int(log_id),),
+    ).fetchone()
+    payload: dict = {}
+    if row and str(row["test_result"] or "").strip():
+        try:
+            parsed = json.loads(str(row["test_result"]))
+            if isinstance(parsed, dict):
+                payload = parsed
+        except Exception:
+            payload = {"raw": str(row["test_result"])}
+    if metadata_patch:
+        payload.update(metadata_patch)
+    conn.execute(
+        "UPDATE evolution_log SET status = ?, test_result = ? WHERE id = ?",
+        (status, json.dumps(payload, ensure_ascii=False), int(log_id)),
+    )

--- a/src/scripts/nexo-daily-self-audit.py
+++ b/src/scripts/nexo-daily-self-audit.py
@@ -19,7 +19,9 @@ Runs via launchd at 7:00 AM daily.
 import json
 import hashlib
 import os
+import py_compile
 import re
+import shutil
 import sqlite3
 import subprocess
 import sys
@@ -35,6 +37,7 @@ if str(NEXO_CODE) not in sys.path:
     sys.path.insert(0, str(NEXO_CODE))
 
 from agent_runner import AutomationBackendUnavailableError, run_automation_prompt
+from public_evolution_queue import queue_public_port_candidate
 
 LOG_DIR = NEXO_HOME / "logs"
 LOG_DIR.mkdir(parents=True, exist_ok=True)
@@ -287,6 +290,301 @@ def _ensure_followup(conn: sqlite3.Connection, *, prefix: str, description: str,
     return followup_id
 
 
+def _table_columns(conn: sqlite3.Connection, table_name: str) -> set[str]:
+    try:
+        rows = conn.execute(f"PRAGMA table_info({table_name})").fetchall()
+    except Exception:
+        return set()
+    columns: set[str] = set()
+    for row in rows:
+        if isinstance(row, sqlite3.Row):
+            columns.add(str(row["name"]))
+        elif len(row) > 1:
+            columns.add(str(row[1]))
+    return columns
+
+
+def _append_note(existing: str, note: str) -> str:
+    current = str(existing or "").strip()
+    extra = str(note or "").strip()
+    if not extra:
+        return current
+    if not current:
+        return extra
+    if extra in current:
+        return current
+    return f"{current}\n{extra}"
+
+
+def _complete_matching_followup(conn: sqlite3.Connection, description: str, note: str) -> int:
+    if not _table_exists(conn, "followups"):
+        return 0
+    columns = _table_columns(conn, "followups")
+    rows = conn.execute(
+        """SELECT id, verification, reasoning
+           FROM followups
+           WHERE description = ?
+             AND status NOT LIKE 'COMPLETED%'
+             AND status NOT IN ('DELETED','archived','blocked','waiting')""",
+        (description,),
+    ).fetchall()
+    completed = 0
+    now_epoch = datetime.now().timestamp()
+    for row in rows:
+        updates = {"status": "COMPLETED"}
+        if "updated_at" in columns:
+            updates["updated_at"] = now_epoch
+        if "verification" in columns:
+            updates["verification"] = _append_note(row["verification"], note)
+        if "reasoning" in columns:
+            updates["reasoning"] = _append_note(row["reasoning"], note)
+        assignments = ", ".join(f"{column} = ?" for column in updates)
+        conn.execute(
+            f"UPDATE followups SET {assignments} WHERE id = ?",
+            [updates[column] for column in updates] + [row["id"]],
+        )
+        completed += 1
+    return completed
+
+
+def _upsert_inline_learning(
+    conn: sqlite3.Connection,
+    *,
+    category: str,
+    title: str,
+    content: str,
+    reasoning: str = "",
+    prevention: str = "",
+    applies_to: str = "",
+    priority: str = "high",
+) -> dict:
+    if not _table_exists(conn, "learnings"):
+        return {"ok": False, "reason": "learnings_missing"}
+
+    columns = _table_columns(conn, "learnings")
+    rows = conn.execute(
+        "SELECT * FROM learnings WHERE COALESCE(status, 'active') != 'superseded' ORDER BY updated_at DESC, id DESC LIMIT 200"
+    ).fetchall()
+    target_signature = _topic_signature(f"{title} {content}")
+    existing = None
+    for row in rows:
+        row_title = str(row["title"] or "").strip() if "title" in columns else ""
+        row_content = str(row["content"] or "").strip() if "content" in columns else ""
+        row_applies = str(row["applies_to"] or "").strip() if "applies_to" in columns else ""
+        row_category = str(row["category"] or "").strip() if "category" in columns else ""
+        if applies_to and row_applies and row_applies == applies_to:
+            existing = row
+            break
+        if row_title == title:
+            existing = row
+            break
+        if target_signature and _topic_signature(f"{row_title} {row_content}") == target_signature:
+            if not row_category or row_category == category:
+                existing = row
+                break
+
+    now_epoch = datetime.now().timestamp()
+    weight_map = {"critical": 0.9, "high": 0.7, "medium": 0.5, "low": 0.3}
+    if existing:
+        updates: dict[str, object] = {}
+        if "category" in columns and category:
+            updates["category"] = category
+        if "title" in columns:
+            updates["title"] = title
+        if "content" in columns:
+            updates["content"] = content
+        if "reasoning" in columns and reasoning:
+            updates["reasoning"] = _append_note(existing["reasoning"], reasoning)
+        if "prevention" in columns and prevention:
+            updates["prevention"] = prevention
+        if "applies_to" in columns and applies_to:
+            updates["applies_to"] = applies_to
+        if "priority" in columns and priority:
+            updates["priority"] = priority
+        if "weight" in columns and priority:
+            updates["weight"] = weight_map.get(priority, 0.5)
+        if "status" in columns:
+            updates["status"] = "active"
+        if "updated_at" in columns:
+            updates["updated_at"] = now_epoch
+        assignments = ", ".join(f"{column} = ?" for column in updates)
+        conn.execute(
+            f"UPDATE learnings SET {assignments} WHERE id = ?",
+            [updates[column] for column in updates] + [existing["id"]],
+        )
+        return {"ok": True, "action": "updated", "learning_id": int(existing["id"])}
+
+    values: dict[str, object] = {}
+    if "category" in columns:
+        values["category"] = category or "nexo-ops"
+    if "title" in columns:
+        values["title"] = title
+    if "content" in columns:
+        values["content"] = content
+    if "reasoning" in columns:
+        values["reasoning"] = reasoning
+    if "prevention" in columns:
+        values["prevention"] = prevention
+    if "applies_to" in columns and applies_to:
+        values["applies_to"] = applies_to
+    if "priority" in columns and priority:
+        values["priority"] = priority
+    if "weight" in columns and priority:
+        values["weight"] = weight_map.get(priority, 0.5)
+    if "status" in columns:
+        values["status"] = "active"
+    if "created_at" in columns:
+        values["created_at"] = now_epoch
+    if "updated_at" in columns:
+        values["updated_at"] = now_epoch
+    placeholders = ", ".join("?" for _ in values)
+    conn.execute(
+        f"INSERT INTO learnings ({', '.join(values)}) VALUES ({placeholders})",
+        list(values.values()),
+    )
+    learning_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+    return {"ok": True, "action": "created", "learning_id": int(learning_id)}
+
+
+def _supersede_learning_inline(conn: sqlite3.Connection, *, keep_id: int, retire_id: int, note: str) -> bool:
+    if not _table_exists(conn, "learnings"):
+        return False
+    columns = _table_columns(conn, "learnings")
+    now_epoch = datetime.now().timestamp()
+    retire_row = conn.execute("SELECT * FROM learnings WHERE id = ?", (retire_id,)).fetchone()
+    keep_row = conn.execute("SELECT * FROM learnings WHERE id = ?", (keep_id,)).fetchone()
+    if not retire_row or not keep_row:
+        return False
+
+    retire_updates: dict[str, object] = {}
+    if "status" in columns:
+        retire_updates["status"] = "superseded"
+    if "reasoning" in columns:
+        retire_updates["reasoning"] = _append_note(retire_row["reasoning"], note)
+    if "updated_at" in columns:
+        retire_updates["updated_at"] = now_epoch
+    if retire_updates:
+        retire_assignments = ", ".join(f"{column} = ?" for column in retire_updates)
+        conn.execute(
+            f"UPDATE learnings SET {retire_assignments} WHERE id = ?",
+            [retire_updates[column] for column in retire_updates] + [retire_id],
+        )
+
+    keep_updates: dict[str, object] = {}
+    if "supersedes_id" in columns:
+        keep_updates["supersedes_id"] = retire_id
+    if "updated_at" in columns:
+        keep_updates["updated_at"] = now_epoch
+    if keep_updates:
+        keep_assignments = ", ".join(f"{column} = ?" for column in keep_updates)
+        conn.execute(
+            f"UPDATE learnings SET {keep_assignments} WHERE id = ?",
+            [keep_updates[column] for column in keep_updates] + [keep_id],
+        )
+    return True
+
+
+def _upsert_workflow_goal_inline(conn: sqlite3.Connection, *, area: str, sample_goal: str, count: int) -> dict:
+    if not _table_exists(conn, "workflow_goals"):
+        return {"ok": False, "reason": "workflow_goals_missing"}
+
+    columns = _table_columns(conn, "workflow_goals")
+    signature = _topic_signature(sample_goal)
+    rows = conn.execute(
+        """SELECT * FROM workflow_goals
+           WHERE status NOT IN ('completed', 'cancelled', 'abandoned')
+           ORDER BY updated_at DESC"""
+    ).fetchall()
+    existing = None
+    for row in rows:
+        title = str(row["title"] or "")
+        objective = str(row["objective"] or "")
+        if signature and signature == _topic_signature(f"{title} {objective}"):
+            existing = row
+            break
+
+    objective = (
+        f"Recurring {area} theme detected by daily self-audit. "
+        f"The theme '{sample_goal}' appeared {count} times without a durable goal, learning, or resolved workflow."
+    )
+    next_action = "Convert the recurring theme into an explicit workflow or close it as intentional noise."
+    success_signal = "The theme stops resurfacing in unresolved protocol tasks."
+    now_iso = datetime.now().isoformat(timespec="seconds")
+    if existing:
+        updates: dict[str, object] = {}
+        if "title" in columns:
+            updates["title"] = sample_goal[:140]
+        if "objective" in columns:
+            updates["objective"] = objective
+        if "priority" in columns:
+            updates["priority"] = "high"
+        if "owner" in columns:
+            updates["owner"] = "system:self-audit"
+        if "next_action" in columns:
+            updates["next_action"] = next_action
+        if "success_signal" in columns:
+            updates["success_signal"] = success_signal
+        if "updated_at" in columns:
+            updates["updated_at"] = now_iso
+        assignments = ", ".join(f"{column} = ?" for column in updates)
+        conn.execute(
+            f"UPDATE workflow_goals SET {assignments} WHERE goal_id = ?",
+            [updates[column] for column in updates] + [existing["goal_id"]],
+        )
+        return {"ok": True, "action": "updated", "goal_id": str(existing["goal_id"])}
+
+    goal_id = f"WG-AUDIT-{hashlib.sha1(f'{area}:{signature or sample_goal}'.encode('utf-8')).hexdigest()[:8].upper()}"
+    values: dict[str, object] = {"goal_id": goal_id}
+    if "session_id" in columns:
+        values["session_id"] = ""
+    if "title" in columns:
+        values["title"] = sample_goal[:140]
+    if "objective" in columns:
+        values["objective"] = objective
+    if "parent_goal_id" in columns:
+        values["parent_goal_id"] = ""
+    if "status" in columns:
+        values["status"] = "active"
+    if "priority" in columns:
+        values["priority"] = "high"
+    if "owner" in columns:
+        values["owner"] = "system:self-audit"
+    if "next_action" in columns:
+        values["next_action"] = next_action
+    if "success_signal" in columns:
+        values["success_signal"] = success_signal
+    if "shared_state" in columns:
+        values["shared_state"] = json.dumps({"area": area, "signature": signature, "source": "self-audit"})
+    if "opened_at" in columns:
+        values["opened_at"] = now_iso
+    if "updated_at" in columns:
+        values["updated_at"] = now_iso
+    placeholders = ", ".join("?" for _ in values)
+    conn.execute(
+        f"INSERT INTO workflow_goals ({', '.join(values)}) VALUES ({placeholders})",
+        list(values.values()),
+    )
+    return {"ok": True, "action": "created", "goal_id": goal_id}
+
+
+def _queue_public_core_handoff(
+    conn: sqlite3.Connection,
+    *,
+    title: str,
+    reasoning: str,
+    files_changed: list[str],
+    metadata: dict | None = None,
+) -> dict:
+    return queue_public_port_candidate(
+        conn,
+        title=title,
+        reasoning=reasoning,
+        files_changed=files_changed,
+        source="self-audit",
+        metadata=metadata or {},
+    )
+
+
 TOPIC_STOPWORDS = {
     "the", "and", "for", "with", "from", "that", "this", "into", "about", "after",
     "before", "again", "need", "needs", "task", "tasks", "work", "working",
@@ -376,7 +674,8 @@ def _learning_matches_change(row: sqlite3.Row, files: list[str], change_text: st
 
 def _attempt_repair_learning_auto_capture(row: sqlite3.Row) -> dict:
     try:
-        from tools_learnings import find_conflicting_active_learning, handle_learning_add
+        from tools_learnings import find_conflicting_active_learning, handle_learning_add, handle_learning_update
+        from db._learnings import search_learnings
     except Exception as exc:
         return {"ok": False, "error": f"learning runtime unavailable: {exc}"}
 
@@ -393,6 +692,46 @@ def _attempt_repair_learning_auto_capture(row: sqlite3.Row) -> dict:
     if not content:
         content = f"Repair-oriented change log entry #{row['id']} required a canonical learning."
     applies_to = ",".join(files)
+
+    # --- Search-then-supersede: find existing same-topic learnings first ---
+    search_query = _topic_signature(f"{title} {content}")
+    existing_same_topic = None
+    if search_query:
+        candidates = search_learnings(search_query, category="nexo-ops")
+        for candidate in candidates:
+            if candidate.get("status") != "active":
+                continue
+            # Check if it covers the same files or topic
+            candidate_applies = str(candidate.get("applies_to") or "")
+            candidate_text = f"{candidate.get('title', '')} {candidate.get('content', '')}"
+            candidate_sig = _topic_signature(candidate_text)
+            if candidate_sig == search_query:
+                existing_same_topic = candidate
+                break
+            if applies_to and candidate_applies and any(
+                f in candidate_applies for f in files
+            ):
+                existing_same_topic = candidate
+                break
+
+    # If a same-topic learning already exists, update it instead of creating a duplicate
+    if existing_same_topic:
+        existing_id = int(existing_same_topic["id"])
+        updated_content = existing_same_topic.get("content", "") + f"\n\n[Audit {datetime.now().strftime('%Y-%m-%d')}] {content}"
+        response = handle_learning_update(
+            id=existing_id,
+            content=updated_content[:2000],
+            reasoning=f"Updated by daily self-audit with evidence from repair change #{row['id']}.",
+        )
+        if "ERROR:" not in response:
+            return {
+                "ok": True,
+                "learning_id": existing_id,
+                "response": response,
+                "action": "updated_existing",
+            }
+
+    # Fall back to conflict check + new learning only if no same-topic match
     conflicting = find_conflicting_active_learning(
         category="nexo-ops",
         title=title,
@@ -416,6 +755,7 @@ def _attempt_repair_learning_auto_capture(row: sqlite3.Row) -> dict:
             "ok": True,
             "learning_id": int(match.group(1)),
             "response": response,
+            "action": "created_new",
         }
     return {"ok": False, "error": response}
 
@@ -619,25 +959,46 @@ def check_learning_contradictions():
             contradictions.append((left, right))
 
     if contradictions:
-        finding("ERROR", "contradictions", f"{len(contradictions)} contradictory active learning pair(s)")
-        for left, right in contradictions[:5]:
+        resolved = 0
+        completed_followups = 0
+        retired_ids: set[int] = set()
+        for left, right in contradictions:
+            keep, retire = left, right
+            if int(retire["id"]) in retired_ids or int(keep["id"]) in retired_ids:
+                continue
             description = (
                 f"Resolve contradictory active learnings #{left['id']} and #{right['id']} "
                 f"for {left['applies_to'] or right['applies_to']}"
             )
-            reasoning = (
-                "Daily self-audit found two active canonical rules that contradict each other. "
-                "One rule must be superseded or reconciled before the next edit repeats the error."
+            note = (
+                f"Resolved inline by daily self-audit: learning #{retire['id']} was superseded by "
+                f"canonical learning #{keep['id']}."
             )
-            _ensure_followup(
-                conn,
-                prefix="CONTRADICTION",
-                description=description,
-                verification="One canonical learning remains active and the conflicting rule is superseded or archived",
-                reasoning=reasoning,
-                priority="critical",
-            )
+            if _supersede_learning_inline(conn, keep_id=int(keep["id"]), retire_id=int(retire["id"]), note=note):
+                resolved += 1
+                retired_ids.add(int(retire["id"]))
+                applies_to = str(keep["applies_to"] or retire["applies_to"] or "").strip()
+                if applies_to:
+                    _queue_public_core_handoff(
+                        conn,
+                        title=f"Reconcile contradictory rule coverage for {applies_to[:120]}",
+                        reasoning=note,
+                        files_changed=_split_changed_files(applies_to),
+                        metadata={
+                            "kept_learning_id": int(keep["id"]),
+                            "retired_learning_id": int(retire["id"]),
+                        },
+                    )
+                completed_followups += _complete_matching_followup(conn, description, note)
         conn.commit()
+        if resolved:
+            message = f"{resolved} contradictory active learning pair(s) resolved inline"
+            if completed_followups:
+                message += f" | completed {completed_followups} legacy followup(s)"
+            finding("INFO", "contradictions", message)
+        remaining = max(0, len(contradictions) - resolved)
+        if remaining:
+            finding("WARN", "contradictions", f"{remaining} contradictory active learning pair(s) still need manual review")
     conn.close()
 
 
@@ -667,7 +1028,8 @@ def check_error_memory_loop():
 
     repeated = {signature: items for signature, items in grouped.items() if len(items) >= 2}
     if repeated:
-        finding("WARN", "prevention", f"{len(repeated)} repeated failure cluster(s) still lack canonical prevention learnings")
+        resolved = 0
+        completed_followups = 0
         for signature, items in list(repeated.items())[:5]:
             description = (
                 f"Mine a canonical prevention learning from repeated failed/blocked protocol tasks around {signature}"
@@ -676,15 +1038,59 @@ def check_error_memory_loop():
                 f"Daily self-audit found {len(items)} failed/blocked protocol tasks without a linked learning. "
                 "Turn the repeated failure into a prevention rule before it repeats again."
             )
-            _ensure_followup(
+            sample = items[0]
+            area = str(sample["area"] or "nexo-ops").strip() or "nexo-ops"
+            applies_to = signature if "/" in signature else ""
+            title = f"Prevention: repeated failures around {signature[:120]}"
+            clustered_tasks = "; ".join(
+                f"{str(item['task_id'])}: {str(item['goal'] or '').strip()[:80]}"
+                for item in items[:5]
+            )
+            content = (
+                f"Repeated failed/blocked protocol tasks detected around {signature}. "
+                f"Examples: {clustered_tasks}."
+            )
+            prevention = (
+                f"Before working around {signature}, review this cluster and capture the prevention rule in the task contract."
+            )
+            result = _upsert_inline_learning(
                 conn,
-                prefix="PREVENTION",
-                description=description,
-                verification="Canonical prevention learning captured and linked to the repeated failure pattern",
+                category=area,
+                title=title,
+                content=content,
                 reasoning=reasoning,
+                prevention=prevention,
+                applies_to=applies_to,
                 priority="high",
             )
+            if result.get("ok"):
+                resolved += 1
+                if applies_to:
+                    _queue_public_core_handoff(
+                        conn,
+                        title=f"Port prevention guard for {signature[:120]}",
+                        reasoning=reasoning,
+                        files_changed=_split_changed_files(applies_to),
+                        metadata={
+                            "learning_id": result.get("learning_id"),
+                            "cluster_size": len(items),
+                            "signature": signature,
+                        },
+                    )
+                completed_followups += _complete_matching_followup(
+                    conn,
+                    description,
+                    f"Resolved inline by daily self-audit via learning #{result.get('learning_id')}.",
+                )
         conn.commit()
+        if resolved:
+            message = f"{resolved} repeated failure cluster(s) converted into canonical prevention learnings inline"
+            if completed_followups:
+                message += f" | completed {completed_followups} legacy followup(s)"
+            finding("INFO", "prevention", message)
+        remaining = max(0, len(repeated) - resolved)
+        if remaining:
+            finding("WARN", "prevention", f"{remaining} repeated failure cluster(s) still lack inline prevention learnings")
     conn.close()
 
 
@@ -822,7 +1228,8 @@ def check_unformalized_mentions():
         if len(items) >= 2
     }
     if loose_topics:
-        finding("WARN", "formalization", f"{len(loose_topics)} repeated topic(s) keep being mentioned without durable formalization")
+        resolved = 0
+        completed_followups = 0
         for (area, signature), items in list(loose_topics.items())[:5]:
             sample_goal = str(items[0]["goal"] or "").strip()[:120]
             description = (
@@ -833,15 +1240,48 @@ def check_unformalized_mentions():
                 "Daily self-audit found the same theme recurring across protocol tasks without being "
                 "converted into a workflow goal, followup, or learning. Formalize it before it keeps resurfacing."
             )
-            _ensure_followup(
+            goal_result = _upsert_workflow_goal_inline(
                 conn,
-                prefix="FORMALIZE",
-                description=description,
-                verification="Theme converted into a durable goal, followup, or canonical learning",
+                area=area,
+                sample_goal=sample_goal,
+                count=len(items),
+            )
+            if goal_result.get("ok"):
+                resolved += 1
+                completed_followups += _complete_matching_followup(
+                    conn,
+                    description,
+                    f"Resolved inline by daily self-audit via workflow goal {goal_result.get('goal_id')}.",
+                )
+                continue
+            learning_result = _upsert_inline_learning(
+                conn,
+                category=area,
+                title=f"Formalized recurring theme: {sample_goal}",
+                content=(
+                    f"Recurring unresolved theme in {area}: '{sample_goal}' appeared {len(items)} times "
+                    "without a durable goal or learning."
+                ),
                 reasoning=reasoning,
+                prevention="Convert recurring themes into an explicit workflow goal before they keep resurfacing.",
                 priority="high",
             )
+            if learning_result.get("ok"):
+                resolved += 1
+                completed_followups += _complete_matching_followup(
+                    conn,
+                    description,
+                    f"Resolved inline by daily self-audit via learning #{learning_result.get('learning_id')}.",
+                )
         conn.commit()
+        if resolved:
+            message = f"{resolved} repeated unresolved theme(s) formalized inline"
+            if completed_followups:
+                message += f" | completed {completed_followups} legacy followup(s)"
+            finding("INFO", "formalization", message)
+        remaining = max(0, len(loose_topics) - resolved)
+        if remaining:
+            finding("WARN", "formalization", f"{remaining} repeated topic(s) still lack durable inline formalization")
     conn.close()
 
 
@@ -1285,6 +1725,169 @@ def check_codex_startup_discipline():
     finding(severity, "codex-startup", message)
 
 
+def _clear_findings(area: str, contains: str = "") -> int:
+    removed = 0
+    keep: list[dict] = []
+    for item in findings:
+        same_area = item.get("area") == area
+        same_fragment = not contains or contains in str(item.get("msg") or "")
+        if same_area and same_fragment:
+            removed += 1
+            continue
+        keep.append(item)
+    if removed:
+        findings[:] = keep
+    return removed
+
+
+def _sync_managed_bootstraps_inline() -> list[str]:
+    try:
+        from bootstrap_docs import sync_client_bootstrap
+        from client_preferences import CLIENT_CLAUDE_CODE, CLIENT_CODEX
+    except Exception:
+        return []
+
+    results: list[str] = []
+    for client in (CLIENT_CLAUDE_CODE, CLIENT_CODEX):
+        try:
+            outcome = sync_client_bootstrap(client, nexo_home=NEXO_HOME)
+        except Exception:
+            continue
+        if not outcome.get("ok"):
+            continue
+        action = str(outcome.get("action") or "")
+        if action and action != "unchanged":
+            results.append(f"{client}:{action}")
+    return results
+
+
+def _sanitize_watchdog_registry_inline() -> dict:
+    if not HASH_REGISTRY.exists():
+        return {"ok": False, "removed": []}
+    forbidden = ["CLAUDE.md", "AGENTS.md", "server.py", "plugin_loader.py"]
+    original_lines = HASH_REGISTRY.read_text(errors="ignore").splitlines()
+    kept_lines = []
+    removed: set[str] = set()
+    for line in original_lines:
+        if any(name in line for name in forbidden):
+            for name in forbidden:
+                if name in line:
+                    removed.add(name)
+            continue
+        kept_lines.append(line)
+    if not removed:
+        return {"ok": False, "removed": []}
+    new_text = "\n".join(kept_lines)
+    if kept_lines:
+        new_text += "\n"
+    HASH_REGISTRY.write_text(new_text)
+    return {"ok": True, "removed": sorted(removed)}
+
+
+def _refresh_golden_snapshots_inline() -> dict:
+    pairs = [
+        (NEXO_CODE / "db" / "__init__.py", SNAPSHOT_GOLDEN / "db" / "__init__.py"),
+        (NEXO_CODE / "evolution_cycle.py", SNAPSHOT_GOLDEN / "evolution_cycle.py"),
+    ]
+    refreshed: list[str] = []
+    for live, snap in pairs:
+        if not live.exists():
+            continue
+        if snap.exists() and _sha256(live) == _sha256(snap):
+            continue
+        snap.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(live, snap)
+        refreshed.append(live.name)
+    return {"ok": bool(refreshed), "refreshed": refreshed}
+
+
+def _disable_broken_personal_plugins_inline(conn: sqlite3.Connection | None) -> dict:
+    plugins_dir = NEXO_HOME / "plugins"
+    if not plugins_dir.exists():
+        return {"disabled": [], "registry_pruned": 0}
+
+    disabled: list[str] = []
+    registry_pruned = 0
+    personal_filenames: set[str] = set()
+    if conn is not None and _table_exists(conn, "plugins"):
+        try:
+            rows = conn.execute(
+                "SELECT filename, created_by FROM plugins WHERE created_by = 'personal'"
+            ).fetchall()
+            personal_filenames = {str(row["filename"] or "").strip() for row in rows if str(row["filename"] or "").strip()}
+        except Exception:
+            personal_filenames = set()
+
+    for plugin_file in sorted(plugins_dir.glob("*.py")):
+        try:
+            py_compile.compile(str(plugin_file), doraise=True)
+        except Exception:
+            disabled_path = plugin_file.with_name(plugin_file.name + ".disabled")
+            plugin_file.rename(disabled_path)
+            disabled.append(plugin_file.name)
+            if conn is not None and _table_exists(conn, "plugins"):
+                conn.execute("DELETE FROM plugins WHERE filename = ?", (plugin_file.name,))
+                registry_pruned += 1
+
+    if conn is not None and _table_exists(conn, "plugins"):
+        for filename in sorted(personal_filenames):
+            if not filename:
+                continue
+            if not (plugins_dir / filename).exists():
+                conn.execute("DELETE FROM plugins WHERE filename = ?", (filename,))
+                registry_pruned += 1
+    return {"disabled": disabled, "registry_pruned": registry_pruned}
+
+
+def run_mechanical_autofixes():
+    conn = None
+    try:
+        if NEXO_DB.exists():
+            conn = sqlite3.connect(str(NEXO_DB))
+            conn.row_factory = sqlite3.Row
+
+        bootstrap_actions = _sync_managed_bootstraps_inline()
+        if bootstrap_actions:
+            finding("INFO", "autofix", f"Managed bootstraps refreshed inline: {', '.join(bootstrap_actions)}")
+
+        registry_result = _sanitize_watchdog_registry_inline()
+        if registry_result.get("ok"):
+            _clear_findings("watchdog", "mutable files still protected")
+            finding(
+                "INFO",
+                "watchdog",
+                "Self-audit sanitized watchdog registry inline: "
+                + ", ".join(registry_result.get("removed") or []),
+            )
+
+        snapshot_result = _refresh_golden_snapshots_inline()
+        if snapshot_result.get("ok"):
+            _clear_findings("snapshots", "golden snapshot drift")
+            finding(
+                "INFO",
+                "snapshots",
+                "Self-audit refreshed golden snapshots inline: "
+                + ", ".join(snapshot_result.get("refreshed") or []),
+            )
+
+        plugin_result = _disable_broken_personal_plugins_inline(conn)
+        disabled = plugin_result.get("disabled") or []
+        pruned = int(plugin_result.get("registry_pruned") or 0)
+        if disabled or pruned:
+            details: list[str] = []
+            if disabled:
+                details.append(f"disabled {len(disabled)} personal plugin(s): {', '.join(disabled)}")
+            if pruned:
+                details.append(f"pruned {pruned} stale plugin registry entrie(s)")
+            finding("INFO", "autofix", "Self-audit plugin autofix: " + " | ".join(details))
+
+        if conn is not None:
+            conn.commit()
+    finally:
+        if conn is not None:
+            conn.close()
+
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # Stage B: Interpretation (automation backend) — NEW in v2
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -1306,7 +1909,17 @@ def interpret_findings(raw_findings: list) -> bool:
 
 You are NEXO's morning self-audit interpreter. The mechanical checks found
 {len(errors)} errors and {len(warns)} warnings. Your job is to UNDERSTAND what's
-actually wrong, not just list findings. Use nexo_learning_add for new findings and nexo_followup_create for action items.
+actually wrong, not just list findings.
+
+CRITICAL — SEARCH BEFORE CREATING LEARNINGS:
+Before calling nexo_learning_add, you MUST call nexo_learning_search with keywords
+from the finding's area and topic. If a matching active learning already exists:
+  - Call nexo_learning_update(id=<existing_id>, ...) to refresh it with the new
+    evidence/date instead of creating a duplicate.
+  - Only use nexo_learning_add (with supersedes_id=<old_id>) when the existing
+    learning is materially wrong or outdated, not just to add another observation.
+If no existing learning matches, then nexo_learning_add is appropriate.
+The same applies to nexo_followup_create — search existing followups first.
 
 RAW FINDINGS:
 {findings_json}
@@ -1400,6 +2013,7 @@ def main():
     run_watchdog_smoke()
     check_watchdog_smoke()
     check_cognitive_health()
+    run_mechanical_autofixes()
 
     errors = sum(1 for f in findings if f["severity"] == "ERROR")
     warns = sum(1 for f in findings if f["severity"] == "WARN")

--- a/src/scripts/nexo-evolution-run.py
+++ b/src/scripts/nexo-evolution-run.py
@@ -187,6 +187,10 @@ from public_contribution import (
     mark_public_contribution_result,
     STATUS_PAUSED_OPEN_PR,
 )
+from public_evolution_queue import (
+    list_pending_public_port_candidates,
+    update_public_port_candidate,
+)
 
 
 # ── Consecutive failure tracking ─────────────────────────────────────────
@@ -807,10 +811,19 @@ def run_public_contribution_cycle(*, objective: dict, cycle_num: int) -> None:
     branch_name = ""
     summary: dict = {}
     conn = sqlite3.connect(str(NEXO_DB), timeout=10)
+    conn.row_factory = sqlite3.Row
+    queued_candidate: dict | None = None
     try:
+        pending_candidates = list_pending_public_port_candidates(conn, limit=1)
+        if pending_candidates:
+            queued_candidate = pending_candidates[0]
         worktree_dir, branch_name = _prepare_public_worktree(config, title_hint="public-core")
         _prime_public_git_identity(worktree_dir, config)
-        prompt = build_public_contribution_prompt(repo_root=str(worktree_dir), cycle_number=cycle_num)
+        prompt = build_public_contribution_prompt(
+            repo_root=str(worktree_dir),
+            cycle_number=cycle_num,
+            queued_candidate=queued_candidate,
+        )
         raw_response = call_public_claude_cli(prompt, cwd=worktree_dir)
         summary = _parse_summary_json(raw_response)
         changed_files = _changed_public_files(worktree_dir)
@@ -849,6 +862,14 @@ def run_public_contribution_cycle(*, objective: dict, cycle_num: int) -> None:
                 ),
             )
             conn.commit()
+            if queued_candidate:
+                update_public_port_candidate(
+                    conn,
+                    queued_candidate["id"],
+                    status="skipped_duplicate_existing_pr",
+                    metadata_patch={"duplicate_of": duplicate},
+                )
+                conn.commit()
             mark_public_contribution_result(
                 result=f"skipped:duplicate_pr:{duplicate.get('number')}",
                 config=config,
@@ -888,6 +909,19 @@ def run_public_contribution_cycle(*, objective: dict, cycle_num: int) -> None:
             ),
         )
         conn.commit()
+        if queued_candidate:
+            update_public_port_candidate(
+                conn,
+                queued_candidate["id"],
+                status="draft_pr_created",
+                metadata_patch={
+                    "pr_url": pr_url,
+                    "pr_number": pr_number,
+                    "branch": branch_name,
+                    "ported_via_cycle": cycle_num,
+                },
+            )
+            conn.commit()
 
         objective["last_evolution"] = str(date.today())
         objective["total_evolutions"] = cycle_num

--- a/src/server.py
+++ b/src/server.py
@@ -213,6 +213,31 @@ mcp = FastMCP(
 )
 
 
+def _run_kwargs_from_env() -> dict:
+    transport = str(os.environ.get("NEXO_MCP_TRANSPORT", "stdio") or "stdio").strip().lower()
+    if transport in {"http", "streamable_http"}:
+        transport = "streamable-http"
+    if transport == "stdio":
+        return {"transport": "stdio"}
+
+    host = str(os.environ.get("NEXO_MCP_HOST", "127.0.0.1") or "127.0.0.1").strip()
+    port_text = str(os.environ.get("NEXO_MCP_PORT", "8000") or "8000").strip()
+    path = str(os.environ.get("NEXO_MCP_PATH", "/mcp") or "/mcp").strip() or "/mcp"
+    try:
+        port = int(port_text)
+    except Exception:
+        port = 8000
+
+    kwargs = {
+        "transport": transport,
+        "host": host,
+        "port": port,
+    }
+    if transport == "streamable-http":
+        kwargs["path"] = path
+    return kwargs
+
+
 # ── Session management (3 tools) ──────────────────────────────────
 
 @mcp.tool
@@ -912,4 +937,4 @@ def nexo_plugin_remove(filename: str) -> str:
 
 if __name__ == "__main__":
     _server_init()
-    mcp.run(transport="stdio")
+    mcp.run(**_run_kwargs_from_env())

--- a/tests/test_client_sync.py
+++ b/tests/test_client_sync.py
@@ -21,6 +21,7 @@ def _make_runtime(root: Path, *, operator_name: str = "Atlas") -> Path:
         "daily-briefing-check.sh",
         "session-start.sh",
         "session-stop.sh",
+        "protocol-pretool-guardrail.sh",
         "capture-tool-logs.sh",
         "capture-session.sh",
         "inbox-hook.sh",
@@ -65,6 +66,7 @@ def test_sync_claude_code_preserves_existing_settings(tmp_path):
         for hook in section.get("hooks", [])
     ]
     assert any("session-start.sh" in command for command in all_hook_commands)
+    assert any("protocol-pretool-guardrail.sh" in command for command in all_hook_commands)
     assert any("capture-tool-logs.sh" in command for command in all_hook_commands)
     assert any("protocol-guardrail.sh" in command for command in all_hook_commands)
     assert any(".session-start-ts" in command for command in all_hook_commands)

--- a/tests/test_evolution.py
+++ b/tests/test_evolution.py
@@ -382,6 +382,104 @@ class TestPublicContributionExecution:
         assert captured["config"]["status"] == "paused_open_pr"
         assert captured["objective"]["history"][0]["pr_url"] == "https://github.com/wazionapps/nexo/pull/88"
 
+    def test_public_contribution_prioritizes_pending_public_port_queue_item(self, evolution_env, monkeypatch):
+        _, runner = _load_runner_module(monkeypatch, evolution_env)
+        worktree_dir = evolution_env / "public-worktree-queued"
+        worktree_dir.mkdir(parents=True, exist_ok=True)
+        artifact_dir = evolution_env / "operations" / "public-contrib" / "queued-artifact"
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        objective = {
+            "history": [],
+            "total_evolutions": 0,
+            "total_proposals_made": 0,
+        }
+        config = {
+            "enabled": True,
+            "mode": "draft_prs",
+            "status": "active",
+            "github_user": "alice",
+            "fork_repo": "alice/nexo",
+            "upstream_repo": "wazionapps/nexo",
+            "machine_id": "machine-1",
+        }
+        prompts = []
+
+        conn = sqlite3.connect(str(evolution_env / "data" / "nexo.db"))
+        conn.execute(
+            """INSERT INTO evolution_log (
+                   cycle_number, dimension, proposal, classification, reasoning, status, files_changed, test_result
+               ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                0,
+                "public_core",
+                "Port self-audit managed guardrail fix",
+                "public_port_queue",
+                "Self-audit already fixed a managed guardrail gap locally; port it to public core.",
+                "pending_public_port",
+                json.dumps(["src/plugins/protocol.py", "tests/test_protocol.py"]),
+                json.dumps({"source": "self-audit"}),
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+        class Result:
+            def __init__(self, returncode=0, stdout="", stderr=""):
+                self.returncode = returncode
+                self.stdout = stdout
+                self.stderr = stderr
+
+        runner.load_public_contribution_config = lambda: dict(config)
+        runner.can_run_public_contribution = lambda cfg: (True, "", dict(config))
+        runner.verify_claude_cli = lambda: True
+        runner._prepare_public_worktree = lambda cfg, title_hint="public-core": (worktree_dir, "contrib/machine-1/public-port")
+        runner._prime_public_git_identity = lambda worktree, cfg: None
+        runner.call_public_claude_cli = lambda prompt, cwd: prompts.append(prompt) or json.dumps({
+            "title": "fix: port managed guardrail tightening",
+            "problem": "Managed self-audit already found and fixed the gap locally.",
+            "summary": "Port the same guardrail tightening to the public core.",
+            "tests": ["python3 -m py_compile src/plugins/protocol.py tests/test_protocol.py"],
+            "risks": ["low"],
+        })
+        runner._changed_public_files = lambda worktree: ["src/plugins/protocol.py", "tests/test_protocol.py"]
+        runner._sanitize_public_diff = lambda worktree, changed_files: (True, "")
+        runner._run_public_validation = lambda worktree, changed_files: ["python3 -m py_compile src/plugins/protocol.py tests/test_protocol.py"]
+        runner._public_pr_duplicate_candidate = lambda cfg, title, changed_files: None
+        runner._git = lambda cwd, *args, **kwargs: Result()
+        runner._create_draft_pr = lambda worktree, cfg, branch_name, summary: ("https://github.com/wazionapps/nexo/pull/91", 91)
+        runner._write_public_artifacts = lambda worktree, branch_name, summary: artifact_dir
+        runner.mark_active_pr = lambda **kwargs: {
+            **config,
+            "active_pr_url": kwargs["pr_url"],
+            "active_pr_number": kwargs["pr_number"],
+            "active_branch": kwargs["branch"],
+            "status": "paused_open_pr",
+        }
+        runner.mark_public_contribution_result = lambda **kwargs: None
+        runner.save_objective = lambda obj: None
+        runner._remove_public_worktree = lambda worktree: None
+
+        runner.run_public_contribution_cycle(objective=objective, cycle_num=4)
+
+        assert prompts
+        assert "PRIORITY PUBLIC-PORT QUEUE ITEM" in prompts[0]
+        assert "Port self-audit managed guardrail fix" in prompts[0]
+
+        conn = sqlite3.connect(str(evolution_env / "data" / "nexo.db"))
+        row = conn.execute(
+            """SELECT status, test_result
+               FROM evolution_log
+               WHERE classification = 'public_port_queue'
+               ORDER BY id DESC
+               LIMIT 1"""
+        ).fetchone()
+        conn.close()
+
+        assert row[0] == "draft_pr_created"
+        payload = json.loads(row[1])
+        assert payload["pr_url"] == "https://github.com/wazionapps/nexo/pull/91"
+        assert payload["ported_via_cycle"] == 4
+
     def test_list_reviewable_public_prs_filters_out_own_reviewed_or_unsafe_candidates(self, evolution_env, monkeypatch):
         _, runner = _load_runner_module(monkeypatch, evolution_env)
         config = {

--- a/tests/test_hook_guardrails.py
+++ b/tests/test_hook_guardrails.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import json
 import os
 import sys
 from pathlib import Path
@@ -40,6 +41,7 @@ def _reload_guardrail_stack():
 def guardrail_env(tmp_path, monkeypatch):
     home = tmp_path / "nexo"
     (home / "data").mkdir(parents=True, exist_ok=True)
+    (home / "brain").mkdir(parents=True, exist_ok=True)
     monkeypatch.setenv("NEXO_HOME", str(home))
     monkeypatch.setenv("NEXO_CODE", str(REPO_SRC))
     return home
@@ -160,3 +162,76 @@ def test_process_tool_event_records_debt_when_writing_before_guard_ack(guardrail
     ).fetchone()
     assert debt["task_id"] == task["task_id"]
     assert debt["severity"] == "error"
+
+
+def test_process_pre_tool_event_blocks_write_without_open_task_in_strict_mode(guardrail_env):
+    db, hook_guardrails = _reload_guardrail_stack()
+    db.init_db()
+    (guardrail_env / "brain" / "calibration.json").write_text(
+        json.dumps({"preferences": {"protocol_strictness": "strict"}})
+    )
+    db.register_session(
+        "nexo-2004-3004",
+        "strict edit",
+        external_session_id="claude-strict-1",
+        session_client="claude_code",
+    )
+
+    result = hook_guardrails.process_pre_tool_event(
+        {
+            "session_id": "claude-strict-1",
+            "tool_name": "Edit",
+            "tool_input": {"file_path": "/repo/src/plugins/protocol.py"},
+        }
+    )
+
+    assert result["status"] == "blocked"
+    assert result["strictness"] == "strict"
+    assert result["blocks"][0]["debt_type"] == "strict_protocol_write_without_task"
+    message = hook_guardrails.format_pretool_block_message(result)
+    assert "open `nexo_task_open" in message
+
+
+def test_process_pre_tool_event_learning_mode_explains_guard_ack_requirement(guardrail_env):
+    db, hook_guardrails = _reload_guardrail_stack()
+    db.init_db()
+    (guardrail_env / "brain" / "calibration.json").write_text(
+        json.dumps({"preferences": {"protocol_strictness": "learning"}})
+    )
+    sid = "nexo-2005-3005"
+    db.register_session(
+        sid,
+        "learning mode edit",
+        external_session_id="claude-learning-1",
+        session_client="claude_code",
+    )
+    task = db.create_protocol_task(
+        sid,
+        "Patch guard file",
+        task_type="edit",
+        files=["/repo/src/plugins/guard.py"],
+        opened_with_guard=True,
+        guard_has_blocking=True,
+        guard_summary="BLOCKING RULES",
+    )
+    db.create_protocol_debt(
+        sid,
+        "unacknowledged_guard_blocking",
+        severity="error",
+        task_id=task["task_id"],
+        evidence="Guard rule still unacknowledged for /repo/src/plugins/guard.py",
+    )
+
+    result = hook_guardrails.process_pre_tool_event(
+        {
+            "session_id": "claude-learning-1",
+            "tool_name": "Edit",
+            "tool_input": {"file_path": "/repo/src/plugins/guard.py"},
+        }
+    )
+
+    assert result["status"] == "blocked"
+    assert result["strictness"] == "learning"
+    assert result["blocks"][0]["debt_type"] == "strict_protocol_write_without_guard_ack"
+    message = hook_guardrails.format_pretool_block_message(result)
+    assert "nexo_task_acknowledge_guard" in message

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -136,6 +136,25 @@ def test_task_open_with_blocking_guard_creates_guard_debt(monkeypatch):
     assert debt["status"] == "open"
 
 
+def test_task_open_requires_files_for_edit_in_strict_mode(monkeypatch):
+    import plugins.protocol as protocol
+
+    sid = _register_session("nexo-1004-2005")
+    monkeypatch.setattr(protocol, "get_protocol_strictness", lambda: "strict")
+    payload = json.loads(
+        protocol.handle_task_open(
+            sid=sid,
+            goal="Edit without explicit files",
+            task_type="edit",
+            area="nexo-ops",
+        )
+    )
+
+    assert payload["ok"] is False
+    assert payload["protocol_strictness"] == "strict"
+    assert "requires explicit `files`" in payload["error"]
+
+
 def test_task_acknowledge_guard_resolves_guard_debt(monkeypatch):
     from db import get_db
     from plugins.protocol import handle_task_open, handle_task_acknowledge_guard

--- a/tests/test_self_audit.py
+++ b/tests/test_self_audit.py
@@ -308,6 +308,7 @@ def test_main_returns_zero_and_writes_summary_when_findings_exist(self_audit_env
         "run_watchdog_smoke",
         "check_watchdog_smoke",
         "check_cognitive_health",
+        "run_mechanical_autofixes",
     ]
     for name in no_op_checks:
         monkeypatch.setattr(module, name, lambda: None)
@@ -331,7 +332,7 @@ def test_main_returns_zero_and_writes_summary_when_findings_exist(self_audit_env
     assert "Self-audit completed with findings: 1 errors, 0 warnings, 0 info." in log_body
 
 
-def test_check_learning_contradictions_creates_followup(self_audit_env):
+def test_check_learning_contradictions_supersedes_older_rule_inline(self_audit_env):
     module = _load_self_audit_module()
     module.findings.clear()
 
@@ -343,30 +344,34 @@ def test_check_learning_contradictions_creates_followup(self_audit_env):
             content TEXT,
             applies_to TEXT,
             status TEXT,
-            updated_at REAL
+            updated_at REAL,
+            reasoning TEXT,
+            supersedes_id INTEGER
         )"""
     )
     conn.execute(
-        """CREATE TABLE followups (
-            id TEXT PRIMARY KEY,
-            date TEXT,
-            description TEXT,
-            verification TEXT,
-            status TEXT,
-            reasoning TEXT,
-            recurrence TEXT,
-            created_at REAL,
-            updated_at REAL,
-            priority TEXT
+        """CREATE TABLE evolution_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            created_at TEXT DEFAULT (datetime('now')),
+            cycle_number INTEGER NOT NULL,
+            dimension TEXT NOT NULL,
+            proposal TEXT NOT NULL,
+            classification TEXT NOT NULL DEFAULT 'auto',
+            status TEXT DEFAULT 'pending',
+            files_changed TEXT,
+            snapshot_ref TEXT,
+            test_result TEXT,
+            impact INTEGER DEFAULT 0,
+            reasoning TEXT NOT NULL
         )"""
     )
     now_ts = datetime(2026, 4, 6, 8, 0, 0).timestamp()
     conn.execute(
-        "INSERT INTO learnings (id, title, content, applies_to, status, updated_at) VALUES (1, ?, ?, ?, 'active', ?)",
+        "INSERT INTO learnings (id, title, content, applies_to, status, updated_at, reasoning) VALUES (1, ?, ?, ?, 'active', ?, '')",
         ("Never edit protocol.py directly", "Never edit protocol.py directly in hotfixes.", "/repo/src/plugins/protocol.py", now_ts),
     )
     conn.execute(
-        "INSERT INTO learnings (id, title, content, applies_to, status, updated_at) VALUES (2, ?, ?, ?, 'active', ?)",
+        "INSERT INTO learnings (id, title, content, applies_to, status, updated_at, reasoning) VALUES (2, ?, ?, ?, 'active', ?, '')",
         ("Edit protocol.py directly for hotfixes", "Edit protocol.py directly for urgent hotfixes.", "/repo/src/plugins/protocol.py", now_ts),
     )
     conn.commit()
@@ -376,18 +381,23 @@ def test_check_learning_contradictions_creates_followup(self_audit_env):
 
     assert module.findings
     assert module.findings[-1]["area"] == "contradictions"
-    assert module.findings[-1]["severity"] == "ERROR"
+    assert module.findings[-1]["severity"] == "INFO"
 
     conn = sqlite3.connect(str(self_audit_env / "data" / "nexo.db"))
-    followup = conn.execute("SELECT description, priority FROM followups").fetchone()
+    statuses = dict(conn.execute("SELECT id, status FROM learnings").fetchall())
+    queued = conn.execute(
+        "SELECT classification, status, files_changed FROM evolution_log ORDER BY id DESC LIMIT 1"
+    ).fetchone()
     conn.close()
-    assert "Resolve contradictory active learnings" in followup[0]
-    assert "#1" in followup[0]
-    assert "#2" in followup[0]
-    assert followup[1] == "critical"
+    assert statuses[1] == "superseded"
+    assert statuses[2] == "active"
+    assert queued[0] == "public_port_queue"
+    assert queued[1] == "pending_public_port"
+    assert "/repo/src/plugins/protocol.py" not in queued[2]
+    assert "src/plugins/protocol.py" in queued[2]
 
 
-def test_check_error_memory_loop_creates_prevention_followup(self_audit_env):
+def test_check_error_memory_loop_creates_prevention_learning_inline(self_audit_env):
     module = _load_self_audit_module()
     module.findings.clear()
 
@@ -404,17 +414,35 @@ def test_check_error_memory_loop_creates_prevention_followup(self_audit_env):
         )"""
     )
     conn.execute(
-        """CREATE TABLE followups (
-            id TEXT PRIMARY KEY,
-            date TEXT,
-            description TEXT,
-            verification TEXT,
-            status TEXT,
+        """CREATE TABLE learnings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            category TEXT,
+            title TEXT,
+            content TEXT,
             reasoning TEXT,
-            recurrence TEXT,
+            prevention TEXT,
+            applies_to TEXT,
+            status TEXT,
             created_at REAL,
             updated_at REAL,
-            priority TEXT
+            priority TEXT,
+            weight REAL
+        )"""
+    )
+    conn.execute(
+        """CREATE TABLE evolution_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            created_at TEXT DEFAULT (datetime('now')),
+            cycle_number INTEGER NOT NULL,
+            dimension TEXT NOT NULL,
+            proposal TEXT NOT NULL,
+            classification TEXT NOT NULL DEFAULT 'auto',
+            status TEXT DEFAULT 'pending',
+            files_changed TEXT,
+            snapshot_ref TEXT,
+            test_result TEXT,
+            impact INTEGER DEFAULT 0,
+            reasoning TEXT NOT NULL
         )"""
     )
     conn.execute(
@@ -432,13 +460,23 @@ def test_check_error_memory_loop_creates_prevention_followup(self_audit_env):
 
     assert module.findings
     assert module.findings[-1]["area"] == "prevention"
-    assert module.findings[-1]["severity"] == "WARN"
+    assert module.findings[-1]["severity"] == "INFO"
 
     conn = sqlite3.connect(str(self_audit_env / "data" / "nexo.db"))
-    followup = conn.execute("SELECT description, priority FROM followups").fetchone()
+    learning = conn.execute(
+        "SELECT category, title, applies_to, priority FROM learnings ORDER BY id DESC LIMIT 1"
+    ).fetchone()
+    queued = conn.execute(
+        "SELECT classification, status, files_changed FROM evolution_log ORDER BY id DESC LIMIT 1"
+    ).fetchone()
     conn.close()
-    assert "repeated failed/blocked protocol tasks around /repo/src/plugins/workflow.py" in followup[0]
-    assert followup[1] == "high"
+    assert learning[0] == "nexo"
+    assert "repeated failures around /repo/src/plugins/workflow.py" in learning[1]
+    assert learning[2] == "/repo/src/plugins/workflow.py"
+    assert learning[3] == "high"
+    assert queued[0] == "public_port_queue"
+    assert queued[1] == "pending_public_port"
+    assert "src/plugins/workflow.py" in queued[2]
 
 
 def test_check_repair_changes_missing_learning_capture_creates_debt_and_followup(self_audit_env):
@@ -572,7 +610,7 @@ def test_check_repair_changes_missing_learning_capture_auto_captures_when_runtim
     assert debt == 0
 
 
-def test_check_unformalized_mentions_creates_formalization_followup(self_audit_env):
+def test_check_unformalized_mentions_creates_workflow_goal_inline(self_audit_env):
     module = _load_self_audit_module()
     module.findings.clear()
 
@@ -588,17 +626,21 @@ def test_check_unformalized_mentions_creates_formalization_followup(self_audit_e
         )"""
     )
     conn.execute(
-        """CREATE TABLE followups (
-            id TEXT PRIMARY KEY,
-            date TEXT,
-            description TEXT,
-            verification TEXT,
+        """CREATE TABLE workflow_goals (
+            goal_id TEXT PRIMARY KEY,
+            session_id TEXT,
+            title TEXT,
+            objective TEXT,
+            parent_goal_id TEXT,
             status TEXT,
-            reasoning TEXT,
-            recurrence TEXT,
-            created_at REAL,
-            updated_at REAL,
-            priority TEXT
+            priority TEXT,
+            owner TEXT,
+            next_action TEXT,
+            success_signal TEXT,
+            shared_state TEXT,
+            opened_at TEXT,
+            updated_at TEXT,
+            closed_at TEXT
         )"""
     )
     conn.execute(
@@ -616,14 +658,14 @@ def test_check_unformalized_mentions_creates_formalization_followup(self_audit_e
 
     assert module.findings
     assert module.findings[-1]["area"] == "formalization"
-    assert module.findings[-1]["severity"] == "WARN"
+    assert module.findings[-1]["severity"] == "INFO"
 
     conn = sqlite3.connect(str(self_audit_env / "data" / "nexo.db"))
-    followup = conn.execute("SELECT description, priority FROM followups").fetchone()
+    goal = conn.execute("SELECT title, priority, objective FROM workflow_goals").fetchone()
     conn.close()
-    assert "Formalize repeated unresolved theme in nexo" in followup[0]
-    assert "Prepare release readiness" in followup[0]
-    assert followup[1] == "high"
+    assert "Prepare release readiness" in goal[0]
+    assert goal[1] == "high"
+    assert "Recurring nexo theme detected by daily self-audit" in goal[2]
 
 
 def test_check_automation_opportunities_creates_opportunity_followup(self_audit_env):
@@ -771,3 +813,71 @@ def test_check_memory_quality_scores_creates_followup(self_audit_env):
     followup = conn.execute("SELECT description FROM followups").fetchone()
     conn.close()
     assert "Refresh low-quality conditioned learnings" in followup[0]
+
+
+def test_run_mechanical_autofixes_sanitizes_registry_and_refreshes_snapshots(self_audit_env, monkeypatch):
+    module = _load_self_audit_module()
+    module.findings[:] = [
+        {"severity": "ERROR", "area": "watchdog", "msg": "mutable files still protected: CLAUDE.md, AGENTS.md"},
+        {"severity": "WARN", "area": "snapshots", "msg": "golden snapshot drift: __init__.py, evolution_cycle.py"},
+    ]
+
+    scripts_dir = self_audit_env / "scripts"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    (scripts_dir / ".watchdog-hashes").write_text(
+        "aaa /tmp/CLAUDE.md\nbbb /tmp/keep.py\nccc /tmp/server.py\n",
+    )
+
+    monkeypatch.setattr(module, "_sync_managed_bootstraps_inline", lambda: [])
+    monkeypatch.setattr(module, "_disable_broken_personal_plugins_inline", lambda conn: {"disabled": [], "registry_pruned": 0})
+
+    module.run_mechanical_autofixes()
+
+    registry_text = (scripts_dir / ".watchdog-hashes").read_text()
+    assert "CLAUDE.md" not in registry_text
+    assert "server.py" not in registry_text
+    assert "keep.py" in registry_text
+    assert any(item["area"] == "watchdog" and item["severity"] == "INFO" for item in module.findings)
+    assert any(item["area"] == "snapshots" and item["severity"] == "INFO" for item in module.findings)
+    assert not any(item["area"] == "watchdog" and "mutable files still protected" in item["msg"] for item in module.findings)
+    assert not any(item["area"] == "snapshots" and "golden snapshot drift" in item["msg"] for item in module.findings)
+    assert (self_audit_env / "snapshots" / "golden" / "files" / "claude" / "evolution_cycle.py").is_file()
+
+
+def test_run_mechanical_autofixes_disables_broken_personal_plugins(self_audit_env, monkeypatch):
+    module = _load_self_audit_module()
+    module.findings.clear()
+
+    conn = sqlite3.connect(str(self_audit_env / "data" / "nexo.db"))
+    conn.execute(
+        """CREATE TABLE plugins (
+            filename TEXT PRIMARY KEY,
+            tools_count INTEGER DEFAULT 0,
+            tool_names TEXT DEFAULT '',
+            loaded_at REAL,
+            created_by TEXT DEFAULT 'manual'
+        )"""
+    )
+    conn.execute(
+        "INSERT INTO plugins (filename, created_by) VALUES ('broken_plugin.py', 'personal')"
+    )
+    conn.commit()
+    conn.close()
+
+    plugins_dir = self_audit_env / "plugins"
+    plugins_dir.mkdir(parents=True, exist_ok=True)
+    (plugins_dir / "broken_plugin.py").write_text("def broken(:\n    pass\n")
+
+    monkeypatch.setattr(module, "_sync_managed_bootstraps_inline", lambda: [])
+    monkeypatch.setattr(module, "_sanitize_watchdog_registry_inline", lambda: {"ok": False, "removed": []})
+    monkeypatch.setattr(module, "_refresh_golden_snapshots_inline", lambda: {"ok": False, "refreshed": []})
+
+    module.run_mechanical_autofixes()
+
+    assert not (plugins_dir / "broken_plugin.py").exists()
+    assert (plugins_dir / "broken_plugin.py.disabled").exists()
+    conn = sqlite3.connect(str(self_audit_env / "data" / "nexo.db"))
+    remaining = conn.execute("SELECT COUNT(*) FROM plugins WHERE filename = 'broken_plugin.py'").fetchone()[0]
+    conn.close()
+    assert remaining == 0
+    assert any("plugin autofix" in item["msg"] for item in module.findings if item["area"] == "autofix")


### PR DESCRIPTION
## Summary
- make self-audit resolve contradictions, formalizations, and prevention gaps inline instead of spawning orphan internal followups
- add mechanical post-audit autofixes and a durable public-port queue so private core fixes can still feed the public Evolution cycle
- add opt-in protocol strictness, Gemini/Cursor/Windsurf/Docker onboarding docs, workflow quickstart examples, and a reproducible memory benchmark package
- bump release artifacts and `gh-pages` to `v3.1.0`

## Why
Closes #14
Closes #15
Closes #16
Closes #24
Closes #25
Closes #26
Closes #44
Closes #47

## Verification
- `pytest -q tests/test_self_audit.py tests/test_evolution.py tests/test_hook_guardrails.py tests/test_protocol.py tests/test_client_sync.py`
- `python3 scripts/verify_release_readiness.py --ci --website-root /Users/franciscoc/Documents/_PhpstormProjects/nexo-gh-pages`
- `bash /Users/franciscoc/claude/scripts/nexo-release-validate.sh`
- `docker compose up -d --build nexo`
- `docker inspect -f '{{.State.Health.Status}}' nexo`
- `docker compose down`
