### PR TITLE
fix: align dashboard history filters and proactive scans

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [3.1.5] - 2026-04-08
+
+### Dashboard + Proactive History Hygiene
+- The dashboard operations view now treats completed, deleted, and full-history reminder/followup states explicitly instead of collapsing everything into a vague “all” bucket. Agents and operators can inspect soft-deleted past work without losing the default open-work view.
+- Reminder and followup API list filters now normalize status families consistently, so `completed`, `deleted`, `history`, and `all` mean the same thing across dashboard screens and backend endpoints.
+- The proactive dashboard no longer surfaces deleted, waiting, cancelled, archived, blocked, or completed reminders/followups as live overdue work, which removes another source of “zombie state” from the public operational surface.
+- Added regression coverage for the new dashboard filters and for proactive scans ignoring inactive reminder/followup states.
+
 ## [3.1.4] - 2026-04-08
 
 ### History Integrity Hotfix

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 3.1.4
+version: 3.1.5
 metadata:
   openclaw:
     requires:

--- a/openclaw-plugin/package-lock.json
+++ b/openclaw-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "3.1.1",
+  "version": "3.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wazionapps/openclaw-memory-nexo-brain",
-      "version": "3.1.1",
+      "version": "3.1.5",
       "license": "AGPL-3.0",
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "3.1.4" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "3.1.5" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -161,6 +161,26 @@ def _deep_sleep_dir() -> Path:
     return nexo_home / "operations" / "deep-sleep"
 
 
+def _normalize_item_status(status: object) -> str:
+    return str(status or "").strip().upper()
+
+
+def _dashboard_status_matches(status: object, requested: str | None) -> bool:
+    normalized = _normalize_item_status(status)
+    requested_key = str(requested or "").strip().lower()
+    if not requested_key:
+        return normalized != "DELETED"
+    if requested_key in {"any", "history"}:
+        return True
+    if requested_key == "all":
+        return normalized != "DELETED"
+    if requested_key == "completed":
+        return normalized.startswith("COMPLETED")
+    if requested_key == "deleted":
+        return normalized == "DELETED"
+    return normalized == requested_key.upper()
+
+
 def _latest_periodic_summary(kind: str) -> dict:
     root = _deep_sleep_dir()
     pattern = f"*-{kind}-summary.json"
@@ -745,18 +765,8 @@ async def api_reminders_list(
 ):
     """List reminders."""
     db = _db()
-    reminders = db.get_reminders("any")
-    if status:
-        if status in {"any", "all", "history"}:
-            pass
-        elif status == "completed":
-            reminders = [r for r in reminders if str(r.get("status") or "").startswith("COMPLETED")]
-        elif status == "deleted":
-            reminders = [r for r in reminders if r.get("status") == "DELETED"]
-        else:
-            reminders = [r for r in reminders if r.get("status") == status]
-    else:
-        reminders = [r for r in reminders if r.get("status") != "DELETED"]
+    reminders = db.get_reminders("history")
+    reminders = [r for r in reminders if _dashboard_status_matches(r.get("status"), status)]
     if category:
         reminders = [r for r in reminders if r.get("category") == category]
     reminders = sorted(reminders, key=lambda item: item.get("updated_at") or item.get("created_at") or 0, reverse=True)
@@ -851,18 +861,8 @@ async def api_followups_list(
 ):
     """List followups."""
     db = _db()
-    followups = db.get_followups("any")
-    if status:
-        if status in {"any", "all", "history"}:
-            pass
-        elif status == "completed":
-            followups = [r for r in followups if str(r.get("status") or "").startswith("COMPLETED")]
-        elif status == "deleted":
-            followups = [r for r in followups if r.get("status") == "DELETED"]
-        else:
-            followups = [r for r in followups if r.get("status") == status]
-    else:
-        followups = [r for r in followups if r.get("status") != "DELETED"]
+    followups = db.get_followups("history")
+    followups = [r for r in followups if _dashboard_status_matches(r.get("status"), status)]
     followups = sorted(followups, key=lambda item: item.get("updated_at") or item.get("created_at") or 0, reverse=True)
     return {"count": len(followups), "followups": followups}
 

--- a/src/dashboard/templates/dashboard.html
+++ b/src/dashboard/templates/dashboard.html
@@ -211,6 +211,11 @@
 <script>
 function getToday() { return new Date().toISOString().split('T')[0]; }
 
+function isInactiveItemStatus(status) {
+  const normalized = String(status || '').trim().toUpperCase();
+  return normalized.startsWith('COMPLETED') || ['ARCHIVED', 'DELETED', 'BLOCKED', 'WAITING', 'CANCELLED'].includes(normalized);
+}
+
 // -----------------------------------------------------------------------
 // Modal
 // -----------------------------------------------------------------------
@@ -324,11 +329,10 @@ async function loadDashboardData() {
 
   // --- Overdue Items ---
   if (remindersData || followupsData) {
-    const excludeStatus = ['completed', 'COMPLETED', 'archived', 'deleted', 'DELETED', 'blocked', 'waiting'];
     const reminders = (remindersData?.reminders || []).filter(r =>
-      !excludeStatus.includes(r.status) && r.date && r.date <= today);
+      !isInactiveItemStatus(r.status) && r.date && r.date <= today);
     const followups = (followupsData?.followups || []).filter(f =>
-      !excludeStatus.includes(f.status) && f.date && f.date <= today);
+      !isInactiveItemStatus(f.status) && f.date && f.date <= today);
     const total = reminders.length + followups.length;
     const el = document.getElementById('overdue-count');
     el.textContent = total;
@@ -375,13 +379,11 @@ async function loadDashboardData() {
   const agendaList = document.getElementById('agenda-list');
   const agendaItems = [];
   if (remindersData?.reminders) {
-    const excludeStatus = ['completed', 'COMPLETED', 'archived', 'deleted', 'DELETED'];
-    remindersData.reminders.filter(r => !excludeStatus.includes(r.status) && r.date && r.date <= today)
+    remindersData.reminders.filter(r => !isInactiveItemStatus(r.status) && r.date && r.date <= today)
       .forEach(r => agendaItems.push({ text: r.description, type: 'reminder', date: r.date }));
   }
   if (followupsData?.followups) {
-    const excludeStatus = ['completed', 'COMPLETED', 'archived', 'deleted', 'DELETED'];
-    followupsData.followups.filter(f => !excludeStatus.includes(f.status) && f.date && f.date <= today)
+    followupsData.followups.filter(f => !isInactiveItemStatus(f.status) && f.date && f.date <= today)
       .forEach(f => agendaItems.push({ text: f.description, type: 'followup', date: f.date }));
   }
   if (agendaItems.length > 0) {

--- a/src/dashboard/templates/operations.html
+++ b/src/dashboard/templates/operations.html
@@ -27,7 +27,9 @@
 >
   <option value="PENDING">Pending</option>
   <option value="all">All</option>
-  <option value="COMPLETED">Completed</option>
+  <option value="completed">Completed</option>
+  <option value="deleted">Deleted</option>
+  <option value="history">History</option>
 </select>
 {% endblock %}
 
@@ -328,7 +330,7 @@ function renderGroupedItems(items, type, containerId) {
 // -----------------------------------------------------------------------
 async function loadOpsData() {
   const status = document.getElementById('ops-status').value;
-  const statusParam = status !== 'all' ? '?status=' + status : '';
+  const statusParam = status ? '?status=' + encodeURIComponent(status) : '';
 
   const [remData, fupData] = await Promise.all([
     fetchJSON('/api/reminders' + statusParam),
@@ -429,7 +431,7 @@ function deleteItem(id, type) {
       const res = await fetch(url, { method: 'DELETE' });
       const data = await res.json();
       if (data.success) {
-        opsToast('Deleted ' + id);
+        opsToast('Marked ' + id + ' as deleted');
         loadOpsData();
       } else {
         opsToast(data.error || data.detail || 'Delete failed (HTTP ' + res.status + ')', 'error');
@@ -438,7 +440,7 @@ function deleteItem(id, type) {
       opsToast('Delete error: ' + err.message, 'error');
     }
   };
-  document.getElementById('confirm-message').textContent = 'Delete ' + id + '? This cannot be undone.';
+  document.getElementById('confirm-message').textContent = 'Delete ' + id + '? This marks it as DELETED and keeps its history.';
   document.getElementById('confirm-modal').classList.remove('hidden');
 }
 

--- a/src/scripts/nexo-proactive-dashboard.py
+++ b/src/scripts/nexo-proactive-dashboard.py
@@ -22,6 +22,7 @@ from pathlib import Path
 NEXO_HOME = Path(os.environ.get("NEXO_HOME", str(Path.home() / ".nexo")))
 
 NEXO_DB = NEXO_HOME / "data" / "nexo.db"
+INACTIVE_STATUSES = {"DELETED", "ARCHIVED", "BLOCKED", "WAITING", "CANCELLED"}
 
 
 def get_db():
@@ -30,21 +31,27 @@ def get_db():
     return conn
 
 
+def _is_open_status(status: object) -> bool:
+    normalized = str(status or "").strip().upper()
+    if normalized.startswith("COMPLETED"):
+        return False
+    return normalized not in INACTIVE_STATUSES
+
+
 def check_overdue_followups() -> list[dict]:
     """Find followups that are overdue and not completed."""
     conn = get_db()
-    now_epoch = datetime.now().timestamp()
     rows = conn.execute("""
-        SELECT id, description, date, created_at, reasoning
+        SELECT id, description, date, created_at, reasoning, status
         FROM followups
-        WHERE status NOT LIKE 'COMPLETED%'
-        AND status NOT IN ('DELETED','archived','blocked','waiting')
-        AND date IS NOT NULL AND date != ''
+        WHERE date IS NOT NULL AND date != ''
         ORDER BY date ASC
     """).fetchall()
     conn.close()
     alerts = []
     for r in rows:
+        if not _is_open_status(r["status"]):
+            continue
         due_str = r["date"]
         try:
             due = datetime.fromisoformat(due_str) if due_str else None
@@ -68,13 +75,14 @@ def check_overdue_reminders() -> list[dict]:
     rows = conn.execute("""
         SELECT id, description, date, status
         FROM reminders
-        WHERE status NOT IN ('COMPLETED', 'CANCELLED')
-        AND date IS NOT NULL AND date != ''
+        WHERE date IS NOT NULL AND date != ''
         ORDER BY date ASC
     """).fetchall()
     conn.close()
     alerts = []
     for r in rows:
+        if not _is_open_status(r["status"]):
+            continue
         due_str = r["date"]
         try:
             due = datetime.fromisoformat(due_str) if due_str else None
@@ -96,16 +104,17 @@ def check_stale_ideas() -> list[dict]:
     """Find reminders/ideas without due dates that have been sitting for too long."""
     conn = get_db()
     rows = conn.execute("""
-        SELECT id, description, created_at
+        SELECT id, description, created_at, status
         FROM reminders
-        WHERE status NOT IN ('COMPLETED', 'CANCELLED')
-        AND (date IS NULL OR date = '')
+        WHERE date IS NULL OR date = ''
         ORDER BY created_at ASC
     """).fetchall()
     conn.close()
     alerts = []
     stale_count = 0
     for r in rows:
+        if not _is_open_status(r["status"]):
+            continue
         try:
             # created_at is epoch float
             created = datetime.fromtimestamp(r["created_at"])

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -181,3 +181,45 @@ def test_dashboard_move_preserves_source_as_deleted(isolated_db):
     assert old_row["status"] == "DELETED"
     assert any(event["event_type"] == "deleted" for event in old_row["history"])
     assert any("dashboard move" in (event.get("note") or "") for event in new_row["history"])
+
+
+def test_dashboard_status_filters_distinguish_all_deleted_and_history(isolated_db):
+    client = TestClient(app)
+
+    active = client.post(
+        "/api/reminders",
+        json={"description": "Active reminder", "date": "2026-04-09", "category": "tasks"},
+    ).json()["reminder"]["id"]
+    completed = client.post(
+        "/api/reminders",
+        json={"description": "Completed reminder", "date": "2026-04-10", "category": "tasks"},
+    ).json()["reminder"]["id"]
+    deleted = client.post(
+        "/api/reminders",
+        json={"description": "Deleted reminder", "date": "2026-04-11", "category": "tasks"},
+    ).json()["reminder"]["id"]
+
+    client.put(f"/api/reminders/{completed}", json={"status": "COMPLETED"})
+    client.delete(f"/api/reminders/{deleted}")
+
+    all_payload = client.get("/api/reminders?status=all").json()["reminders"]
+    deleted_payload = client.get("/api/reminders?status=deleted").json()["reminders"]
+    history_payload = client.get("/api/reminders?status=history").json()["reminders"]
+
+    all_ids = {item["id"] for item in all_payload}
+    deleted_ids = {item["id"] for item in deleted_payload}
+    history_ids = {item["id"] for item in history_payload}
+
+    assert active in all_ids
+    assert completed in all_ids
+    assert deleted not in all_ids
+    assert deleted_ids == {deleted}
+    assert {active, completed, deleted}.issubset(history_ids)
+
+
+def test_operations_page_exposes_deleted_and_history_filters():
+    client = TestClient(app)
+    page = client.get("/ops")
+    assert page.status_code == 200
+    assert 'value="deleted"' in page.text
+    assert 'value="history"' in page.text

--- a/tests/test_proactive_dashboard.py
+++ b/tests/test_proactive_dashboard.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REPO_SRC = REPO_ROOT / "src"
+SCRIPT_PATH = REPO_SRC / "scripts" / "nexo-proactive-dashboard.py"
+
+
+def _load_module(module_name: str = "nexo_proactive_dashboard_test"):
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_proactive_dashboard_ignores_deleted_waiting_and_cancelled_items(tmp_path, monkeypatch):
+    home = tmp_path / "nexo"
+    data_dir = home / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    db_path = data_dir / "nexo.db"
+
+    monkeypatch.setenv("NEXO_HOME", str(home))
+    monkeypatch.setenv("NEXO_CODE", str(REPO_SRC))
+    monkeypatch.setenv("NEXO_DB", str(db_path))
+
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "CREATE TABLE followups (id TEXT, description TEXT, date TEXT, created_at REAL, reasoning TEXT, status TEXT)"
+    )
+    conn.execute(
+        "CREATE TABLE reminders (id TEXT, description TEXT, date TEXT, created_at REAL, status TEXT)"
+    )
+    conn.executemany(
+        "INSERT INTO followups VALUES (?, ?, ?, ?, ?, ?)",
+        [
+            ("NF-OPEN", "Open followup", "2026-04-01", 1.0, "", "PENDING"),
+            ("NF-DELETED", "Deleted followup", "2026-04-01", 1.0, "", "DELETED"),
+            ("NF-WAITING", "Waiting followup", "2026-04-01", 1.0, "", "waiting"),
+        ],
+    )
+    conn.executemany(
+        "INSERT INTO reminders VALUES (?, ?, ?, ?, ?)",
+        [
+            ("R-OPEN", "Open reminder", "2026-04-01", 1.0, "PENDING"),
+            ("R-CANCELLED", "Cancelled reminder", "2026-04-01", 1.0, "CANCELLED"),
+            ("R-DELETED", "Deleted reminder", "", 1.0, "DELETED"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    module = _load_module()
+    overdue_followups = module.check_overdue_followups()
+    overdue_reminders = module.check_overdue_reminders()
+    stale_ideas = module.check_stale_ideas()
+
+    assert [item["id"] for item in overdue_followups] == ["NF-OPEN"]
+    assert [item["id"] for item in overdue_reminders] == ["R-OPEN"]
+    assert stale_ideas == []


### PR DESCRIPTION
## Summary\n- make dashboard reminder/followup filters explicit for completed, deleted, history, and all states\n- stop proactive overdue scans from reviving inactive reminder/followup rows\n- bump release artifacts and website to v3.1.5\n\n## Testing\n- pytest -q tests/test_dashboard_app.py tests/test_proactive_dashboard.py tests/test_reminders_history.py tests/test_followup_hygiene.py\n- PYTHONPATH=src python3 scripts/verify_release_readiness.py --nexo-home /Users/franciscoc/claude