### PR TITLE
fix: preserve reminder history across core automation

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [3.1.4] - 2026-04-08
+
+### History Integrity Hotfix
+- Closed the gap where public core scripts still mutated reminders/followups outside the new history model. `daily self-audit`, `deep sleep apply`, and `followup hygiene` now record history-aware followup/reminder mutations instead of silently bypassing the operational timeline.
+- Followup creation now accepts priority at creation time through the public stack, which removes the last raw post-insert priority patch in the MCP server path.
+- Hardened learning auto-capture so `self-audit` no longer depends on a fragile reread after metadata updates when creating repair learnings inline.
+- Added regression coverage for history-aware self-audit followup creation/completion, deep-sleep duplicate consolidation notes, hygiene normalization events, and priority-aware followup creation.
+
 ## [3.1.3] - 2026-04-08
 
 ### History-Aware Reminders + Followups

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 3.1.3
+version: 3.1.4
 metadata:
   openclaw:
     requires:

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "3.1.3" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "3.1.4" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/src/db/_reminders.py
+++ b/src/db/_reminders.py
@@ -14,6 +14,14 @@ ACTIVE_EXCLUDED_STATUSES = {"DELETED", "archived", "blocked", "waiting"}
 READ_TOKEN_TTL_SECONDS = 30 * 60
 
 
+def _table_exists(conn: sqlite3.Connection, table_name: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type IN ('table', 'view') AND name = ? LIMIT 1",
+        (table_name,),
+    ).fetchone()
+    return bool(row)
+
+
 def _serialize_metadata(metadata: dict[str, Any] | None) -> str:
     if not metadata:
         return "{}"
@@ -63,6 +71,8 @@ def _history_rules(item_type: str) -> list[str]:
 
 
 def _latest_history_seq(conn, item_type: str, item_id: str) -> int:
+    if not _table_exists(conn, "item_history"):
+        return 0
     row = conn.execute(
         "SELECT MAX(id) AS max_id FROM item_history WHERE item_type = ? AND item_id = ?",
         (item_type, item_id),
@@ -82,6 +92,17 @@ def add_item_history(
 ) -> dict:
     """Append an event to reminder/followup history."""
     conn = get_db()
+    if not _table_exists(conn, "item_history"):
+        return {
+            "item_type": item_type,
+            "item_id": item_id,
+            "event_type": event_type,
+            "note": note or "",
+            "actor": actor,
+            "metadata": _serialize_metadata(metadata),
+            "created_at": created_at if created_at is not None else now_epoch(),
+            "skipped": True,
+        }
     ts = created_at if created_at is not None else now_epoch()
     conn.execute(
         "INSERT INTO item_history (item_type, item_id, event_type, note, actor, metadata, created_at) "
@@ -99,6 +120,8 @@ def add_item_history(
 def get_item_history(item_type: str, item_id: str, limit: int = 20) -> list[dict]:
     """Return latest history events for a reminder/followup."""
     conn = get_db()
+    if not _table_exists(conn, "item_history"):
+        return []
     rows = conn.execute(
         "SELECT * FROM item_history WHERE item_type = ? AND item_id = ? ORDER BY id DESC LIMIT ?",
         (item_type, item_id, limit),
@@ -376,6 +399,7 @@ def create_followup(
     status: str = "PENDING",
     reasoning: str = "",
     recurrence: str = None,
+    priority: str = "medium",
 ) -> dict:
     """Create a new followup with optional reasoning and recurrence."""
     conn = get_db()
@@ -389,14 +413,32 @@ def create_followup(
             f"(scores: {', '.join(str(s['_similarity']) for s in similar[:3])}). Consider updating instead."
         )
 
+    columns = {str(row["name"]) for row in conn.execute("PRAGMA table_info(followups)").fetchall()}
+    payload: dict[str, object] = {
+        "id": id,
+        "date": date,
+        "description": description,
+        "verification": verification,
+        "status": status,
+        "reasoning": reasoning,
+        "recurrence": recurrence,
+        "created_at": now,
+        "updated_at": now,
+    }
+    if "priority" in columns:
+        payload["priority"] = priority or "medium"
+
+    insert_columns = [column for column in payload if column in columns]
+    placeholders = ", ".join("?" for _ in insert_columns)
+
     try:
         conn.execute(
-            "INSERT INTO followups (id, date, description, verification, status, reasoning, recurrence, created_at, updated_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-            (id, date, description, verification, status, reasoning, recurrence, now, now),
+            f"INSERT INTO followups ({', '.join(insert_columns)}) VALUES ({placeholders})",
+            [payload[column] for column in insert_columns],
         )
         conn.commit()
-        fts_upsert("followup", id, id, f"{description} {verification} {reasoning}", "followup", commit=False)
+        if _table_exists(conn, "unified_search"):
+            fts_upsert("followup", id, id, f"{description} {verification} {reasoning}", "followup", commit=False)
     except sqlite3.IntegrityError:
         return {"error": f"Followup {id} already exists. Use update instead."}
 
@@ -441,7 +483,7 @@ def update_followup(
     conn.commit()
 
     new_row = conn.execute("SELECT * FROM followups WHERE id = ?", (id,)).fetchone()
-    if new_row:
+    if new_row and _table_exists(conn, "unified_search"):
         new_row_dict = dict(new_row)
         fts_upsert(
             "followup",
@@ -541,9 +583,10 @@ def complete_followup(id: str, result: str = "") -> dict:
             _reassign_item_identity(conn, "followup", id, archived_id)
             conn.commit()
 
-            conn.execute("DELETE FROM unified_search WHERE source = 'followup' AND source_id = ?", (id,))
+            if _table_exists(conn, "unified_search"):
+                conn.execute("DELETE FROM unified_search WHERE source = 'followup' AND source_id = ?", (id,))
             archived_row = conn.execute("SELECT * FROM followups WHERE id = ?", (archived_id,)).fetchone()
-            if archived_row:
+            if archived_row and _table_exists(conn, "unified_search"):
                 fts_upsert(
                     "followup",
                     archived_id,

--- a/src/scripts/deep-sleep/apply_findings.py
+++ b/src/scripts/deep-sleep/apply_findings.py
@@ -30,6 +30,8 @@ NEXO_CODE = Path(os.environ.get("NEXO_CODE", str(Path(__file__).resolve().parent
 if str(NEXO_CODE) not in sys.path:
     sys.path.insert(0, str(NEXO_CODE))
 
+import db as nexo_db
+
 DEEP_SLEEP_DIR = NEXO_HOME / "operations" / "deep-sleep"
 NEXO_DB = NEXO_HOME / "data" / "nexo.db"
 COGNITIVE_DB = NEXO_HOME / "data" / "cognitive.db"
@@ -294,25 +296,31 @@ def _touch_existing_followup(existing: dict, *, description: str, date: str = ""
     preferred_date = _prefer_due_date(existing.get("date", ""), date)
     if preferred_date and preferred_date != str(existing.get("date", "") or "") and "date" in cols:
         updates["date"] = preferred_date
-    if "reasoning" in cols and reasoning_note:
-        updates["reasoning"] = _append_note(existing.get("reasoning", ""), reasoning_note)
-    if "updated_at" in cols:
-        updates["updated_at"] = datetime.now().timestamp()
-
+    note = reasoning_note or "Deep Sleep matched this followup semantically."
+    changed = False
     if updates:
-        conn = sqlite3.connect(str(NEXO_DB))
-        set_clause = ", ".join(f"{column} = ?" for column in updates)
-        params = list(updates.values()) + [existing["id"]]
-        conn.execute(f"UPDATE followups SET {set_clause} WHERE id = ?", params)
-        conn.commit()
-        conn.close()
+        result = nexo_db.update_followup(
+            str(existing["id"]),
+            history_actor="deep-sleep",
+            history_event="updated",
+            history_note=note,
+            **updates,
+        )
+        if result.get("error"):
+            return {"success": False, "error": result["error"]}
+        changed = True
+    elif note:
+        note_result = nexo_db.add_followup_note(str(existing["id"]), note, actor="deep-sleep")
+        if note_result.get("error"):
+            return {"success": False, "error": note_result["error"]}
+        changed = True
 
     return {
         "success": True,
         "id": existing["id"],
         "outcome": "matched_existing_followup",
         "similarity": existing.get("_similarity", 1.0),
-        "updated_existing": bool(updates),
+        "updated_existing": changed,
     }
 
 
@@ -509,32 +517,27 @@ def create_followup(description: str, date: str = "", reasoning_note: str = "") 
                 reasoning_note=reasoning_note or "Deep Sleep matched this followup semantically.",
             )
 
-        now = datetime.now().timestamp()
         # Generate a deterministic ID
         fid = "NF-DS-" + hashlib.md5(description.encode()).hexdigest()[:8].upper()
-        columns = _table_columns(NEXO_DB, "followups")
-        payload = {
-            "id": fid,
-            "description": description,
-            "date": date,
-            "status": "PENDING",
-            "created_at": now,
-            "updated_at": now,
-        }
-        if "reasoning" in columns:
-            payload["reasoning"] = reasoning_note or "Deep Sleep v2 overnight analysis"
-        if "verification" in columns:
-            payload["verification"] = ""
-        insert_columns = [column for column in payload if column in columns]
-        values = [payload[column] for column in insert_columns]
+        existing = nexo_db.get_followup(fid)
+        if existing:
+            return _touch_existing_followup(
+                existing,
+                description=description,
+                date=date,
+                reasoning_note=reasoning_note or "Deep Sleep revisited this deterministic followup.",
+            )
 
-        conn = sqlite3.connect(str(NEXO_DB))
-        conn.execute(
-            f"INSERT OR IGNORE INTO followups ({', '.join(insert_columns)}) VALUES ({', '.join('?' for _ in insert_columns)})",
-            values,
+        followup_result = nexo_db.create_followup(
+            id=fid,
+            description=description,
+            date=date or None,
+            verification="",
+            reasoning=reasoning_note or "Deep Sleep v2 overnight analysis",
+            recurrence=None,
         )
-        conn.commit()
-        conn.close()
+        if followup_result.get("error"):
+            return {"success": False, "error": followup_result["error"]}
         return {"success": True, "id": fid, "outcome": "new_followup"}
     except Exception as e:
         return {"success": False, "error": str(e)}

--- a/src/scripts/nexo-daily-self-audit.py
+++ b/src/scripts/nexo-daily-self-audit.py
@@ -37,6 +37,7 @@ if str(NEXO_CODE) not in sys.path:
     sys.path.insert(0, str(NEXO_CODE))
 
 from agent_runner import AutomationBackendUnavailableError, run_automation_prompt
+import db as nexo_db
 from public_evolution_queue import queue_public_port_candidate
 
 LOG_DIR = NEXO_HOME / "logs"
@@ -251,42 +252,36 @@ def _ensure_followup(conn: sqlite3.Connection, *, prefix: str, description: str,
             "description": description,
             "verification": verification,
             "reasoning": reasoning,
-            "updated_at": now_epoch,
         }
         if "priority" in columns:
             update_fields["priority"] = priority
         closed_status = str(existing_id_row["status"] or "").upper()
         if closed_status.startswith("COMPLETED") or closed_status in {"DELETED", "ARCHIVED", "BLOCKED", "WAITING"}:
             update_fields["status"] = "PENDING"
-        ordered_updates = [name for name in update_fields.keys() if name in columns]
-        if ordered_updates:
-            assignments = ", ".join(f"{name} = ?" for name in ordered_updates)
-            conn.execute(
-                f"UPDATE followups SET {assignments} WHERE id = ?",
-                [update_fields[name] for name in ordered_updates] + [followup_id],
-            )
+        conn.commit()
+        result = nexo_db.update_followup(
+            followup_id,
+            history_actor="self-audit",
+            history_event="updated",
+            history_note="Daily self-audit refreshed canonical followup coverage.",
+            **update_fields,
+        )
+        if result.get("error"):
+            return ""
         return followup_id
 
-    values = {
-        "id": followup_id,
-        "date": "",
-        "description": description,
-        "verification": verification,
-        "status": "PENDING",
-        "reasoning": reasoning,
-        "recurrence": None,
-        "created_at": now_epoch,
-        "updated_at": now_epoch,
-    }
-    if "priority" in columns:
-        values["priority"] = priority
-
-    ordered_columns = [name for name in values.keys() if name in columns]
-    placeholders = ", ".join("?" for _ in ordered_columns)
-    conn.execute(
-        f"INSERT INTO followups ({', '.join(ordered_columns)}) VALUES ({placeholders})",
-        [values[name] for name in ordered_columns],
+    conn.commit()
+    result = nexo_db.create_followup(
+        id=followup_id,
+        description=description,
+        date=None,
+        verification=verification,
+        reasoning=reasoning,
+        recurrence=None,
+        priority=priority,
     )
+    if result.get("error"):
+        return ""
     return followup_id
 
 
@@ -319,7 +314,6 @@ def _append_note(existing: str, note: str) -> str:
 def _complete_matching_followup(conn: sqlite3.Connection, description: str, note: str) -> int:
     if not _table_exists(conn, "followups"):
         return 0
-    columns = _table_columns(conn, "followups")
     rows = conn.execute(
         """SELECT id, verification, reasoning
            FROM followups
@@ -329,21 +323,11 @@ def _complete_matching_followup(conn: sqlite3.Connection, description: str, note
         (description,),
     ).fetchall()
     completed = 0
-    now_epoch = datetime.now().timestamp()
+    conn.commit()
     for row in rows:
-        updates = {"status": "COMPLETED"}
-        if "updated_at" in columns:
-            updates["updated_at"] = now_epoch
-        if "verification" in columns:
-            updates["verification"] = _append_note(row["verification"], note)
-        if "reasoning" in columns:
-            updates["reasoning"] = _append_note(row["reasoning"], note)
-        assignments = ", ".join(f"{column} = ?" for column in updates)
-        conn.execute(
-            f"UPDATE followups SET {assignments} WHERE id = ?",
-            [updates[column] for column in updates] + [row["id"]],
-        )
-        completed += 1
+        result = nexo_db.complete_followup(str(row["id"]), note)
+        if not result.get("error"):
+            completed += 1
     return completed
 
 

--- a/src/scripts/nexo-followup-hygiene.py
+++ b/src/scripts/nexo-followup-hygiene.py
@@ -18,6 +18,13 @@ from datetime import datetime, date, timedelta
 from pathlib import Path
 
 NEXO_HOME = Path(os.environ.get("NEXO_HOME", str(Path.home() / ".nexo")))
+_script_dir = Path(__file__).resolve().parent
+_repo_src = _script_dir.parent
+NEXO_CODE = Path(os.environ.get("NEXO_CODE", str(_repo_src) if (_repo_src / "server.py").exists() else str(NEXO_HOME)))
+if str(NEXO_CODE) not in sys.path:
+    sys.path.insert(0, str(NEXO_CODE))
+
+import db as nexo_db
 
 NEXO_DB = NEXO_HOME / "data" / "nexo.db"
 COORD_DIR = NEXO_HOME / "coordination"
@@ -50,11 +57,31 @@ def main():
     dirty_r = conn.execute("SELECT COUNT(*) FROM reminders WHERE status LIKE 'COMPLETED %'").fetchone()[0]
 
     if dirty_f > 0:
-        conn.execute("UPDATE followups SET status='COMPLETED' WHERE status LIKE 'COMPLETED %'")
+        dirty_followups = conn.execute(
+            "SELECT id, status FROM followups WHERE status LIKE 'COMPLETED %'"
+        ).fetchall()
+        for row in dirty_followups:
+            nexo_db.update_followup(
+                str(row["id"]),
+                status="COMPLETED",
+                history_actor="followup-hygiene",
+                history_event="normalized",
+                history_note=f"Weekly hygiene normalized dirty status from {row['status']} to COMPLETED.",
+            )
         log(f"Normalized {dirty_f} dirty followup statuses")
 
     if dirty_r > 0:
-        conn.execute("UPDATE reminders SET status='COMPLETED' WHERE status LIKE 'COMPLETED %'")
+        dirty_reminders = conn.execute(
+            "SELECT id, status FROM reminders WHERE status LIKE 'COMPLETED %'"
+        ).fetchall()
+        for row in dirty_reminders:
+            nexo_db.update_reminder(
+                str(row["id"]),
+                status="COMPLETED",
+                history_actor="followup-hygiene",
+                history_event="normalized",
+                history_note=f"Weekly hygiene normalized dirty status from {row['status']} to COMPLETED.",
+            )
         log(f"Normalized {dirty_r} dirty reminder statuses")
 
     # 2. Flag stale followups (PENDING >14 days, no updates)

--- a/src/server.py
+++ b/src/server.py
@@ -620,12 +620,7 @@ def nexo_followup_create(id: str, description: str, date: str = "", verification
                     When completed, a new followup is auto-created with the next date. The completed one is archived with date suffix.
         priority: critical, high, medium, low (default: medium).
     """
-    result = handle_followup_create(id, description, date, verification, reasoning, recurrence)
-    if priority in ('critical', 'high', 'low') and 'created' in result:
-        from db import get_db
-        get_db().execute("UPDATE followups SET priority = ? WHERE id = ?", (priority, id))
-        get_db().commit()
-    return result
+    return handle_followup_create(id, description, date, verification, reasoning, recurrence, priority)
 
 
 @mcp.tool

--- a/src/tools_learnings.py
+++ b/src/tools_learnings.py
@@ -307,16 +307,26 @@ def handle_learning_add(category: str, title: str, content: str, reasoning: str 
         return f"ERROR: {result['error']}"
     if prevention or applies_to or review_days > 0 or priority != 'medium':
         initial_weight = {'critical': 0.9, 'high': 0.7, 'medium': 0.5, 'low': 0.3}[priority]
+        updated_at = now_epoch()
+        review_due_at = now_epoch() + (max(1, int(review_days)) * 86400)
         conn = get_db()
         conn.execute(
             "UPDATE learnings SET prevention = ?, applies_to = ?, status = COALESCE(status, 'active'), "
             "review_due_at = ?, updated_at = ?, priority = ?, weight = ? WHERE id = ?",
-            (prevention, applies_to, now_epoch() + (max(1, int(review_days)) * 86400), now_epoch(),
+            (prevention, applies_to, review_due_at, updated_at,
              priority, initial_weight, result["id"])
         )
         conn.commit()
-        result = conn.execute("SELECT * FROM learnings WHERE id = ?", (result["id"],)).fetchone()
         result = dict(result)
+        result.update({
+            "prevention": prevention,
+            "applies_to": applies_to,
+            "status": result.get("status") or "active",
+            "review_due_at": review_due_at,
+            "updated_at": updated_at,
+            "priority": priority,
+            "weight": initial_weight,
+        })
 
     # Cognitive ingest — embed learning for semantic search
     new_id = result["id"]

--- a/src/tools_reminders_crud.py
+++ b/src/tools_reminders_crud.py
@@ -181,7 +181,15 @@ def handle_reminder_delete(id: str, read_token: str = '') -> str:
 
 # ── Followups ──────────────────────────────────────────────────────────────────
 
-def handle_followup_create(id: str, description: str, date: str = '', verification: str = '', reasoning: str = '', recurrence: str = '') -> str:
+def handle_followup_create(
+    id: str,
+    description: str,
+    date: str = '',
+    verification: str = '',
+    reasoning: str = '',
+    recurrence: str = '',
+    priority: str = 'medium',
+) -> str:
     """Create a new NEXO followup. id must start with 'NF'.
 
     Args:
@@ -196,16 +204,25 @@ def handle_followup_create(id: str, description: str, date: str = '', verificati
     if not id.startswith('NF'):
         return f"ERROR: Followup ID must start with 'NF' (received: '{id}')."
 
-    result = create_followup(id=id, description=description, date=date or None, verification=verification, reasoning=reasoning, recurrence=recurrence or None)
+    result = create_followup(
+        id=id,
+        description=description,
+        date=date or None,
+        verification=verification,
+        reasoning=reasoning,
+        recurrence=recurrence or None,
+        priority=priority or "medium",
+    )
     if not result or "error" in result:
         error_msg = result.get("error", "unknown") if isinstance(result, dict) else "unknown"
         return f"ERROR: {error_msg}"
 
     date_str = date if date else 'no date'
     rec_str = f" Recurrence: {recurrence}." if recurrence else ""
+    priority_str = f" Priority: {priority or 'medium'}."
     warning = result.get("warning", "")
     warn_str = f"\n{warning}" if warning else ""
-    return f"Followup created. Date: {date_str}.{rec_str}{warn_str}"
+    return f"Followup created. Date: {date_str}.{priority_str}{rec_str}{warn_str}"
 
 
 def handle_followup_get(id: str) -> str:

--- a/tests/test_deep_sleep_apply.py
+++ b/tests/test_deep_sleep_apply.py
@@ -9,6 +9,8 @@ import sqlite3
 import sys
 from pathlib import Path
 
+import importlib
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 APPLY_PATH = REPO_ROOT / "src" / "scripts" / "deep-sleep" / "apply_findings.py"
@@ -18,7 +20,11 @@ def _load_apply_module(monkeypatch, home: Path):
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.setenv("NEXO_HOME", str(home / "nexo-home"))
     monkeypatch.setenv("NEXO_CODE", str(REPO_ROOT / "src"))
+    monkeypatch.setenv("NEXO_DB", str(home / "nexo-home" / "data" / "nexo.db"))
+    monkeypatch.setenv("NEXO_TEST_DB", str(home / "nexo-home" / "data" / "nexo.db"))
     sys.modules.pop("deep_sleep_apply_test", None)
+    for name in ("db", "db._core", "db._schema", "db._reminders", "db._fts"):
+        sys.modules.pop(name, None)
     spec = importlib.util.spec_from_file_location("deep_sleep_apply_test", APPLY_PATH)
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
@@ -245,26 +251,16 @@ def test_create_followup_consolidates_semantic_duplicates(monkeypatch, tmp_path)
     nexo_home = Path(os.environ["NEXO_HOME"])
     data_dir = nexo_home / "data"
     data_dir.mkdir(parents=True, exist_ok=True)
+    import db
 
-    conn = sqlite3.connect(str(data_dir / "nexo.db"))
-    conn.execute(
-        "CREATE TABLE followups (id TEXT PRIMARY KEY, description TEXT, date TEXT, status TEXT, verification TEXT, reasoning TEXT, created_at REAL, updated_at REAL)"
+    db.init_db()
+    db.create_followup(
+        id="NF-EXISTING",
+        description="Release reliability issue",
+        date="2026-04-08",
+        verification="",
+        reasoning="",
     )
-    conn.execute(
-        "INSERT INTO followups VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-        (
-            "NF-EXISTING",
-            "Release reliability issue",
-            "2026-04-08",
-            "PENDING",
-            "",
-            "",
-            1.0,
-            1.0,
-        ),
-    )
-    conn.commit()
-    conn.close()
 
     result = apply_mod.create_followup(
         "Add a release reliability validation checklist and script before publishing.",
@@ -278,10 +274,19 @@ def test_create_followup_consolidates_semantic_duplicates(monkeypatch, tmp_path)
 
     conn = sqlite3.connect(str(data_dir / "nexo.db"))
     row = conn.execute("SELECT description, date, reasoning FROM followups WHERE id = 'NF-EXISTING'").fetchone()
+    history = conn.execute(
+        """SELECT event_type, note, actor
+           FROM item_history
+           WHERE item_type = 'followup' AND item_id = 'NF-EXISTING'
+           ORDER BY id DESC"""
+    ).fetchall()
     conn.close()
     assert "validation checklist" in row[0].lower()
     assert row[1] == "2026-04-06"
-    assert "Recurring hotfix pattern" in row[2]
+    assert row[2] == ""
+    assert history[0][0] == "updated"
+    assert "Recurring hotfix pattern detected overnight." in history[0][1]
+    assert history[0][2] == "deep-sleep"
 
 
 def test_add_learning_reinforces_instead_of_duplication(monkeypatch, tmp_path):

--- a/tests/test_followup_hygiene.py
+++ b/tests/test_followup_hygiene.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REPO_SRC = REPO_ROOT / "src"
+SCRIPT_PATH = REPO_SRC / "scripts" / "nexo-followup-hygiene.py"
+
+
+def _load_hygiene_module():
+    module_name = "nexo_followup_hygiene_test"
+    sys.modules.pop(module_name, None)
+    for name in ("db", "db._core", "db._schema", "db._reminders", "db._fts"):
+        sys.modules.pop(name, None)
+    spec = importlib.util.spec_from_file_location(module_name, SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_followup_hygiene_normalizes_dirty_statuses_with_history(tmp_path, monkeypatch):
+    home = tmp_path / "nexo"
+    (home / "data").mkdir(parents=True, exist_ok=True)
+    (home / "logs").mkdir(parents=True, exist_ok=True)
+    (home / "coordination").mkdir(parents=True, exist_ok=True)
+
+    db_path = home / "data" / "nexo.db"
+    monkeypatch.setenv("NEXO_HOME", str(home))
+    monkeypatch.setenv("NEXO_CODE", str(REPO_SRC))
+    monkeypatch.setenv("NEXO_DB", str(db_path))
+    monkeypatch.setenv("NEXO_TEST_DB", str(db_path))
+    monkeypatch.setenv("HOME", str(home))
+
+    import db._core as db_core
+    import db._schema as db_schema
+    import db
+
+    importlib.reload(db_core)
+    importlib.reload(db_schema)
+    importlib.reload(db)
+    db.init_db()
+
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "INSERT INTO followups (id, date, description, verification, status, reasoning, recurrence, created_at, updated_at, priority) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        ("NF-DIRTY", "2026-04-01", "Dirty followup", "", "COMPLETED 2026-04-08", "", None, 1.0, 1.0, "medium"),
+    )
+    conn.execute(
+        "INSERT INTO reminders (id, date, description, status, category, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("R-DIRTY", "2026-04-01", "Dirty reminder", "COMPLETED 2026-04-08", "general", 1.0, 1.0),
+    )
+    conn.commit()
+    conn.close()
+
+    module = _load_hygiene_module()
+    module.main()
+
+    conn = sqlite3.connect(str(db_path))
+    followup_status = conn.execute("SELECT status FROM followups WHERE id = 'NF-DIRTY'").fetchone()[0]
+    reminder_status = conn.execute("SELECT status FROM reminders WHERE id = 'R-DIRTY'").fetchone()[0]
+    followup_history = conn.execute(
+        """SELECT event_type, note, actor
+           FROM item_history
+           WHERE item_type = 'followup' AND item_id = 'NF-DIRTY'
+           ORDER BY id DESC LIMIT 1"""
+    ).fetchone()
+    reminder_history = conn.execute(
+        """SELECT event_type, note, actor
+           FROM item_history
+           WHERE item_type = 'reminder' AND item_id = 'R-DIRTY'
+           ORDER BY id DESC LIMIT 1"""
+    ).fetchone()
+    conn.close()
+
+    assert followup_status == "COMPLETED"
+    assert reminder_status == "COMPLETED"
+    assert followup_history == (
+        "normalized",
+        "Weekly hygiene normalized dirty status from COMPLETED 2026-04-08 to COMPLETED.",
+        "followup-hygiene",
+    )
+    assert reminder_history == (
+        "normalized",
+        "Weekly hygiene normalized dirty status from COMPLETED 2026-04-08 to COMPLETED.",
+        "followup-hygiene",
+    )

--- a/tests/test_reminders_history.py
+++ b/tests/test_reminders_history.py
@@ -59,13 +59,16 @@ def test_followup_handlers_soft_delete_and_restore(isolated_db):
         date="2026-04-09",
         verification="Check the logs",
         reasoning="Regression coverage",
+        priority="high",
     )
     assert "Followup created." in created
+    assert "Priority: high." in created
 
     detail = reminders_tools.handle_followup_get("NF-HIST-1")
     token = _extract_read_token(detail)
     assert "Usage rules:" in detail
     assert "History:" in detail
+    assert "Priority: high" in detail
 
     deleted = reminders_tools.handle_followup_delete(id="NF-HIST-1", read_token=token)
     assert "soft-deleted" in deleted

--- a/tests/test_self_audit.py
+++ b/tests/test_self_audit.py
@@ -6,6 +6,7 @@ import importlib.util
 import json
 import os
 import sqlite3
+import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -23,6 +24,8 @@ if str(REPO_SRC) not in sys.path:
 def _load_self_audit_module():
     module_name = "nexo_daily_self_audit_test"
     sys.modules.pop(module_name, None)
+    for name in ("db", "db._core", "db._schema", "db._reminders", "db._fts", "tools_learnings"):
+        sys.modules.pop(name, None)
     spec = importlib.util.spec_from_file_location(module_name, SCRIPT_PATH)
     module = importlib.util.module_from_spec(spec)
     assert spec and spec.loader
@@ -552,62 +555,77 @@ def test_check_repair_changes_missing_learning_capture_creates_debt_and_followup
 
 
 def test_check_repair_changes_missing_learning_capture_auto_captures_when_runtime_can_create_learning(self_audit_env):
-    import importlib
-    import db._core as db_core
-    import db._schema as db_schema
-    import db
-
-    importlib.reload(db_core)
-    importlib.reload(db_schema)
-    importlib.reload(db)
-    db.init_db()
-    module = _load_self_audit_module()
-    module.findings.clear()
-
-    conn = sqlite3.connect(str(self_audit_env / "data" / "nexo.db"))
-    conn.execute(
-        """CREATE TABLE IF NOT EXISTS change_log (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            session_id TEXT,
-            created_at TEXT,
-            files TEXT,
-            what_changed TEXT,
-            why TEXT
-        )"""
+    db_path = self_audit_env / "data" / "nexo.db"
+    script = f"""
+import importlib, importlib.util, json, os, sqlite3, sys
+from pathlib import Path
+src = Path({str(REPO_SRC)!r})
+db_path = Path({str(db_path)!r})
+os.environ['NEXO_HOME'] = {str(self_audit_env)!r}
+os.environ['NEXO_CODE'] = str(src)
+os.environ['NEXO_DB'] = str(db_path)
+os.environ['NEXO_TEST_DB'] = str(db_path)
+os.environ['HOME'] = {str(self_audit_env)!r}
+if str(src) not in sys.path:
+    sys.path.insert(0, str(src))
+for name in ('db','db._core','db._schema','db._reminders','db._fts','tools_learnings','nexo_daily_self_audit_test'):
+    sys.modules.pop(name, None)
+import db
+db.init_db()
+spec = importlib.util.spec_from_file_location('nexo_daily_self_audit_test', src / 'scripts' / 'nexo-daily-self-audit.py')
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+conn = sqlite3.connect(str(db_path))
+conn.execute(\"\"\"CREATE TABLE IF NOT EXISTS change_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT,
+    created_at TEXT,
+    files TEXT,
+    what_changed TEXT,
+    why TEXT
+)\"\"\")
+conn.execute(\"\"\"INSERT INTO change_log (session_id, files, what_changed, why, created_at)
+   VALUES ('sid-1', ?, ?, ?, datetime('now'))\"\"\", (
+    '/repo/src/plugins/protocol.py',
+    'Fixed protocol task close regression',
+    'Repair canonical close path before the bug repeats',
+))
+conn.commit()
+conn.close()
+module.check_repair_changes_missing_learning_capture()
+conn = sqlite3.connect(str(db_path))
+learning = conn.execute(
+    \"SELECT category, title, applies_to, status FROM learnings WHERE category = 'nexo-ops' ORDER BY id DESC LIMIT 1\"
+).fetchone()
+debt = conn.execute(
+    \"SELECT COUNT(*) FROM protocol_debt WHERE debt_type = 'repair_change_without_learning_capture'\"
+).fetchone()[0]
+conn.close()
+print(json.dumps({{
+    'findings': module.findings,
+    'learning': learning,
+    'debt': debt,
+}}))
+"""
+    completed = subprocess.run(
+        ["python3", "-c", script],
+        check=True,
+        text=True,
+        capture_output=True,
     )
-    conn.execute(
-        """INSERT INTO change_log (session_id, files, what_changed, why, created_at)
-           VALUES ('sid-1', ?, ?, ?, datetime('now'))""",
-        (
-            "/repo/src/plugins/protocol.py",
-            "Fixed protocol task close regression",
-            "Repair canonical close path before the bug repeats",
-        ),
-    )
-    conn.commit()
-    conn.close()
+    payload = json.loads(completed.stdout.strip().splitlines()[-1])
 
-    module.check_repair_changes_missing_learning_capture()
+    assert payload["findings"]
+    assert payload["findings"][-1]["area"] == "learning-capture"
+    assert payload["findings"][-1]["severity"] == "INFO"
 
-    assert module.findings
-    assert module.findings[-1]["area"] == "learning-capture"
-    assert module.findings[-1]["severity"] == "INFO"
-
-    conn = sqlite3.connect(str(self_audit_env / "data" / "nexo.db"))
-    learning = conn.execute(
-        "SELECT category, title, applies_to, status FROM learnings WHERE category = 'nexo-ops' ORDER BY id DESC LIMIT 1"
-    ).fetchone()
-    debt = conn.execute(
-        "SELECT COUNT(*) FROM protocol_debt WHERE debt_type = 'repair_change_without_learning_capture'"
-    ).fetchone()[0]
-    conn.close()
-
+    learning = payload["learning"]
     assert learning is not None
     assert learning[0] == "nexo-ops"
     assert "protocol task close regression" in learning[1].lower()
     assert learning[2] == "/repo/src/plugins/protocol.py"
     assert learning[3] == "active"
-    assert debt == 0
+    assert payload["debt"] == 0
 
 
 def test_check_unformalized_mentions_creates_workflow_goal_inline(self_audit_env):
@@ -813,6 +831,56 @@ def test_check_memory_quality_scores_creates_followup(self_audit_env):
     followup = conn.execute("SELECT description FROM followups").fetchone()
     conn.close()
     assert "Refresh low-quality conditioned learnings" in followup[0]
+
+
+def test_self_audit_followup_helpers_record_history(self_audit_env):
+    import importlib
+    import db._core as db_core
+    import db._schema as db_schema
+    import db
+
+    importlib.reload(db_core)
+    importlib.reload(db_schema)
+    importlib.reload(db)
+    db.init_db()
+
+    module = _load_self_audit_module()
+    conn = sqlite3.connect(str(self_audit_env / "data" / "nexo.db"))
+    conn.row_factory = sqlite3.Row
+
+    followup_id = module._ensure_followup(
+        conn,
+        prefix="TEST",
+        description="Capture self-audit canonical followup",
+        verification="History exists",
+        reasoning="Self-audit regression coverage",
+        priority="high",
+    )
+    completed = module._complete_matching_followup(
+        conn,
+        "Capture self-audit canonical followup",
+        "Resolved inline by self-audit test.",
+    )
+    conn.close()
+
+    assert followup_id.startswith("NF-TEST-")
+    assert completed == 1
+
+    conn = sqlite3.connect(str(self_audit_env / "data" / "nexo.db"))
+    status = conn.execute("SELECT status FROM followups WHERE id = ?", (followup_id,)).fetchone()[0]
+    history = conn.execute(
+        """SELECT event_type, actor, note
+           FROM item_history
+           WHERE item_type = 'followup' AND item_id = ?
+           ORDER BY id ASC""",
+        (followup_id,),
+    ).fetchall()
+    conn.close()
+
+    assert status == "COMPLETED"
+    assert [row[0] for row in history] == ["created", "completed"]
+    assert history[-1][1] == "db"
+    assert "Resolved inline by self-audit test." in history[-1][2]
 
 
 def test_run_mechanical_autofixes_sanitizes_registry_and_refreshes_snapshots(self_audit_env, monkeypatch):


### PR DESCRIPTION
## Summary
- ensure internal core automation jobs preserve reminder/followup history instead of bypassing it silently
- move followup priority into the creation path so the MCP server no longer patches priority post-insert
- harden self-audit repair learning capture and add regression coverage for history-aware automation paths

## Verification
- pytest -q tests/test_reminders_history.py tests/test_deep_sleep_apply.py tests/test_self_audit.py tests/test_followup_hygiene.py
- pytest -q tests/test_migrations.py tests/test_dashboard_app.py tests/test_decision_reviews.py tests/test_tools_learnings.py
- python3 scripts/verify_release_readiness.py --ci
