### PR TITLE
fix: restore updates with duplicate personal script names

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.1.1] - 2026-04-08
+
+### Update Reliability Hotfix
+- Fixed personal script registry ID generation so `nexo update` and runtime reconciliation no longer fail when two distinct personal scripts share the same logical `name` but live at different paths, such as paired `.py` and `.sh` variants of the same workflow.
+- This specifically restores safe runtime updates on installations that keep both shell and Python implementations for the same personal automation.
+
 ## [3.1.0] - 2026-04-08
 
 ### Self-Audit Goes Corrective

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 3.1.0
+version: 3.1.1
 metadata:
   openclaw:
     requires:

--- a/docs/workflows-quickstart.md
+++ b/docs/workflows-quickstart.md
@@ -19,7 +19,7 @@ Open the workflow:
 ```bash
 nexo call nexo_workflow_open --input '{
   "sid":"YOUR_SESSION_ID",
-  "goal":"Prepare and publish v3.1.0",
+  "goal":"Prepare and publish v3.1.1",
   "owner":"codex",
   "priority":"high",
   "workflow_kind":"release",

--- a/openclaw-plugin/package-lock.json
+++ b/openclaw-plugin/package-lock.json
@@ -1,0 +1,57 @@
+{
+  "name": "@wazionapps/openclaw-memory-nexo-brain",
+  "version": "3.1.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@wazionapps/openclaw-memory-nexo-brain",
+      "version": "3.1.1",
+      "license": "AGPL-3.0",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "devDependencies": {
+        "@types/node": "^25.5.0",
+        "typescript": "^5.7.0"
+      }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
+      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "3.1.0" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "3.1.1" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/src/db/_personal_scripts.py
+++ b/src/db/_personal_scripts.py
@@ -62,8 +62,8 @@ def _safe_slug(value: str) -> str:
 
 def _ensure_script_id(conn, name: str, path: str) -> str:
     existing = conn.execute(
-        "SELECT id FROM personal_scripts WHERE path = ? OR name = ? ORDER BY path = ? DESC LIMIT 1",
-        (path, name, path),
+        "SELECT id FROM personal_scripts WHERE path = ? LIMIT 1",
+        (path,),
     ).fetchone()
     if existing:
         return existing["id"]

--- a/tests/test_script_registry.py
+++ b/tests/test_script_registry.py
@@ -383,6 +383,32 @@ class TestRegistrySync:
         assert len(schedules) == 1
         assert schedules[0]["cron_id"] == "backup"
 
+    def test_sync_personal_scripts_allows_duplicate_names_with_distinct_paths(self, scripts_dir, monkeypatch):
+        init_db()
+        python_script = scripts_dir / "shopify-delivery-times.py"
+        shell_script = scripts_dir / "shopify-delivery-times.sh"
+        python_script.write_text(
+            "# nexo: name=shopify-delivery-times\n"
+            "# nexo: runtime=python\n"
+            "print('ok')\n"
+        )
+        shell_script.write_text(
+            "#!/bin/bash\n"
+            "# nexo: name=shopify-delivery-times\n"
+            "# nexo: runtime=shell\n"
+            "echo ok\n"
+        )
+
+        monkeypatch.setattr("script_registry._discover_personal_schedule_records", lambda: [])
+
+        result = sync_personal_scripts()
+
+        assert result["scripts_upserted"] == 2
+        scripts = list_personal_scripts()
+        assert len(scripts) == 2
+        assert {script["path"] for script in scripts} == {str(python_script), str(shell_script)}
+        assert len({script["id"] for script in scripts}) == 2
+
     def test_ensure_personal_schedules_dry_run(self, scripts_dir, monkeypatch):
         import script_registry
 


### PR DESCRIPTION
## Summary
- fix `personal_scripts` ID generation so runtime reconciliation uses the file path as the stable identity and no longer collides on shared logical names
- add a regression for paired `.py` / `.sh` personal scripts with the same `# nexo: name=...`
- bump release artifacts to `v3.1.1`

## Why
`v3.1.0` exposed a real runtime-update bug while updating a live installation: `nexo update` could abort with `UNIQUE constraint failed: personal_scripts.id` when two different personal scripts shared the same logical name.

## Verification
- `pytest -q tests/test_script_registry.py tests/test_startup_preflight.py tests/test_cli_scripts.py`
- `python3 scripts/verify_release_readiness.py --ci --website-root /Users/franciscoc/Documents/_PhpstormProjects/nexo-gh-pages`
- live repro fixed: `/Users/franciscoc/claude/bin/nexo update --json`
