### PR TITLE
feat: add history-aware reminders and followups

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [3.1.3] - 2026-04-08
+
+### History-Aware Reminders + Followups
+- Reminders and followups now keep an append-only operational history (`created`, `updated`, `completed`, `deleted`, `restored`, `note`, and recurring archive/spawn events) so agents can reconstruct what happened instead of overwriting state blindly.
+- Delete is now soft for both reminders and followups. Completed, deleted, and archived items remain queryable, which means NEXO can inspect old operational context instead of losing it permanently.
+- Added history-aware `get`, `note`, and `restore` MCP tools plus read-token enforcement for update/delete/restore/note flows. Agents now have to read the item history first before mutating it through the public MCP surface.
+- The dashboard now follows the same model: create/update actions log history, delete becomes soft delete, moved reminder/followup items preserve the source row as deleted, and per-item API detail endpoints expose history.
+
 ## [3.1.2] - 2026-04-08
 
 ### Evolution Load Balancing + Runtime Sync Fixes

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 3.1.2
+version: 3.1.3
 metadata:
   openclaw:
     requires:

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "3.1.2" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "3.1.3" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -745,18 +745,21 @@ async def api_reminders_list(
 ):
     """List reminders."""
     db = _db()
-    conn = db.get_db()
-    query = "SELECT * FROM reminders WHERE 1=1"
-    params = []
+    reminders = db.get_reminders("any")
     if status:
-        query += " AND status = ?"
-        params.append(status)
+        if status in {"any", "all", "history"}:
+            pass
+        elif status == "completed":
+            reminders = [r for r in reminders if str(r.get("status") or "").startswith("COMPLETED")]
+        elif status == "deleted":
+            reminders = [r for r in reminders if r.get("status") == "DELETED"]
+        else:
+            reminders = [r for r in reminders if r.get("status") == status]
+    else:
+        reminders = [r for r in reminders if r.get("status") != "DELETED"]
     if category:
-        query += " AND category = ?"
-        params.append(category)
-    query += " ORDER BY created_at DESC"
-    rows = conn.execute(query, params).fetchall()
-    reminders = [dict(r) for r in rows]
+        reminders = [r for r in reminders if r.get("category") == category]
+    reminders = sorted(reminders, key=lambda item: item.get("updated_at") or item.get("created_at") or 0, reverse=True)
     return {"count": len(reminders), "reminders": reminders}
 
 
@@ -766,59 +769,60 @@ async def api_reminders_create(body: ReminderCreate):
     db = _db()
     conn = db.get_db()
     rid = _next_reminder_id(conn)
-    now = time.time()
-    conn.execute(
-        "INSERT INTO reminders (id, description, date, status, category, created_at, updated_at) VALUES (?,?,?,?,?,?,?)",
-        (rid, body.description, body.date, "PENDING", body.category or "general", now, now),
+    result = db.create_reminder(
+        rid,
+        body.description,
+        date=body.date,
+        category=body.category or "general",
     )
-    conn.commit()
-    row = conn.execute("SELECT * FROM reminders WHERE id = ?", (rid,)).fetchone()
-    return {"success": True, "reminder": dict(row)}
+    if not result or "error" in result:
+        return JSONResponse({"error": result.get("error", "Failed to create reminder")}, status_code=400)
+    return {"success": True, "reminder": result}
+
+
+@app.get("/api/reminders/{rid}")
+async def api_reminders_get(rid: str):
+    """Get a reminder with history."""
+    db = _db()
+    row = db.get_reminder(rid, include_history=True)
+    if not row:
+        return JSONResponse({"error": f"Reminder {rid} not found"}, status_code=404)
+    return {"success": True, "reminder": row}
 
 
 @app.put("/api/reminders/{rid}")
 async def api_reminders_update(rid: str, body: ReminderUpdate):
     """Update a reminder."""
     db = _db()
-    conn = db.get_db()
-    row = conn.execute("SELECT * FROM reminders WHERE id = ?", (rid,)).fetchone()
+    row = db.get_reminder(rid)
     if not row:
         return JSONResponse({"error": f"Reminder {rid} not found"}, status_code=404)
-    fields = []
-    params = []
+    fields = {}
     if body.description is not None:
-        fields.append("description = ?")
-        params.append(body.description)
+        fields["description"] = body.description
     if body.date is not None:
-        fields.append("date = ?")
-        params.append(body.date)
+        fields["date"] = body.date
     if body.status is not None:
-        fields.append("status = ?")
-        params.append(body.status)
+        fields["status"] = body.status
     if body.category is not None:
-        fields.append("category = ?")
-        params.append(body.category)
+        fields["category"] = body.category
     if not fields:
-        return {"success": True, "reminder": dict(row)}
-    fields.append("updated_at = ?")
-    params.append(time.time())
-    params.append(rid)
-    conn.execute(f"UPDATE reminders SET {', '.join(fields)} WHERE id = ?", params)
-    conn.commit()
-    row = conn.execute("SELECT * FROM reminders WHERE id = ?", (rid,)).fetchone()
-    return {"success": True, "reminder": dict(row)}
+        return {"success": True, "reminder": row}
+    result = db.update_reminder(rid, history_actor="dashboard", **fields)
+    if not result or "error" in result:
+        return JSONResponse({"error": result.get("error", f"Reminder {rid} not found")}, status_code=400)
+    return {"success": True, "reminder": result}
 
 
 @app.delete("/api/reminders/{rid}")
 async def api_reminders_delete(rid: str):
-    """Delete a reminder."""
+    """Soft-delete a reminder."""
     db = _db()
-    conn = db.get_db()
-    row = conn.execute("SELECT * FROM reminders WHERE id = ?", (rid,)).fetchone()
+    row = db.get_reminder(rid)
     if not row:
         return JSONResponse({"error": f"Reminder {rid} not found"}, status_code=404)
-    conn.execute("DELETE FROM reminders WHERE id = ?", (rid,))
-    conn.commit()
+    db.add_reminder_note(rid, "Soft-deleted from dashboard.", actor="dashboard")
+    db.delete_reminder(rid)
     return {"success": True, "deleted_id": rid}
 
 
@@ -847,15 +851,19 @@ async def api_followups_list(
 ):
     """List followups."""
     db = _db()
-    conn = db.get_db()
-    query = "SELECT * FROM followups WHERE 1=1"
-    params = []
+    followups = db.get_followups("any")
     if status:
-        query += " AND status = ?"
-        params.append(status)
-    query += " ORDER BY created_at DESC"
-    rows = conn.execute(query, params).fetchall()
-    followups = [dict(r) for r in rows]
+        if status in {"any", "all", "history"}:
+            pass
+        elif status == "completed":
+            followups = [r for r in followups if str(r.get("status") or "").startswith("COMPLETED")]
+        elif status == "deleted":
+            followups = [r for r in followups if r.get("status") == "DELETED"]
+        else:
+            followups = [r for r in followups if r.get("status") == status]
+    else:
+        followups = [r for r in followups if r.get("status") != "DELETED"]
+    followups = sorted(followups, key=lambda item: item.get("updated_at") or item.get("created_at") or 0, reverse=True)
     return {"count": len(followups), "followups": followups}
 
 
@@ -865,62 +873,63 @@ async def api_followups_create(body: FollowupCreate):
     db = _db()
     conn = db.get_db()
     fid = _next_followup_id(conn)
-    now = time.time()
-    conn.execute(
-        "INSERT INTO followups (id, description, date, verification, status, reasoning, created_at, updated_at) VALUES (?,?,?,?,?,?,?,?)",
-        (fid, body.description, body.date, body.verification, "PENDING", body.reasoning, now, now),
+    result = db.create_followup(
+        fid,
+        body.description,
+        date=body.date,
+        verification=body.verification or "",
+        reasoning=body.reasoning or "",
     )
-    conn.commit()
-    row = conn.execute("SELECT * FROM followups WHERE id = ?", (fid,)).fetchone()
-    return {"success": True, "followup": dict(row)}
+    if not result or "error" in result:
+        return JSONResponse({"error": result.get("error", "Failed to create followup")}, status_code=400)
+    return {"success": True, "followup": result}
+
+
+@app.get("/api/followups/{fid}")
+async def api_followups_get(fid: str):
+    """Get a followup with history."""
+    db = _db()
+    row = db.get_followup(fid, include_history=True)
+    if not row:
+        return JSONResponse({"error": f"Followup {fid} not found"}, status_code=404)
+    return {"success": True, "followup": row}
 
 
 @app.put("/api/followups/{fid}")
 async def api_followups_update(fid: str, body: FollowupUpdate):
     """Update a followup."""
     db = _db()
-    conn = db.get_db()
-    row = conn.execute("SELECT * FROM followups WHERE id = ?", (fid,)).fetchone()
+    row = db.get_followup(fid)
     if not row:
         return JSONResponse({"error": f"Followup {fid} not found"}, status_code=404)
-    fields = []
-    params = []
+    fields = {}
     if body.description is not None:
-        fields.append("description = ?")
-        params.append(body.description)
+        fields["description"] = body.description
     if body.date is not None:
-        fields.append("date = ?")
-        params.append(body.date)
+        fields["date"] = body.date
     if body.status is not None:
-        fields.append("status = ?")
-        params.append(body.status)
+        fields["status"] = body.status
     if body.verification is not None:
-        fields.append("verification = ?")
-        params.append(body.verification)
+        fields["verification"] = body.verification
     if body.reasoning is not None:
-        fields.append("reasoning = ?")
-        params.append(body.reasoning)
+        fields["reasoning"] = body.reasoning
     if not fields:
-        return {"success": True, "followup": dict(row)}
-    fields.append("updated_at = ?")
-    params.append(time.time())
-    params.append(fid)
-    conn.execute(f"UPDATE followups SET {', '.join(fields)} WHERE id = ?", params)
-    conn.commit()
-    row = conn.execute("SELECT * FROM followups WHERE id = ?", (fid,)).fetchone()
-    return {"success": True, "followup": dict(row)}
+        return {"success": True, "followup": row}
+    result = db.update_followup(fid, history_actor="dashboard", **fields)
+    if not result or "error" in result:
+        return JSONResponse({"error": result.get("error", f"Followup {fid} not found")}, status_code=400)
+    return {"success": True, "followup": result}
 
 
 @app.delete("/api/followups/{fid}")
 async def api_followups_delete(fid: str):
-    """Delete a followup."""
+    """Soft-delete a followup."""
     db = _db()
-    conn = db.get_db()
-    row = conn.execute("SELECT * FROM followups WHERE id = ?", (fid,)).fetchone()
+    row = db.get_followup(fid)
     if not row:
         return JSONResponse({"error": f"Followup {fid} not found"}, status_code=404)
-    conn.execute("DELETE FROM followups WHERE id = ?", (fid,))
-    conn.commit()
+    db.add_followup_note(fid, "Soft-deleted from dashboard.", actor="dashboard")
+    db.delete_followup(fid)
     return {"success": True, "deleted_id": fid}
 
 
@@ -933,36 +942,49 @@ async def api_ops_move(body: MoveRequest):
     """Move an item between reminders and followups."""
     db = _db()
     conn = db.get_db()
-    now = time.time()
 
     if body.direction == "to_followup":
-        # Read from reminders
-        row = conn.execute("SELECT * FROM reminders WHERE id = ?", (body.id,)).fetchone()
-        if not row:
+        item = db.get_reminder(body.id)
+        if not item:
             return JSONResponse({"error": f"Reminder {body.id} not found"}, status_code=404)
-        item = dict(row)
         fid = _next_followup_id(conn)
-        conn.execute(
-            "INSERT INTO followups (id, description, date, status, created_at, updated_at) VALUES (?,?,?,?,?,?)",
-            (fid, item["description"], item.get("date"), "PENDING", now, now),
+        created = db.create_followup(
+            fid,
+            item["description"],
+            date=item.get("date"),
+            reasoning=f"Moved from reminder {body.id} via dashboard.",
         )
-        conn.execute("DELETE FROM reminders WHERE id = ?", (body.id,))
-        conn.commit()
+        if not created or "error" in created:
+            return JSONResponse({"error": created.get("error", "Failed to create followup")}, status_code=400)
+        db.add_followup_note(fid, f"Created from reminder {body.id} via dashboard move.", actor="dashboard")
+        db.add_reminder_note(body.id, f"Moved to followup {fid} via dashboard.", actor="dashboard")
+        db.delete_reminder(body.id)
         return {"success": True, "new_id": fid, "direction": "to_followup"}
 
     elif body.direction == "to_reminder":
-        # Read from followups
-        row = conn.execute("SELECT * FROM followups WHERE id = ?", (body.id,)).fetchone()
-        if not row:
+        item = db.get_followup(body.id)
+        if not item:
             return JSONResponse({"error": f"Followup {body.id} not found"}, status_code=404)
-        item = dict(row)
         rid = _next_reminder_id(conn)
-        conn.execute(
-            "INSERT INTO reminders (id, description, date, status, category, created_at, updated_at) VALUES (?,?,?,?,?,?,?)",
-            (rid, item["description"], item.get("date"), "PENDING", "general", now, now),
+        created = db.create_reminder(
+            rid,
+            item["description"],
+            date=item.get("date"),
+            category="general",
         )
-        conn.execute("DELETE FROM followups WHERE id = ?", (body.id,))
-        conn.commit()
+        if not created or "error" in created:
+            return JSONResponse({"error": created.get("error", "Failed to create reminder")}, status_code=400)
+        migration_note = f"Created from followup {body.id} via dashboard move."
+        extra = []
+        if item.get("verification"):
+            extra.append(f"Previous verification: {item['verification']}")
+        if item.get("reasoning"):
+            extra.append(f"Previous reasoning: {item['reasoning']}")
+        if extra:
+            migration_note += " " + " ".join(extra)
+        db.add_reminder_note(rid, migration_note, actor="dashboard")
+        db.add_followup_note(body.id, f"Moved to reminder {rid} via dashboard.", actor="dashboard")
+        db.delete_followup(body.id)
         return {"success": True, "new_id": rid, "direction": "to_reminder"}
 
     else:
@@ -977,7 +999,10 @@ async def api_ops_execute(fid: str):
     """Execute a followup by opening Terminal with the configured NEXO client."""
     db = _db()
     conn = db.get_db()
-    row = conn.execute("SELECT * FROM followups WHERE id = ?", (fid,)).fetchone()
+    row = conn.execute(
+        "SELECT * FROM followups WHERE id = ? AND status != 'DELETED'",
+        (fid,),
+    ).fetchone()
     if not row:
         return JSONResponse({"error": f"Followup {fid} not found"}, status_code=404)
     item = dict(row)
@@ -1092,12 +1117,12 @@ async def api_calendar(
     month_prefix = f"{year}-{month:02d}%"
 
     reminder_rows = conn.execute(
-        "SELECT *, 'reminder' as item_type FROM reminders WHERE date LIKE ? ORDER BY date ASC",
+        "SELECT *, 'reminder' as item_type FROM reminders WHERE date LIKE ? AND status != 'DELETED' ORDER BY date ASC",
         (month_prefix,),
     ).fetchall()
 
     followup_rows = conn.execute(
-        "SELECT *, 'followup' as item_type FROM followups WHERE date LIKE ? ORDER BY date ASC",
+        "SELECT *, 'followup' as item_type FROM followups WHERE date LIKE ? AND status != 'DELETED' ORDER BY date ASC",
         (month_prefix,),
     ).fetchall()
 

--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -36,10 +36,11 @@ from db._sessions import (
 # Reminders and followups
 from db._reminders import (
     create_reminder, update_reminder, complete_reminder, delete_reminder,
-    get_reminders, get_reminder,
+    restore_reminder, add_reminder_note, get_reminders, get_reminder, get_reminder_history,
     create_followup, update_followup, complete_followup, delete_followup,
-    get_followups, get_followup,
+    restore_followup, add_followup_note, get_followups, get_followup, get_followup_history,
     find_similar_followups,
+    add_item_history, get_item_history, validate_item_read_token,
 )
 
 # Learnings

--- a/src/db/_core.py
+++ b/src/db/_core.py
@@ -190,6 +190,26 @@ def init_db():
             updated_at REAL NOT NULL
         );
 
+        CREATE TABLE IF NOT EXISTS item_history (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            item_type TEXT NOT NULL,
+            item_id TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            note TEXT DEFAULT '',
+            actor TEXT DEFAULT '',
+            metadata TEXT DEFAULT '{}',
+            created_at REAL NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS item_read_tokens (
+            token TEXT PRIMARY KEY,
+            item_type TEXT NOT NULL,
+            item_id TEXT NOT NULL,
+            history_seq INTEGER DEFAULT 0,
+            issued_at REAL NOT NULL,
+            expires_at REAL NOT NULL
+        );
+
         CREATE TABLE IF NOT EXISTS learnings (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             category TEXT NOT NULL,
@@ -415,4 +435,3 @@ def _multi_word_like(query: str, columns: list[str]) -> tuple[str, list]:
         word_conditions.append(f"({col_or})")
         params.extend([pattern] * len(columns))
     return " AND ".join(word_conditions), params
-

--- a/src/db/_reminders.py
+++ b/src/db/_reminders.py
@@ -1,14 +1,182 @@
 from __future__ import annotations
-"""NEXO DB — Reminders module."""
-import sqlite3, time, datetime
-from datetime import timedelta
+"""NEXO DB — Reminders and followups with history + soft delete."""
+
+import datetime
+import json
+import secrets
+import sqlite3
+from typing import Any
+
 from db._core import get_db, now_epoch
 from db._fts import fts_upsert
 
+ACTIVE_EXCLUDED_STATUSES = {"DELETED", "archived", "blocked", "waiting"}
+READ_TOKEN_TTL_SECONDS = 30 * 60
+
+
+def _serialize_metadata(metadata: dict[str, Any] | None) -> str:
+    if not metadata:
+        return "{}"
+    try:
+        return json.dumps(metadata, ensure_ascii=True, sort_keys=True)
+    except Exception:
+        return "{}"
+
+
+def _truncate(text: str | None, limit: int = 240) -> str:
+    if not text:
+        return ""
+    text = str(text).strip()
+    return text if len(text) <= limit else text[: limit - 3] + "..."
+
+
+def _format_changes(before: sqlite3.Row | dict | None, after: sqlite3.Row | dict | None, fields: list[str]) -> str:
+    if before is None or after is None:
+        return ""
+    changes: list[str] = []
+    before_d = dict(before)
+    after_d = dict(after)
+    for field in fields:
+        old = before_d.get(field)
+        new = after_d.get(field)
+        if old == new:
+            continue
+        changes.append(f"{field}: {_truncate(old, 60) or '∅'} -> {_truncate(new, 60) or '∅'}")
+    return "; ".join(changes)
+
+
+def _item_table(item_type: str) -> str:
+    if item_type == "reminder":
+        return "reminders"
+    if item_type == "followup":
+        return "followups"
+    raise ValueError(f"Unsupported item_type: {item_type}")
+
+
+def _history_rules(item_type: str) -> list[str]:
+    label = "followup" if item_type == "followup" else "reminder"
+    return [
+        f"Read this {label} and its history before update/delete/restore via MCP.",
+        f"Delete is soft: the {label} stays in the DB with status DELETED.",
+        f"Use notes to append operational context instead of overwriting history.",
+    ]
+
+
+def _latest_history_seq(conn, item_type: str, item_id: str) -> int:
+    row = conn.execute(
+        "SELECT MAX(id) AS max_id FROM item_history WHERE item_type = ? AND item_id = ?",
+        (item_type, item_id),
+    ).fetchone()
+    return int(row["max_id"] or 0)
+
+
+def add_item_history(
+    item_type: str,
+    item_id: str,
+    event_type: str,
+    note: str = "",
+    *,
+    actor: str = "system",
+    metadata: dict[str, Any] | None = None,
+    created_at: float | None = None,
+) -> dict:
+    """Append an event to reminder/followup history."""
+    conn = get_db()
+    ts = created_at if created_at is not None else now_epoch()
+    conn.execute(
+        "INSERT INTO item_history (item_type, item_id, event_type, note, actor, metadata, created_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (item_type, item_id, event_type, note or "", actor, _serialize_metadata(metadata), ts),
+    )
+    conn.commit()
+    row = conn.execute(
+        "SELECT * FROM item_history WHERE item_type = ? AND item_id = ? ORDER BY id DESC LIMIT 1",
+        (item_type, item_id),
+    ).fetchone()
+    return dict(row)
+
+
+def get_item_history(item_type: str, item_id: str, limit: int = 20) -> list[dict]:
+    """Return latest history events for a reminder/followup."""
+    conn = get_db()
+    rows = conn.execute(
+        "SELECT * FROM item_history WHERE item_type = ? AND item_id = ? ORDER BY id DESC LIMIT ?",
+        (item_type, item_id, limit),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def _issue_item_read_token(item_type: str, item_id: str, ttl_seconds: int = READ_TOKEN_TTL_SECONDS) -> str:
+    conn = get_db()
+    now = now_epoch()
+    token = "IRT-" + secrets.token_hex(12)
+    history_seq = _latest_history_seq(conn, item_type, item_id)
+    conn.execute(
+        "INSERT INTO item_read_tokens (token, item_type, item_id, history_seq, issued_at, expires_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (token, item_type, item_id, history_seq, now, now + ttl_seconds),
+    )
+    conn.commit()
+    return token
+
+
+def validate_item_read_token(token: str, item_type: str, item_id: str) -> tuple[bool, str]:
+    """Validate that an item was read recently enough before mutation."""
+    if not token:
+        return False, "Missing read_token. Call the corresponding *_get tool first and use its READ_TOKEN."
+
+    conn = get_db()
+    row = conn.execute(
+        "SELECT * FROM item_read_tokens WHERE token = ? AND item_type = ? AND item_id = ?",
+        (token, item_type, item_id),
+    ).fetchone()
+    if not row:
+        return False, "Invalid read_token. Call the corresponding *_get tool again."
+
+    now = now_epoch()
+    if float(row["expires_at"] or 0) < now:
+        conn.execute("DELETE FROM item_read_tokens WHERE token = ?", (token,))
+        conn.commit()
+        return False, "Expired read_token. Read the item again to refresh its history context."
+
+    current_seq = _latest_history_seq(conn, item_type, item_id)
+    if current_seq != int(row["history_seq"] or 0):
+        return False, "History changed since that read. Read the item again before mutating it."
+
+    return True, ""
+
+
+def _reassign_item_identity(conn, item_type: str, old_id: str, new_id: str):
+    if old_id == new_id:
+        return
+    conn.execute(
+        "UPDATE item_history SET item_id = ? WHERE item_type = ? AND item_id = ?",
+        (new_id, item_type, old_id),
+    )
+    conn.execute(
+        "UPDATE item_read_tokens SET item_id = ? WHERE item_type = ? AND item_id = ?",
+        (new_id, item_type, old_id),
+    )
+
+
+def _active_status_where(column_name: str = "status") -> str:
+    excluded = ", ".join(f"'{value}'" for value in sorted(ACTIVE_EXCLUDED_STATUSES))
+    return (
+        f"{column_name} NOT LIKE 'COMPLETED%' "
+        f"AND {column_name} NOT IN ({excluded})"
+    )
+
+
 # ── Reminders ──────────────────────────────────────────────────────
 
-def create_reminder(id: str, description: str, date: str = None,
-                    status: str = 'PENDING', category: str = 'general') -> dict:
+
+def create_reminder(
+    id: str,
+    description: str,
+    date: str = None,
+    status: str = "PENDING",
+    category: str = "general",
+) -> dict:
     """Create a new reminder."""
     conn = get_db()
     now = now_epoch()
@@ -16,97 +184,164 @@ def create_reminder(id: str, description: str, date: str = None,
         conn.execute(
             "INSERT INTO reminders (id, date, description, status, category, created_at, updated_at) "
             "VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (id, date, description, status, category, now, now)
+            (id, date, description, status, category, now, now),
         )
         conn.commit()
     except sqlite3.IntegrityError:
         return {"error": f"Reminder {id} already exists. Use update instead."}
+
     row = conn.execute("SELECT * FROM reminders WHERE id = ?", (id,)).fetchone()
+    add_item_history(
+        "reminder",
+        id,
+        "created",
+        note=f"Reminder created. Category={category}. Date={date or '—'}.",
+        actor="db",
+    )
     return dict(row)
 
 
-def update_reminder(id: str, **kwargs) -> dict:
+def update_reminder(
+    id: str,
+    *,
+    log_history: bool = True,
+    history_event: str = "updated",
+    history_actor: str = "db",
+    history_note: str = "",
+    **kwargs,
+) -> dict:
     """Update any fields of a reminder: description, date, status, category."""
     conn = get_db()
     row = conn.execute("SELECT * FROM reminders WHERE id = ?", (id,)).fetchone()
     if not row:
-            return {"error": f"Reminder {id} not found"}
+        return {"error": f"Reminder {id} not found"}
+
     allowed = {"description", "date", "status", "category"}
     updates = {k: v for k, v in kwargs.items() if k in allowed}
     if not updates:
-            return {"error": "No valid fields to update"}
+        return {"error": "No valid fields to update"}
+
     updates["updated_at"] = now_epoch()
     set_clause = ", ".join(f"{k} = ?" for k in updates)
     values = list(updates.values()) + [id]
     conn.execute(f"UPDATE reminders SET {set_clause} WHERE id = ?", values)
     conn.commit()
-    row = conn.execute("SELECT * FROM reminders WHERE id = ?", (id,)).fetchone()
-    return dict(row)
+
+    new_row = conn.execute("SELECT * FROM reminders WHERE id = ?", (id,)).fetchone()
+    if log_history:
+        note = history_note or _format_changes(row, new_row, ["description", "date", "status", "category"])
+        add_item_history("reminder", id, history_event, note=note or "Reminder updated.", actor=history_actor)
+    return dict(new_row)
 
 
 def complete_reminder(id: str) -> dict:
-    """Mark a reminder as completed with today's date."""
-    today = datetime.date.today().isoformat()
-    return update_reminder(id, status="COMPLETED")
+    """Mark a reminder as completed."""
+    result = update_reminder(
+        id,
+        status="COMPLETED",
+        log_history=False,
+    )
+    if "error" in result:
+        return result
+    add_item_history("reminder", id, "completed", note="Reminder marked COMPLETED.", actor="db")
+    return result
 
 
 def delete_reminder(id: str) -> bool:
-    """Delete a reminder."""
-    conn = get_db()
-    result = conn.execute("DELETE FROM reminders WHERE id = ?", (id,))
-    conn.commit()
-    deleted = result.rowcount > 0
-    return deleted
+    """Soft-delete a reminder by setting status to DELETED."""
+    result = update_reminder(
+        id,
+        status="DELETED",
+        log_history=False,
+    )
+    if "error" in result:
+        return False
+    add_item_history("reminder", id, "deleted", note="Reminder soft-deleted (status=DELETED).", actor="db")
+    return True
 
 
-def get_reminders(filter_type: str = 'all') -> list[dict]:
-    """Get reminders by filter: 'all' (active), 'due' (date <= today), 'completed'."""
+def restore_reminder(id: str) -> dict:
+    """Restore a soft-deleted reminder back to PENDING."""
+    row = get_reminder(id)
+    if not row:
+        return {"error": f"Reminder {id} not found"}
+    result = update_reminder(
+        id,
+        status="PENDING",
+        log_history=False,
+    )
+    if "error" in result:
+        return result
+    previous = row.get("status") or "unknown"
+    add_item_history("reminder", id, "restored", note=f"Reminder restored from {previous} to PENDING.", actor="db")
+    return result
+
+
+def add_reminder_note(id: str, note: str, actor: str = "nexo") -> dict:
+    """Append an operational note to a reminder history."""
+    row = get_reminder(id)
+    if not row:
+        return {"error": f"Reminder {id} not found"}
+    return add_item_history("reminder", id, "note", note=note, actor=actor)
+
+
+def get_reminders(filter_type: str = "all") -> list[dict]:
+    """Get reminders by filter: active, due, completed, deleted, history."""
     conn = get_db()
     today = datetime.date.today().isoformat()
-    if filter_type == 'completed':
+    if filter_type == "completed":
         rows = conn.execute(
             "SELECT * FROM reminders WHERE status LIKE 'COMPLETED%' ORDER BY updated_at DESC"
         ).fetchall()
-    elif filter_type == 'due':
+    elif filter_type == "deleted":
         rows = conn.execute(
-            "SELECT * FROM reminders WHERE status NOT LIKE 'COMPLETED%' "
-            "AND status NOT IN ('DELETED','archived','blocked','waiting') "
+            "SELECT * FROM reminders WHERE status = 'DELETED' ORDER BY updated_at DESC"
+        ).fetchall()
+    elif filter_type in {"history", "any"}:
+        rows = conn.execute(
+            "SELECT * FROM reminders ORDER BY updated_at DESC"
+        ).fetchall()
+    elif filter_type == "due":
+        rows = conn.execute(
+            f"SELECT * FROM reminders WHERE {_active_status_where()} "
             "AND date IS NOT NULL AND date <= ? "
             "ORDER BY date ASC",
-            (today,)
+            (today,),
         ).fetchall()
-    else:  # 'all' — active only
+    else:
         rows = conn.execute(
-            "SELECT * FROM reminders WHERE status NOT LIKE 'COMPLETED%' "
-            "AND status NOT IN ('DELETED','archived','blocked','waiting') "
+            f"SELECT * FROM reminders WHERE {_active_status_where()} "
             "ORDER BY date ASC NULLS LAST"
         ).fetchall()
     return [dict(r) for r in rows]
 
 
-def get_reminder(id: str) -> dict | None:
-    """Get a single reminder by id."""
+def get_reminder(id: str, include_history: bool = False) -> dict | None:
+    """Get a single reminder by id, optionally with history and read token."""
     conn = get_db()
     row = conn.execute("SELECT * FROM reminders WHERE id = ?", (id,)).fetchone()
-    return dict(row) if row else None
+    if not row:
+        return None
+    result = dict(row)
+    if include_history:
+        result["history"] = get_item_history("reminder", id)
+        result["history_rules"] = _history_rules("reminder")
+        result["read_token"] = _issue_item_read_token("reminder", id)
+    return result
+
+
+def get_reminder_history(id: str, limit: int = 20) -> list[dict]:
+    return get_item_history("reminder", id, limit=limit)
 
 
 def find_similar_followups(description: str, threshold: float = 0.3) -> list[dict]:
-    """Find open followups similar to a description using keyword overlap.
-
-    Uses asymmetric scoring: what fraction of the SMALLER token set overlaps
-    with the larger. This handles different-length texts better than Jaccard.
-
-    Returns matches sorted by similarity score (highest first).
-    threshold: minimum overlap ratio (0.0-1.0) to consider a match.
-    """
+    """Find open followups similar to a description using keyword overlap."""
     conn = get_db()
     rows = conn.execute(
-        "SELECT * FROM followups WHERE status NOT LIKE 'COMPLETED%' "
-        "AND status NOT IN ('DELETED','archived','blocked','waiting')"
+        f"SELECT * FROM followups WHERE {_active_status_where()}"
     ).fetchall()
 
-    def tokenize(text: str) -> set:
+    def tokenize(text: str) -> set[str]:
         return {w.lower() for w in text.split() if len(w) > 3}
 
     query_tokens = tokenize(description)
@@ -132,158 +367,215 @@ def find_similar_followups(description: str, threshold: float = 0.3) -> list[dic
 
 # ── Followups ──────────────────────────────────────────────────────
 
-def create_followup(id: str, description: str, date: str = None,
-                    verification: str = '', status: str = 'PENDING',
-                    reasoning: str = '', recurrence: str = None) -> dict:
-    """Create a new followup with optional reasoning and recurrence.
 
-    Checks for similar open followups before creating. If a match is found,
-    returns a warning with the existing followup ID (still creates the new one).
-
-    recurrence format: 'weekly:monday', 'monthly:1', 'monthly:10', 'quarterly', etc.
-    When a recurring followup is completed, a new one is auto-created with the next date.
-    """
+def create_followup(
+    id: str,
+    description: str,
+    date: str = None,
+    verification: str = "",
+    status: str = "PENDING",
+    reasoning: str = "",
+    recurrence: str = None,
+) -> dict:
+    """Create a new followup with optional reasoning and recurrence."""
     conn = get_db()
     now = now_epoch()
-
-    # Anti-duplicate check
     similar = find_similar_followups(description)
     warning = ""
     if similar:
         ids = ", ".join(s["id"] for s in similar[:3])
-        warning = f" ⚠ SIMILAR FOLLOWUPS EXIST: {ids} (scores: {', '.join(str(s['_similarity']) for s in similar[:3])}). Consider updating instead."
+        warning = (
+            f" ⚠ SIMILAR FOLLOWUPS EXIST: {ids} "
+            f"(scores: {', '.join(str(s['_similarity']) for s in similar[:3])}). Consider updating instead."
+        )
 
     try:
         conn.execute(
             "INSERT INTO followups (id, date, description, verification, status, reasoning, recurrence, created_at, updated_at) "
             "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-            (id, date, description, verification, status, reasoning, recurrence, now, now)
+            (id, date, description, verification, status, reasoning, recurrence, now, now),
         )
         conn.commit()
         fts_upsert("followup", id, id, f"{description} {verification} {reasoning}", "followup", commit=False)
     except sqlite3.IntegrityError:
         return {"error": f"Followup {id} already exists. Use update instead."}
+
     row = conn.execute("SELECT * FROM followups WHERE id = ?", (id,)).fetchone()
+    add_item_history(
+        "followup",
+        id,
+        "created",
+        note=f"Followup created. Date={date or '—'}. Recurrence={recurrence or '—'}.",
+        actor="db",
+    )
     result = dict(row)
     if warning:
         result["warning"] = warning
     return result
 
 
-def update_followup(id: str, **kwargs) -> dict:
-    """Update any fields of a followup: description, date, verification, status, reasoning."""
+def update_followup(
+    id: str,
+    *,
+    log_history: bool = True,
+    history_event: str = "updated",
+    history_actor: str = "db",
+    history_note: str = "",
+    **kwargs,
+) -> dict:
+    """Update any fields of a followup."""
     conn = get_db()
     row = conn.execute("SELECT * FROM followups WHERE id = ?", (id,)).fetchone()
     if not row:
-            return {"error": f"Followup {id} not found"}
-    allowed = {"description", "date", "verification", "status", "reasoning", "recurrence"}
+        return {"error": f"Followup {id} not found"}
+
+    allowed = {"description", "date", "verification", "status", "reasoning", "recurrence", "priority"}
     updates = {k: v for k, v in kwargs.items() if k in allowed}
     if not updates:
-            return {"error": "No valid fields to update"}
+        return {"error": "No valid fields to update"}
+
     updates["updated_at"] = now_epoch()
     set_clause = ", ".join(f"{k} = ?" for k in updates)
     values = list(updates.values()) + [id]
     conn.execute(f"UPDATE followups SET {set_clause} WHERE id = ?", values)
     conn.commit()
-    row = conn.execute("SELECT * FROM followups WHERE id = ?", (id,)).fetchone()
-    r = dict(row)
-    fts_upsert("followup", id, id, f"{r.get('description','')} {r.get('verification','')} {r.get('reasoning','')}", "followup", commit=False)
-    return r
+
+    new_row = conn.execute("SELECT * FROM followups WHERE id = ?", (id,)).fetchone()
+    if new_row:
+        new_row_dict = dict(new_row)
+        fts_upsert(
+            "followup",
+            id,
+            id,
+            f"{new_row_dict.get('description','')} {new_row_dict.get('verification','')} {new_row_dict.get('reasoning','')}",
+            "followup",
+            commit=False,
+        )
+    if log_history:
+        note = history_note or _format_changes(
+            row,
+            new_row,
+            ["description", "date", "verification", "status", "reasoning", "recurrence", "priority"],
+        )
+        add_item_history("followup", id, history_event, note=note or "Followup updated.", actor=history_actor)
+    return dict(new_row)
 
 
-def _calc_next_recurrence_date(recurrence: str, current_date: str = None) -> str:
-    """Calculate the next date for a recurring followup.
-
-    Formats:
-        weekly:monday, weekly:thursday, weekly:friday, weekly:sunday
-        monthly:1, monthly:10, monthly:15
-        quarterly
-    """
+def _calc_next_recurrence_date(recurrence: str, current_date: str = None) -> str | None:
+    """Calculate the next date for a recurring followup."""
     today = datetime.date.today()
     base = datetime.date.fromisoformat(current_date) if current_date else today
 
-    if recurrence.startswith('weekly:'):
-        day_name = recurrence.split(':')[1].lower()
-        day_map = {'monday': 0, 'tuesday': 1, 'wednesday': 2, 'thursday': 3,
-                   'friday': 4, 'saturday': 5, 'sunday': 6}
+    if recurrence.startswith("weekly:"):
+        day_name = recurrence.split(":")[1].lower()
+        day_map = {
+            "monday": 0,
+            "tuesday": 1,
+            "wednesday": 2,
+            "thursday": 3,
+            "friday": 4,
+            "saturday": 5,
+            "sunday": 6,
+        }
         target_day = day_map.get(day_name, 0)
         days_ahead = (target_day - today.weekday()) % 7
         if days_ahead == 0:
-            days_ahead = 7  # next week, not today
+            days_ahead = 7
         return (today + datetime.timedelta(days=days_ahead)).isoformat()
 
-    elif recurrence.startswith('monthly:'):
-        target_day = int(recurrence.split(':')[1])
-        # Next month from today
+    if recurrence.startswith("monthly:"):
+        target_day = int(recurrence.split(":")[1])
         if today.month == 12:
-            next_date = datetime.date(today.year + 1, 1, min(target_day, 28))
+            year, month = today.year + 1, 1
         else:
-            import calendar
-            max_day = calendar.monthrange(today.year, today.month + 1)[1]
-            next_date = datetime.date(today.year, today.month + 1, min(target_day, max_day))
-        return next_date.isoformat()
+            year, month = today.year, today.month + 1
+        import calendar
 
-    elif recurrence == 'quarterly':
-        # 3 months from current date
+        max_day = calendar.monthrange(year, month)[1]
+        return datetime.date(year, month, min(target_day, max_day)).isoformat()
+
+    if recurrence == "quarterly":
         month = base.month + 3
         year = base.year
         if month > 12:
             month -= 12
             year += 1
         import calendar
+
         max_day = calendar.monthrange(year, month)[1]
         return datetime.date(year, month, min(base.day, max_day)).isoformat()
 
     return None
 
 
-def complete_followup(id: str, result: str = '') -> dict:
-    """Mark a followup as completed with today's date and optional result.
-    If the followup has a recurrence pattern, auto-creates the next occurrence."""
+def complete_followup(id: str, result: str = "") -> dict:
+    """Mark a followup as completed. If recurring, archive old row and spawn next."""
     conn = get_db()
     row = conn.execute("SELECT * FROM followups WHERE id = ?", (id,)).fetchone()
     if not row:
         return {"error": f"Followup {id} not found"}
 
-    today = datetime.date.today().isoformat()
     kwargs = {"status": "COMPLETED"}
     if result:
-        existing = row["verification"] or ''
+        existing = row["verification"] or ""
         kwargs["verification"] = f"{existing}\n{result}".strip() if existing else result
 
-    update_result = update_followup(id, **kwargs)
+    update_result = update_followup(id, log_history=False, **kwargs)
+    if "error" in update_result:
+        return update_result
+    add_item_history(
+        "followup",
+        id,
+        "completed",
+        note=result or "Followup marked COMPLETED.",
+        actor="db",
+    )
 
-    # Auto-regenerate if recurring
     recurrence = row["recurrence"]
     if recurrence:
+        today = datetime.date.today().isoformat()
         next_date = _calc_next_recurrence_date(recurrence, row["date"])
         if next_date:
-            # Rename completed one to include date suffix, then create fresh one
             archived_id = f"{id}-{today}"
             conn.execute("UPDATE followups SET id = ? WHERE id = ?", (archived_id, id))
+            _reassign_item_identity(conn, "followup", id, archived_id)
             conn.commit()
 
-            # Fix FTS: remove old entry for original ID, add entry for archived ID
             conn.execute("DELETE FROM unified_search WHERE source = 'followup' AND source_id = ?", (id,))
             archived_row = conn.execute("SELECT * FROM followups WHERE id = ?", (archived_id,)).fetchone()
             if archived_row:
                 fts_upsert(
-                    "followup", archived_id, archived_id,
+                    "followup",
+                    archived_id,
+                    archived_id,
                     f"{archived_row['description']} {archived_row['verification'] or ''} {archived_row['reasoning'] or ''}",
-                    "followup", commit=False,
+                    "followup",
+                    commit=False,
                 )
 
-            # create_followup handles its own FTS entry for the new recurring ID
             create_followup(
                 id=id,
                 description=row["description"],
                 date=next_date,
-                verification='',
-                reasoning=row["reasoning"] or '',
+                verification="",
+                reasoning=row["reasoning"] or "",
                 recurrence=recurrence,
             )
-
-            # Return accurate result: the completed one is now archived_id, not id
+            add_item_history(
+                "followup",
+                archived_id,
+                "recurrence_archived",
+                note=f"Recurring followup archived as {archived_id}. Next occurrence spawned as {id} for {next_date}.",
+                actor="db",
+            )
+            add_item_history(
+                "followup",
+                id,
+                "recurrence_spawned",
+                note=f"Spawned automatically from {archived_id}.",
+                actor="db",
+                metadata={"source_followup_id": archived_id},
+            )
             return {
                 "id": archived_id,
                 "status": "COMPLETED",
@@ -296,44 +588,79 @@ def complete_followup(id: str, result: str = '') -> dict:
 
 
 def delete_followup(id: str) -> bool:
-    """Delete a followup."""
-    conn = get_db()
-    result = conn.execute("DELETE FROM followups WHERE id = ?", (id,))
-    conn.execute("DELETE FROM unified_search WHERE source = 'followup' AND source_id = ?", (str(id),))
-    conn.commit()
-    deleted = result.rowcount > 0
-    return deleted
+    """Soft-delete a followup by setting status to DELETED."""
+    result = update_followup(id, status="DELETED", log_history=False)
+    if "error" in result:
+        return False
+    add_item_history("followup", id, "deleted", note="Followup soft-deleted (status=DELETED).", actor="db")
+    return True
 
 
-def get_followups(filter_type: str = 'all') -> list[dict]:
-    """Get followups by filter: 'all' (active), 'due' (date <= today), 'completed'."""
+def restore_followup(id: str) -> dict:
+    """Restore a followup from DELETED to PENDING."""
+    row = get_followup(id)
+    if not row:
+        return {"error": f"Followup {id} not found"}
+    result = update_followup(id, status="PENDING", log_history=False)
+    if "error" in result:
+        return result
+    previous = row.get("status") or "unknown"
+    add_item_history("followup", id, "restored", note=f"Followup restored from {previous} to PENDING.", actor="db")
+    return result
+
+
+def add_followup_note(id: str, note: str, actor: str = "nexo") -> dict:
+    """Append an operational note to a followup history."""
+    row = get_followup(id)
+    if not row:
+        return {"error": f"Followup {id} not found"}
+    return add_item_history("followup", id, "note", note=note, actor=actor)
+
+
+def get_followups(filter_type: str = "all") -> list[dict]:
+    """Get followups by filter: active, due, completed, deleted, history."""
     conn = get_db()
     today = datetime.date.today().isoformat()
-    if filter_type == 'completed':
+    if filter_type == "completed":
         rows = conn.execute(
             "SELECT * FROM followups WHERE status LIKE 'COMPLETED%' ORDER BY updated_at DESC"
         ).fetchall()
-    elif filter_type == 'due':
+    elif filter_type == "deleted":
         rows = conn.execute(
-            "SELECT * FROM followups WHERE status NOT LIKE 'COMPLETED%' "
-            "AND status NOT IN ('DELETED','archived','blocked','waiting') "
+            "SELECT * FROM followups WHERE status = 'DELETED' ORDER BY updated_at DESC"
+        ).fetchall()
+    elif filter_type in {"history", "any"}:
+        rows = conn.execute(
+            "SELECT * FROM followups ORDER BY updated_at DESC"
+        ).fetchall()
+    elif filter_type == "due":
+        rows = conn.execute(
+            f"SELECT * FROM followups WHERE {_active_status_where()} "
             "AND date IS NOT NULL AND date <= ? "
             "ORDER BY date ASC",
-            (today,)
+            (today,),
         ).fetchall()
-    else:  # 'all' — active only
+    else:
         rows = conn.execute(
-            "SELECT * FROM followups WHERE status NOT LIKE 'COMPLETED%' "
-            "AND status NOT IN ('DELETED','archived','blocked','waiting') "
+            f"SELECT * FROM followups WHERE {_active_status_where()} "
             "ORDER BY date ASC NULLS LAST"
         ).fetchall()
     return [dict(r) for r in rows]
 
 
-def get_followup(id: str) -> dict | None:
-    """Get a single followup by id."""
+def get_followup(id: str, include_history: bool = False) -> dict | None:
+    """Get a single followup by id, optionally with history and read token."""
     conn = get_db()
     row = conn.execute("SELECT * FROM followups WHERE id = ?", (id,)).fetchone()
-    return dict(row) if row else None
+    if not row:
+        return None
+    result = dict(row)
+    if include_history:
+        result["history"] = get_item_history("followup", id)
+        result["history_rules"] = _history_rules("followup")
+        result["read_token"] = _issue_item_read_token("followup", id)
+    return result
 
 
+def get_followup_history(id: str, limit: int = 20) -> list[dict]:
+    return get_item_history("followup", id, limit=limit)

--- a/src/db/_schema.py
+++ b/src/db/_schema.py
@@ -674,6 +674,35 @@ def _m28_automation_runs(conn):
     _migrate_add_index(conn, "idx_automation_runs_status", "automation_runs", "status")
 
 
+def _m29_item_history_and_soft_delete(conn):
+    """Persist reminder/followup history and read-before-mutate tokens."""
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS item_history (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            item_type TEXT NOT NULL,
+            item_id TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            note TEXT DEFAULT '',
+            actor TEXT DEFAULT '',
+            metadata TEXT DEFAULT '{}',
+            created_at REAL NOT NULL
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS item_read_tokens (
+            token TEXT PRIMARY KEY,
+            item_type TEXT NOT NULL,
+            item_id TEXT NOT NULL,
+            history_seq INTEGER DEFAULT 0,
+            issued_at REAL NOT NULL,
+            expires_at REAL NOT NULL
+        )
+    """)
+    _migrate_add_index(conn, "idx_item_history_lookup", "item_history", "item_type, item_id, created_at")
+    _migrate_add_index(conn, "idx_item_history_item", "item_history", "item_id")
+    _migrate_add_index(conn, "idx_item_read_tokens_lookup", "item_read_tokens", "item_type, item_id, expires_at")
+
+
 MIGRATIONS = [
     (1, "learnings_columns", _m1_learnings_columns),
     (2, "followups_reasoning", _m2_followups_reasoning),
@@ -703,6 +732,7 @@ MIGRATIONS = [
     (26, "protocol_answer_confidence", _m26_protocol_answer_confidence),
     (27, "state_watchers", _m27_state_watchers),
     (28, "automation_runs", _m28_automation_runs),
+    (29, "item_history_and_soft_delete", _m29_item_history_and_soft_delete),
 ]
 
 

--- a/src/server.py
+++ b/src/server.py
@@ -24,10 +24,10 @@ from tools_coordination import (
 from tools_reminders import handle_reminders
 from tools_menu import handle_menu
 from tools_reminders_crud import (
-    handle_reminder_create, handle_reminder_update,
-    handle_reminder_complete, handle_reminder_delete,
-    handle_followup_create, handle_followup_update,
-    handle_followup_complete, handle_followup_delete,
+    handle_reminder_create, handle_reminder_get, handle_reminder_update,
+    handle_reminder_complete, handle_reminder_note, handle_reminder_restore, handle_reminder_delete,
+    handle_followup_create, handle_followup_get, handle_followup_update,
+    handle_followup_complete, handle_followup_note, handle_followup_restore, handle_followup_delete,
 )
 from tools_learnings import (
     handle_learning_add, handle_learning_search,
@@ -191,6 +191,8 @@ mcp = FastMCP(
         "React: DIARY REMINDER→write diary, VIBE:NEGATIVE→ultra-concise, AUTO-PRIME→read learnings\n"
         "- **Followups:** NEXO tasks, execute silently. 'done'/'all set'→`nexo_followup_complete` NOW. "
         "Reminders=user's, alert when due\n"
+        "- **Reminder/followup history:** before update/delete/restore/note, call the corresponding "
+        "`nexo_reminder_get` / `nexo_followup_get` first and use its `READ_TOKEN`.\n"
         "- **Observe:** correction→learning. 'tomorrow'→followup. person→entity. open topic→followup 3d\n"
         "- **Trust events:** When user expresses satisfaction/thanks (any language)→`nexo_cognitive_trust(event='explicit_thanks')`. "
         "When user corrects you→`nexo_cognitive_trust(event='correction')`. "
@@ -488,7 +490,7 @@ def nexo_reminders(filter: str = "due") -> str:
     """Check reminders and followups.
 
     Args:
-        filter: 'due' (vencidos/hoy), 'all' (todos activos), 'followups' (solo NEXO followups)
+        filter: 'due', 'all', 'followups', 'completed', 'deleted', 'history', or 'any'
     """
     return handle_reminders(filter)
 
@@ -503,7 +505,7 @@ def nexo_menu() -> str:
     return handle_menu()
 
 
-# ── Reminders CRUD (4 tools) ──────────────────────────────────────
+# ── Reminders CRUD (7 tools) ──────────────────────────────────────
 
 @mcp.tool
 def nexo_reminder_create(id: str, description: str, date: str = "", category: str = "general") -> str:
@@ -519,8 +521,26 @@ def nexo_reminder_create(id: str, description: str, date: str = "", category: st
 
 
 @mcp.tool
-def nexo_reminder_update(id: str, description: str = "", date: str = "", status: str = "", category: str = "") -> str:
+def nexo_reminder_get(id: str) -> str:
+    """Read a reminder with its history and usage rules.
+
+    IMPORTANT: before update/delete/restore/note, call this tool first and use the returned READ_TOKEN.
+    """
+    return handle_reminder_get(id)
+
+
+@mcp.tool
+def nexo_reminder_update(
+    id: str,
+    description: str = "",
+    date: str = "",
+    status: str = "",
+    category: str = "",
+    read_token: str = "",
+) -> str:
     """Update fields of an existing reminder. Only non-empty fields are changed.
+
+    IMPORTANT: call `nexo_reminder_get` first and pass its READ_TOKEN.
 
     Args:
         id: Reminder ID (e.g., R87).
@@ -528,8 +548,9 @@ def nexo_reminder_update(id: str, description: str = "", date: str = "", status:
         date: New date YYYY-MM-DD (optional).
         status: New status (optional).
         category: New category (optional).
+        read_token: Token returned by `nexo_reminder_get`.
     """
-    return handle_reminder_update(id, description, date, status, category)
+    return handle_reminder_update(id, description, date, status, category, read_token)
 
 
 @mcp.tool
@@ -543,16 +564,47 @@ def nexo_reminder_complete(id: str) -> str:
 
 
 @mcp.tool
-def nexo_reminder_delete(id: str) -> str:
-    """Delete a reminder permanently.
+def nexo_reminder_note(id: str, note: str, read_token: str = "", actor: str = "nexo") -> str:
+    """Append a note to reminder history.
+
+    IMPORTANT: call `nexo_reminder_get` first and pass its READ_TOKEN.
 
     Args:
         id: Reminder ID (e.g., R87).
+        note: Operational note to append to history.
+        read_token: Token returned by `nexo_reminder_get`.
+        actor: Actor label for the history note.
     """
-    return handle_reminder_delete(id)
+    return handle_reminder_note(id, note, read_token, actor)
 
 
-# ── Followups CRUD (4 tools) ──────────────────────────────────────
+@mcp.tool
+def nexo_reminder_restore(id: str, read_token: str = "") -> str:
+    """Restore a soft-deleted reminder back to PENDING.
+
+    IMPORTANT: call `nexo_reminder_get` first and pass its READ_TOKEN.
+
+    Args:
+        id: Reminder ID (e.g., R87).
+        read_token: Token returned by `nexo_reminder_get`.
+    """
+    return handle_reminder_restore(id, read_token)
+
+
+@mcp.tool
+def nexo_reminder_delete(id: str, read_token: str = "") -> str:
+    """Soft-delete a reminder.
+
+    IMPORTANT: call `nexo_reminder_get` first and pass its READ_TOKEN.
+
+    Args:
+        id: Reminder ID (e.g., R87).
+        read_token: Token returned by `nexo_reminder_get`.
+    """
+    return handle_reminder_delete(id, read_token)
+
+
+# ── Followups CRUD (7 tools) ──────────────────────────────────────
 
 @mcp.tool
 def nexo_followup_create(id: str, description: str, date: str = "", verification: str = "", reasoning: str = "", recurrence: str = "", priority: str = "medium") -> str:
@@ -577,8 +629,27 @@ def nexo_followup_create(id: str, description: str, date: str = "", verification
 
 
 @mcp.tool
-def nexo_followup_update(id: str, description: str = "", date: str = "", verification: str = "", status: str = "", priority: str = "") -> str:
+def nexo_followup_get(id: str) -> str:
+    """Read a followup with its history and usage rules.
+
+    IMPORTANT: before update/delete/restore/note, call this tool first and use the returned READ_TOKEN.
+    """
+    return handle_followup_get(id)
+
+
+@mcp.tool
+def nexo_followup_update(
+    id: str,
+    description: str = "",
+    date: str = "",
+    verification: str = "",
+    status: str = "",
+    priority: str = "",
+    read_token: str = "",
+) -> str:
     """Update fields of an existing followup. Only non-empty fields are changed.
+
+    IMPORTANT: call `nexo_followup_get` first and pass its READ_TOKEN.
 
     Args:
         id: Followup ID (e.g., NF45).
@@ -587,13 +658,9 @@ def nexo_followup_update(id: str, description: str = "", date: str = "", verific
         verification: New verification text (optional).
         status: New status (optional).
         priority: critical, high, medium, low (optional).
+        read_token: Token returned by `nexo_followup_get`.
     """
-    result = handle_followup_update(id, description, date, verification, status)
-    if priority in ('critical', 'high', 'medium', 'low'):
-        from db import get_db
-        get_db().execute("UPDATE followups SET priority = ? WHERE id = ?", (priority, id))
-        get_db().commit()
-    return result
+    return handle_followup_update(id, description, date, verification, status, priority, read_token)
 
 
 @mcp.tool
@@ -608,13 +675,44 @@ def nexo_followup_complete(id: str, result: str = "") -> str:
 
 
 @mcp.tool
-def nexo_followup_delete(id: str) -> str:
-    """Delete a followup permanently.
+def nexo_followup_note(id: str, note: str, read_token: str = "", actor: str = "nexo") -> str:
+    """Append a note to followup history.
+
+    IMPORTANT: call `nexo_followup_get` first and pass its READ_TOKEN.
 
     Args:
         id: Followup ID (e.g., NF45).
+        note: Operational note to append to history.
+        read_token: Token returned by `nexo_followup_get`.
+        actor: Actor label for the history note.
     """
-    return handle_followup_delete(id)
+    return handle_followup_note(id, note, read_token, actor)
+
+
+@mcp.tool
+def nexo_followup_restore(id: str, read_token: str = "") -> str:
+    """Restore a soft-deleted followup back to PENDING.
+
+    IMPORTANT: call `nexo_followup_get` first and pass its READ_TOKEN.
+
+    Args:
+        id: Followup ID (e.g., NF45).
+        read_token: Token returned by `nexo_followup_get`.
+    """
+    return handle_followup_restore(id, read_token)
+
+
+@mcp.tool
+def nexo_followup_delete(id: str, read_token: str = "") -> str:
+    """Soft-delete a followup.
+
+    IMPORTANT: call `nexo_followup_get` first and pass its READ_TOKEN.
+
+    Args:
+        id: Followup ID (e.g., NF45).
+        read_token: Token returned by `nexo_followup_get`.
+    """
+    return handle_followup_delete(id, read_token)
 
 
 # ── Learnings CRUD (5 tools) ──────────────────────────────────────

--- a/src/tools_reminders.py
+++ b/src/tools_reminders.py
@@ -19,16 +19,16 @@ def handle_reminders(filter_type: str = "due") -> str:
     """Read reminders and followups from SQLite, return relevant ones.
 
     Args:
-        filter_type: 'due' (vencidos/hoy), 'all' (todos activos), 'followups' (solo followups)
+        filter_type: 'due', 'all', 'followups', 'completed', 'deleted', 'history', 'any'
     """
     parts = []
 
-    if filter_type in ("due", "all"):
+    if filter_type in ("due", "all", "completed", "deleted", "history", "any"):
         r = _format_reminders(filter_type)
         if r:
             parts.append(r)
 
-    if filter_type in ("due", "all", "followups"):
+    if filter_type in ("due", "all", "followups", "completed", "deleted", "history", "any"):
         f = _format_followups(filter_type)
         if f:
             parts.append(f)
@@ -52,7 +52,8 @@ def _format_reminders(filter_type: str) -> str:
         desc = desc.replace("**", "")
         due_marker = " [DUE]" if _is_due(fecha) else ""
         fecha_display = f"({fecha})" if fecha else "(—)"
-        lines.append(f"  {rid} {fecha_display}{due_marker} — {desc[:120]}")
+        status_tag = f" [{status}]" if status and status != "PENDING" else ""
+        lines.append(f"  {rid} {fecha_display}{due_marker}{status_tag} — {desc[:120]}")
         if "RECURRENTE" in status.upper():
             lines.append(f"    Status: {status}")
 
@@ -81,6 +82,8 @@ def _format_followups(filter_type: str) -> str:
         pri = r.get("priority") or "medium"
         pri_icon = {"critical": "🔴", "high": "🟠", "medium": "", "low": "⚪"}.get(pri, "")
         pri_tag = f" {pri_icon}" if pri_icon else ""
-        lines.append(f"  {nfid} {fecha_display}{due_marker}{pri_tag}{rec_tag} — {desc[:120]}")
+        status = r.get("status") or ""
+        status_tag = f" [{status}]" if status and status != "PENDING" else ""
+        lines.append(f"  {nfid} {fecha_display}{due_marker}{pri_tag}{rec_tag}{status_tag} — {desc[:120]}")
 
     return "\n".join(lines)

--- a/src/tools_reminders_crud.py
+++ b/src/tools_reminders_crud.py
@@ -2,11 +2,75 @@
 
 from db import (
     create_reminder, update_reminder, complete_reminder, delete_reminder,
-    get_reminders, get_reminder,
+    restore_reminder, add_reminder_note, get_reminder,
     create_followup, update_followup, complete_followup, delete_followup,
-    get_followups, get_followup,
+    restore_followup, add_followup_note, get_followup,
+    validate_item_read_token,
     find_decisions_by_context_ref, update_decision_outcome,
 )
+
+
+def _require_item_read(item_type: str, item_id: str, read_token: str) -> str | None:
+    ok, message = validate_item_read_token(read_token, item_type, item_id)
+    if ok:
+        return None
+    prefix = "followup" if item_type == "followup" else "reminder"
+    return f"ERROR: {message} Use nexo_{prefix}_get(id='{item_id}') first."
+
+
+def _history_lines(history: list[dict]) -> list[str]:
+    if not history:
+        return ["- (no history)"]
+    lines: list[str] = []
+    for event in history:
+        created_at = event.get("created_at") or "?"
+        event_type = event.get("event_type") or "event"
+        actor = event.get("actor") or "system"
+        note = (event.get("note") or "").strip()
+        suffix = f" — {note}" if note else ""
+        lines.append(f"- {created_at} [{event_type}] ({actor}){suffix}")
+    return lines
+
+
+def _format_reminder_payload(reminder: dict) -> str:
+    lines = [
+        f"REMINDER {reminder['id']}",
+        f"Description: {reminder.get('description') or ''}",
+        f"Date: {reminder.get('date') or '—'}",
+        f"Status: {reminder.get('status') or '—'}",
+        f"Category: {reminder.get('category') or 'general'}",
+    ]
+    history_rules = reminder.get("history_rules") or []
+    if history_rules:
+        lines.append("Usage rules:")
+        lines.extend(f"- {rule}" for rule in history_rules)
+    lines.append("History:")
+    lines.extend(_history_lines(reminder.get("history") or []))
+    if reminder.get("read_token"):
+        lines.append(f"READ_TOKEN: {reminder['read_token']}")
+    return "\n".join(lines)
+
+
+def _format_followup_payload(followup: dict) -> str:
+    lines = [
+        f"FOLLOWUP {followup['id']}",
+        f"Description: {followup.get('description') or ''}",
+        f"Date: {followup.get('date') or '—'}",
+        f"Status: {followup.get('status') or '—'}",
+        f"Verification: {followup.get('verification') or '—'}",
+        f"Reasoning: {followup.get('reasoning') or '—'}",
+        f"Recurrence: {followup.get('recurrence') or '—'}",
+        f"Priority: {followup.get('priority') or 'medium'}",
+    ]
+    history_rules = followup.get("history_rules") or []
+    if history_rules:
+        lines.append("Usage rules:")
+        lines.extend(f"- {rule}" for rule in history_rules)
+    lines.append("History:")
+    lines.extend(_history_lines(followup.get("history") or []))
+    if followup.get("read_token"):
+        lines.append(f"READ_TOKEN: {followup['read_token']}")
+    return "\n".join(lines)
 
 
 # ── Reminders ──────────────────────────────────────────────────────────────────
@@ -25,8 +89,27 @@ def handle_reminder_create(id: str, description: str, date: str = '', category: 
     return f"Reminder created. Date: {date_str}. Category: {category}."
 
 
-def handle_reminder_update(id: str, description: str = '', date: str = '', status: str = '', category: str = '') -> str:
+def handle_reminder_get(id: str) -> str:
+    """Read a reminder with history and return a read token for safe mutations."""
+    result = get_reminder(id=id, include_history=True)
+    if not result:
+        return f"ERROR: Reminder {id} not found."
+    return _format_reminder_payload(result)
+
+
+def handle_reminder_update(
+    id: str,
+    description: str = '',
+    date: str = '',
+    status: str = '',
+    category: str = '',
+    read_token: str = '',
+) -> str:
     """Update one or more fields of an existing reminder."""
+    error = _require_item_read("reminder", id, read_token)
+    if error:
+        return error
+
     fields: dict = {}
     if description:
         fields['description'] = description
@@ -41,8 +124,9 @@ def handle_reminder_update(id: str, description: str = '', date: str = '', statu
         return f"ERROR: No fields specified to update for {id}."
 
     result = update_reminder(id=id, **fields)
-    if not result:
-        return f"ERROR: Reminder {id} not found."
+    if not result or "error" in result:
+        error_msg = result.get("error", f"Reminder {id} not found.") if isinstance(result, dict) else f"Reminder {id} not found."
+        return f"ERROR: {error_msg}"
 
     changed = ', '.join(fields.keys())
     return f"Reminder {id} updated: {changed}."
@@ -57,13 +141,42 @@ def handle_reminder_complete(id: str) -> str:
     return f"Reminder {id} marked COMPLETED."
 
 
-def handle_reminder_delete(id: str) -> str:
-    """Delete a reminder permanently."""
+def handle_reminder_note(id: str, note: str, read_token: str = '', actor: str = 'nexo') -> str:
+    """Append a note to reminder history."""
+    if not note.strip():
+        return "ERROR: note is required."
+    error = _require_item_read("reminder", id, read_token)
+    if error:
+        return error
+    result = add_reminder_note(id=id, note=note.strip(), actor=actor or "nexo")
+    if not result or "error" in result:
+        error_msg = result.get("error", f"Reminder {id} not found.") if isinstance(result, dict) else f"Reminder {id} not found."
+        return f"ERROR: {error_msg}"
+    return f"Reminder {id} note added."
+
+
+def handle_reminder_restore(id: str, read_token: str = '') -> str:
+    """Restore a soft-deleted reminder."""
+    error = _require_item_read("reminder", id, read_token)
+    if error:
+        return error
+    result = restore_reminder(id=id)
+    if not result or "error" in result:
+        error_msg = result.get("error", f"Reminder {id} not found.") if isinstance(result, dict) else f"Reminder {id} not found."
+        return f"ERROR: {error_msg}"
+    return f"Reminder {id} restored to PENDING."
+
+
+def handle_reminder_delete(id: str, read_token: str = '') -> str:
+    """Soft-delete a reminder."""
+    error = _require_item_read("reminder", id, read_token)
+    if error:
+        return error
     result = delete_reminder(id=id)
     if not result:
         return f"ERROR: Reminder {id} not found."
 
-    return f"Reminder {id} deleted."
+    return f"Reminder {id} soft-deleted."
 
 
 # ── Followups ──────────────────────────────────────────────────────────────────
@@ -95,8 +208,28 @@ def handle_followup_create(id: str, description: str, date: str = '', verificati
     return f"Followup created. Date: {date_str}.{rec_str}{warn_str}"
 
 
-def handle_followup_update(id: str, description: str = '', date: str = '', verification: str = '', status: str = '') -> str:
+def handle_followup_get(id: str) -> str:
+    """Read a followup with history and return a read token for safe mutations."""
+    result = get_followup(id=id, include_history=True)
+    if not result:
+        return f"ERROR: Followup {id} not found."
+    return _format_followup_payload(result)
+
+
+def handle_followup_update(
+    id: str,
+    description: str = '',
+    date: str = '',
+    verification: str = '',
+    status: str = '',
+    priority: str = '',
+    read_token: str = '',
+) -> str:
     """Update one or more fields of an existing followup."""
+    error = _require_item_read("followup", id, read_token)
+    if error:
+        return error
+
     fields: dict = {}
     if description:
         fields['description'] = description
@@ -106,16 +239,19 @@ def handle_followup_update(id: str, description: str = '', date: str = '', verif
         fields['verification'] = verification
     if status:
         fields['status'] = status
+    if priority:
+        fields['priority'] = priority
 
     if not fields:
         return f"ERROR: No fields specified to update for {id}."
 
     result = update_followup(id=id, **fields)
-    if not result:
-        return f"ERROR: Followup {id} not found."
+    if not result or "error" in result:
+        error_msg = result.get("error", f"Followup {id} not found.") if isinstance(result, dict) else f"Followup {id} not found."
+        return f"ERROR: {error_msg}"
 
     changed = ', '.join(fields.keys())
-    return f"Followup updated: {changed}."
+    return f"Followup {id} updated: {changed}."
 
 
 def handle_followup_complete(id: str, result: str = '') -> str:
@@ -157,10 +293,39 @@ def handle_followup_complete(id: str, result: str = '') -> str:
     return msg
 
 
-def handle_followup_delete(id: str) -> str:
-    """Delete a followup permanently."""
+def handle_followup_note(id: str, note: str, read_token: str = '', actor: str = 'nexo') -> str:
+    """Append a note to followup history."""
+    if not note.strip():
+        return "ERROR: note is required."
+    error = _require_item_read("followup", id, read_token)
+    if error:
+        return error
+    result = add_followup_note(id=id, note=note.strip(), actor=actor or "nexo")
+    if not result or "error" in result:
+        error_msg = result.get("error", f"Followup {id} not found.") if isinstance(result, dict) else f"Followup {id} not found."
+        return f"ERROR: {error_msg}"
+    return f"Followup {id} note added."
+
+
+def handle_followup_restore(id: str, read_token: str = '') -> str:
+    """Restore a soft-deleted followup."""
+    error = _require_item_read("followup", id, read_token)
+    if error:
+        return error
+    result = restore_followup(id=id)
+    if not result or "error" in result:
+        error_msg = result.get("error", f"Followup {id} not found.") if isinstance(result, dict) else f"Followup {id} not found."
+        return f"ERROR: {error_msg}"
+    return f"Followup {id} restored to PENDING."
+
+
+def handle_followup_delete(id: str, read_token: str = '') -> str:
+    """Soft-delete a followup."""
+    error = _require_item_read("followup", id, read_token)
+    if error:
+        return error
     result = delete_followup(id=id)
     if not result:
         return f"ERROR: Followup {id} not found."
 
-    return f"Followup deleted."
+    return f"Followup {id} soft-deleted."

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -136,3 +136,48 @@ def test_protocol_routes_render_and_return_snapshot():
     payload = api.json()
     assert "protocol_summary" in payload
     assert "recent_tasks" in payload
+
+
+def test_dashboard_reminder_delete_is_soft_and_history_visible(isolated_db):
+    client = TestClient(app)
+
+    created = client.post(
+        "/api/reminders",
+        json={"description": "Dashboard soft delete", "date": "2026-04-09", "category": "tasks"},
+    )
+    assert created.status_code == 200
+    rid = created.json()["reminder"]["id"]
+
+    deleted = client.delete(f"/api/reminders/{rid}")
+    assert deleted.status_code == 200
+
+    listing = client.get("/api/reminders")
+    assert listing.status_code == 200
+    assert all(item["id"] != rid for item in listing.json()["reminders"])
+
+    detail = client.get(f"/api/reminders/{rid}")
+    assert detail.status_code == 200
+    payload = detail.json()["reminder"]
+    assert payload["status"] == "DELETED"
+    assert any(event["event_type"] == "deleted" for event in payload["history"])
+
+
+def test_dashboard_move_preserves_source_as_deleted(isolated_db):
+    client = TestClient(app)
+
+    created = client.post(
+        "/api/reminders",
+        json={"description": "Move me to followup", "date": "2026-04-10", "category": "tasks"},
+    )
+    rid = created.json()["reminder"]["id"]
+
+    moved = client.post("/api/ops/move", json={"id": rid, "direction": "to_followup"})
+    assert moved.status_code == 200
+    fid = moved.json()["new_id"]
+
+    old_row = db.get_reminder(rid, include_history=True)
+    new_row = db.get_followup(fid, include_history=True)
+
+    assert old_row["status"] == "DELETED"
+    assert any(event["event_type"] == "deleted" for event in old_row["history"])
+    assert any("dashboard move" in (event.get("note") or "") for event in new_row["history"])

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -16,7 +16,7 @@ def test_init_db_creates_core_tables():
         "questions", "reminders", "followups", "learnings", "credentials",
         "task_history", "task_frequencies", "plugins", "entities",
         "preferences", "agents", "change_log", "decisions",
-        "protocol_tasks", "protocol_debt",
+        "protocol_tasks", "protocol_debt", "item_history", "item_read_tokens",
     }
     assert expected.issubset(tables), f"Missing tables: {expected - tables}"
 
@@ -26,7 +26,7 @@ def test_migrations_idempotent():
     db_mod.run_migrations()
     db_mod.run_migrations()
     version = db_mod.get_schema_version()
-    assert version >= 23
+    assert version >= 29
 
 
 def test_session_crud():
@@ -98,21 +98,50 @@ def test_learning_supersede_lifecycle():
 def test_reminder_followup_crud():
     """Create and complete reminders and followups."""
     db_mod.create_reminder("R-TEST1", "Test reminder", date="2026-12-31")
-    reminder = db_mod.get_reminder("R-TEST1")
+    reminder = db_mod.get_reminder("R-TEST1", include_history=True)
     assert reminder is not None
     assert reminder["status"] == "PENDING"
+    assert reminder["history"][0]["event_type"] == "created"
+    assert reminder["read_token"].startswith("IRT-")
 
     db_mod.complete_reminder("R-TEST1")
-    reminder2 = db_mod.get_reminder("R-TEST1")
+    reminder2 = db_mod.get_reminder("R-TEST1", include_history=True)
     assert reminder2["status"] == "COMPLETED"
+    assert any(event["event_type"] == "completed" for event in reminder2["history"])
 
     db_mod.create_followup("NF-TEST1", "Test followup", date="2026-12-31")
-    followup = db_mod.get_followup("NF-TEST1")
+    followup = db_mod.get_followup("NF-TEST1", include_history=True)
     assert followup is not None
+    assert followup["history"][0]["event_type"] == "created"
 
     db_mod.complete_followup("NF-TEST1", result="done")
-    followup2 = db_mod.get_followup("NF-TEST1")
+    followup2 = db_mod.get_followup("NF-TEST1", include_history=True)
     assert followup2["status"] == "COMPLETED"
+    assert any(event["event_type"] == "completed" for event in followup2["history"])
+
+
+def test_soft_delete_restore_and_read_token_validation():
+    db_mod.create_reminder("R-TEST2", "Delete me", date="2026-12-31")
+    reminder = db_mod.get_reminder("R-TEST2", include_history=True)
+    token = reminder["read_token"]
+
+    ok, msg = db_mod.validate_item_read_token(token, "reminder", "R-TEST2")
+    assert ok is True
+    assert msg == ""
+
+    assert db_mod.delete_reminder("R-TEST2") is True
+    deleted = db_mod.get_reminder("R-TEST2", include_history=True)
+    assert deleted["status"] == "DELETED"
+    assert any(event["event_type"] == "deleted" for event in deleted["history"])
+
+    ok2, msg2 = db_mod.validate_item_read_token(token, "reminder", "R-TEST2")
+    assert ok2 is False
+    assert "History changed" in msg2
+
+    restored = db_mod.restore_reminder("R-TEST2")
+    assert restored["status"] == "PENDING"
+    restored_view = db_mod.get_reminder("R-TEST2", include_history=True)
+    assert any(event["event_type"] == "restored" for event in restored_view["history"])
 
 
 def test_recurring_followup():

--- a/tests/test_reminders_history.py
+++ b/tests/test_reminders_history.py
@@ -1,0 +1,87 @@
+"""Tests for reminder/followup history-aware CRUD handlers."""
+
+from __future__ import annotations
+
+import tools_reminders_crud as reminders_tools
+
+
+def _extract_read_token(payload: str) -> str:
+    for line in payload.splitlines():
+        if line.startswith("READ_TOKEN: "):
+            return line.split("READ_TOKEN: ", 1)[1].strip()
+    raise AssertionError(f"READ_TOKEN not found in payload:\n{payload}")
+
+
+def test_reminder_handlers_require_read_before_mutation(isolated_db):
+    created = reminders_tools.handle_reminder_create(
+        id="R-HIST-1",
+        description="History aware reminder",
+        date="2026-04-09",
+        category="tasks",
+    )
+    assert "Reminder created." in created
+
+    denied = reminders_tools.handle_reminder_update(
+        id="R-HIST-1",
+        description="Updated without read token",
+    )
+    assert "Missing read_token" in denied
+
+    detail = reminders_tools.handle_reminder_get("R-HIST-1")
+    token = _extract_read_token(detail)
+    assert "Usage rules:" in detail
+    assert "History:" in detail
+
+    updated = reminders_tools.handle_reminder_update(
+        id="R-HIST-1",
+        description="Updated with read token",
+        read_token=token,
+    )
+    assert "updated" in updated
+
+    stale = reminders_tools.handle_reminder_delete(id="R-HIST-1", read_token=token)
+    assert "History changed" in stale
+
+    refreshed = reminders_tools.handle_reminder_get("R-HIST-1")
+    fresh_token = _extract_read_token(refreshed)
+    noted = reminders_tools.handle_reminder_note(
+        id="R-HIST-1",
+        note="Asked Francisco and waiting for reply.",
+        read_token=fresh_token,
+    )
+    assert "note added" in noted
+
+
+def test_followup_handlers_soft_delete_and_restore(isolated_db):
+    created = reminders_tools.handle_followup_create(
+        id="NF-HIST-1",
+        description="History aware followup",
+        date="2026-04-09",
+        verification="Check the logs",
+        reasoning="Regression coverage",
+    )
+    assert "Followup created." in created
+
+    detail = reminders_tools.handle_followup_get("NF-HIST-1")
+    token = _extract_read_token(detail)
+    assert "Usage rules:" in detail
+    assert "History:" in detail
+
+    deleted = reminders_tools.handle_followup_delete(id="NF-HIST-1", read_token=token)
+    assert "soft-deleted" in deleted
+
+    deleted_detail = reminders_tools.handle_followup_get("NF-HIST-1")
+    assert "Status: DELETED" in deleted_detail
+    restore_token = _extract_read_token(deleted_detail)
+
+    restored = reminders_tools.handle_followup_restore(id="NF-HIST-1", read_token=restore_token)
+    assert "restored to PENDING" in restored
+
+    noted_detail = reminders_tools.handle_followup_get("NF-HIST-1")
+    note_token = _extract_read_token(noted_detail)
+    noted = reminders_tools.handle_followup_note(
+        id="NF-HIST-1",
+        note="Francisco answered, execute the task and close.",
+        read_token=note_token,
+    )
+    assert "note added" in noted


### PR DESCRIPTION
## Summary
- add append-only history and soft delete to reminders/followups
- expose read-before-mutate get/note/restore/read_token flows in the MCP surface
- align dashboard CRUD/move operations with the new history-preserving model

## Verification
- pytest -q tests/test_migrations.py tests/test_reminders_history.py tests/test_dashboard_app.py tests/test_decision_reviews.py
- python3 scripts/verify_release_readiness.py --ci