### PR TITLE
fix: archive abandoned deep sleep followups

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.1.6] - 2026-04-08
+
+### Deep Sleep Abandoned Followups Hotfix
+- Deep Sleep no longer turns abandoned-project discoveries into live `PENDING` followups. New `[Abandoned]` items are created directly as archived historical context, which keeps the trail visible without polluting active work queues.
+- The archived creation path now records an explicit followup-history note so operators and agents can see that the item was intentionally stored as history instead of silently disappearing.
+- Added regression coverage so abandoned followups stay archived and non-actionable across future releases.
+
 ## [3.1.5] - 2026-04-08
 
 ### Dashboard + Proactive History Hygiene

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 3.1.5
+version: 3.1.6
 metadata:
   openclaw:
     requires:

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "3.1.5" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "3.1.6" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/src/scripts/deep-sleep/apply_findings.py
+++ b/src/scripts/deep-sleep/apply_findings.py
@@ -284,7 +284,14 @@ def _find_similar_followup(description: str, threshold: float = 0.58) -> dict | 
     return candidates[0]
 
 
-def _touch_existing_followup(existing: dict, *, description: str, date: str = "", reasoning_note: str = "") -> dict:
+def _touch_existing_followup(
+    existing: dict,
+    *,
+    description: str,
+    date: str = "",
+    reasoning_note: str = "",
+    status: str = "",
+) -> dict:
     cols = _table_columns(NEXO_DB, "followups")
     if not cols:
         return {"success": False, "error": "followups table not found"}
@@ -296,6 +303,9 @@ def _touch_existing_followup(existing: dict, *, description: str, date: str = ""
     preferred_date = _prefer_due_date(existing.get("date", ""), date)
     if preferred_date and preferred_date != str(existing.get("date", "") or "") and "date" in cols:
         updates["date"] = preferred_date
+    desired_status = (status or "").strip()
+    if desired_status and "status" in cols and desired_status != str(existing.get("status", "") or ""):
+        updates["status"] = desired_status
     note = reasoning_note or "Deep Sleep matched this followup semantically."
     changed = False
     if updates:
@@ -503,19 +513,23 @@ def add_learning(category: str, title: str, content: str) -> dict:
         return {"success": False, "error": str(e)}
 
 
-def create_followup(description: str, date: str = "", reasoning_note: str = "") -> dict:
+def create_followup(description: str, date: str = "", reasoning_note: str = "", status: str = "PENDING") -> dict:
     """Create a followup in nexo.db. Returns result dict."""
     if not NEXO_DB.exists():
         return {"success": False, "error": "nexo.db not found"}
     try:
-        matched = _find_similar_followup(description)
-        if matched:
-            return _touch_existing_followup(
-                matched,
-                description=description,
-                date=date,
-                reasoning_note=reasoning_note or "Deep Sleep matched this followup semantically.",
-            )
+        desired_status = (status or "PENDING").strip() or "PENDING"
+        is_abandoned = description.strip().startswith("[Abandoned]")
+        if not is_abandoned:
+            matched = _find_similar_followup(description)
+            if matched:
+                return _touch_existing_followup(
+                    matched,
+                    description=description,
+                    date=date,
+                    reasoning_note=reasoning_note or "Deep Sleep matched this followup semantically.",
+                    status=desired_status,
+                )
 
         # Generate a deterministic ID
         fid = "NF-DS-" + hashlib.md5(description.encode()).hexdigest()[:8].upper()
@@ -526,6 +540,7 @@ def create_followup(description: str, date: str = "", reasoning_note: str = "") 
                 description=description,
                 date=date,
                 reasoning_note=reasoning_note or "Deep Sleep revisited this deterministic followup.",
+                status=desired_status,
             )
 
         followup_result = nexo_db.create_followup(
@@ -533,11 +548,18 @@ def create_followup(description: str, date: str = "", reasoning_note: str = "") 
             description=description,
             date=date or None,
             verification="",
+            status=desired_status,
             reasoning=reasoning_note or "Deep Sleep v2 overnight analysis",
             recurrence=None,
         )
         if followup_result.get("error"):
             return {"success": False, "error": followup_result["error"]}
+        if desired_status != "PENDING":
+            nexo_db.add_followup_note(
+                fid,
+                f"Deep Sleep created this followup directly as {desired_status}.",
+                actor="deep-sleep",
+            )
         return {"success": True, "id": fid, "outcome": "new_followup"}
     except Exception as e:
         return {"success": False, "error": str(e)}
@@ -733,7 +755,9 @@ def create_abandoned_followups(synthesis: dict) -> list[dict]:
             continue
         result = create_followup(
             description=f"[Abandoned] {proj.get('description', '')}",
-            date=""  # No date — it's a discovered gap
+            date="",  # No date — it's a discovered gap
+            reasoning_note="Deep Sleep marked this as abandoned. Keep it as archived history, not active work.",
+            status="archived",
         )
         results.append(result)
     return results

--- a/tests/test_deep_sleep_apply.py
+++ b/tests/test_deep_sleep_apply.py
@@ -289,6 +289,53 @@ def test_create_followup_consolidates_semantic_duplicates(monkeypatch, tmp_path)
     assert history[0][2] == "deep-sleep"
 
 
+def test_abandoned_followups_are_archived_not_active(monkeypatch, tmp_path):
+    apply_mod = _load_apply_module(monkeypatch, tmp_path)
+    nexo_home = Path(os.environ["NEXO_HOME"])
+    data_dir = nexo_home / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    import db
+
+    db.init_db()
+
+    results = apply_mod.create_abandoned_followups(
+        {
+            "abandoned_projects": [
+                {
+                    "description": "Canales YouTube de Francisco — preguntados pero no respondidos",
+                    "has_followup": False,
+                    "recommendation": "Archive as historical context.",
+                }
+            ]
+        }
+    )
+
+    assert results
+    assert results[0]["success"] is True
+
+    conn = sqlite3.connect(str(data_dir / "nexo.db"))
+    row = conn.execute(
+        "SELECT id, status, date, description FROM followups WHERE description LIKE '[Abandoned]%'"
+    ).fetchone()
+    history = conn.execute(
+        """SELECT event_type, note, actor
+           FROM item_history
+           WHERE item_type = 'followup' AND item_id = ?
+           ORDER BY id ASC""",
+        (row[0],),
+    ).fetchall()
+    conn.close()
+
+    assert row[1] == "archived"
+    assert row[2] is None
+    assert row[3].startswith("[Abandoned]")
+    assert any(event == "created" for event, _, _ in history)
+    assert any(
+        event == "note" and "directly as archived" in note and actor == "deep-sleep"
+        for event, note, actor in history
+    )
+
+
 def test_add_learning_reinforces_instead_of_duplication(monkeypatch, tmp_path):
     apply_mod = _load_apply_module(monkeypatch, tmp_path)
     nexo_home = Path(os.environ["NEXO_HOME"])


### PR DESCRIPTION
## Summary\n- archive Deep Sleep  findings as historical followups instead of live pending work\n- record an explicit history note when Deep Sleep creates an archived abandoned followup\n- add regression coverage and bump release artifacts to 3.1.6\n\n## Verification\n- pytest -q tests/test_deep_sleep_apply.py\n- python3 scripts/verify_release_readiness.py --nexo-home /Users/franciscoc/claude