### PR TITLE
Stabilize hot context release for v3.1.8

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [3.1.8] - 2026-04-08
+
+### Hot Context Release Stabilization
+- Promoted the hot-context memory release as `v3.1.8` after the first `v3.1.7` tag exposed CI-only regressions before public publication. The shipped release now matches the green test suite and release artifacts instead of leaving an orphan tag as the public truth.
+- Hardened the modular `db` package reload path so runtime/test DB switches no longer leak stale submodule state. `reload(db)` now refreshes the concrete submodules, and package-level core access resolves against the current live module state instead of captured references.
+- Made hot-context capture additive against partial/minimal schemas. If `hot_context` / `recent_events` tables are unavailable, reminder/followup creation and self-audit flows now degrade safely instead of crashing.
+- Updated learning and hot-context DB helpers to resolve `db._core` dynamically, eliminating connection drift that only appeared under the full suite and release CI order.
+
 ## [3.1.7] - 2026-04-08
 
 ### Hot Context Memory + Dashboard History Discipline

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 3.1.7
+version: 3.1.8
 metadata:
   openclaw:
     requires:

--- a/openclaw-plugin/package-lock.json
+++ b/openclaw-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wazionapps/openclaw-memory-nexo-brain",
-      "version": "3.1.7",
+      "version": "3.1.8",
       "license": "AGPL-3.0",
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "3.1.7" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "3.1.8" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -3,7 +3,54 @@
 This package replaces the monolithic db.py. All public functions are
 re-exported here for full backwards compatibility:
     from db import get_db, create_learning, ...
+
+Important:
+`importlib.reload(db)` must also refresh the concrete submodules. The test
+suite and several runtime repair flows rely on switching database paths or
+runtime roots mid-process. If the package only re-exported functions from
+already-imported submodules, those callables would keep pointing at stale
+module state (especially old `db._core` connection globals).
 """
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+
+def _load_submodule(name: str):
+    """Import or reload a db submodule and expose it on the package."""
+    module = sys.modules.get(name)
+    if module is None:
+        return importlib.import_module(name)
+    return importlib.reload(module)
+
+
+def _module(name: str):
+    module = sys.modules.get(name)
+    if module is None:
+        module = importlib.import_module(name)
+    return module
+
+
+_core = _load_submodule("db._core")
+_fts = _load_submodule("db._fts")
+_schema = _load_submodule("db._schema")
+_sessions = _load_submodule("db._sessions")
+_reminders = _load_submodule("db._reminders")
+_learnings = _load_submodule("db._learnings")
+_credentials = _load_submodule("db._credentials")
+_tasks = _load_submodule("db._tasks")
+_entities = _load_submodule("db._entities")
+_episodic = _load_submodule("db._episodic")
+_evolution = _load_submodule("db._evolution")
+_cron_runs = _load_submodule("db._cron_runs")
+_protocol = _load_submodule("db._protocol")
+_workflow = _load_submodule("db._workflow")
+_watchers = _load_submodule("db._watchers")
+_personal_scripts = _load_submodule("db._personal_scripts")
+_skills = _load_submodule("db._skills")
+_hot_context = _load_submodule("db._hot_context")
 
 # Core: connection, constants, init, utils
 from db._core import (
@@ -150,3 +197,27 @@ from db._hot_context import (
     build_pre_action_context, format_pre_action_context_bundle,
     resolve_hot_context,
 )
+
+
+def get_db():
+    return _module("db._core").get_db()
+
+
+def close_db():
+    return _module("db._core").close_db()
+
+
+def init_db():
+    return _module("db._core").init_db()
+
+
+def now_epoch():
+    return _module("db._core").now_epoch()
+
+
+def run_migrations():
+    return _module("db._schema").run_migrations()
+
+
+def get_schema_version():
+    return _module("db._schema").get_schema_version()

--- a/src/db/_hot_context.py
+++ b/src/db/_hot_context.py
@@ -2,15 +2,38 @@ from __future__ import annotations
 """NEXO DB — recent events + hot context for 24h operational continuity."""
 
 import json
+import importlib
 import re
+import sqlite3
+import sys
 import unicodedata
 from typing import Any
 
-from db._core import get_db, now_epoch
+
+def _core():
+    module = sys.modules.get("db._core")
+    if module is None:
+        module = importlib.import_module("db._core")
+    return module
 
 DEFAULT_CONTEXT_TTL_HOURS = 24
 MAX_CONTEXT_TTL_HOURS = 7 * 24
 ACTIVE_CONTEXT_STATES = {"active", "waiting_user", "waiting_third_party", "blocked"}
+
+
+def _table_exists(conn, table_name: str) -> bool:
+    try:
+        row = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name = ? LIMIT 1",
+            (table_name,),
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return False
+    return row is not None
+
+
+def _hot_context_tables_available(conn) -> bool:
+    return _table_exists(conn, "hot_context") and _table_exists(conn, "recent_events")
 
 
 def _serialize_metadata(metadata: dict[str, Any] | None) -> str:
@@ -84,8 +107,10 @@ def derive_context_key(
 
 
 def cleanup_expired_hot_context(now: float | None = None) -> dict[str, int]:
-    conn = get_db()
-    ts = now if now is not None else now_epoch()
+    conn = _core().get_db()
+    if not _hot_context_tables_available(conn):
+        return {"deleted_events": 0, "deleted_contexts": 0}
+    ts = now if now is not None else _core().now_epoch()
     deleted_events = conn.execute(
         "DELETE FROM recent_events WHERE expires_at < ?",
         (ts,),
@@ -123,8 +148,10 @@ def remember_hot_context(
     if not clean_title:
         return {"error": "title is required"}
 
-    conn = get_db()
-    now = now_epoch()
+    conn = _core().get_db()
+    if not _table_exists(conn, "hot_context"):
+        return {"skipped": True, "reason": "hot_context table unavailable"}
+    now = _core().now_epoch()
     event_ts = float(last_event_at if last_event_at is not None else now)
     ttl = clamp_ttl_hours(ttl_hours)
     expires_at = max(event_ts, now) + ttl * 3600
@@ -226,8 +253,10 @@ def record_recent_event(
     if not clean_event:
         return {"error": "event_type is required"}
 
-    conn = get_db()
-    now = now_epoch()
+    conn = _core().get_db()
+    if not _table_exists(conn, "recent_events"):
+        return {"skipped": True, "reason": "recent_events table unavailable"}
+    now = _core().now_epoch()
     event_ts = float(created_at if created_at is not None else now)
     ttl = clamp_ttl_hours(ttl_hours)
     expires_at = max(event_ts, now) + ttl * 3600
@@ -282,6 +311,19 @@ def capture_context_event(
     created_at: float | None = None,
 ) -> dict:
     cleanup_expired_hot_context()
+    conn = _core().get_db()
+    if not _hot_context_tables_available(conn):
+        return {
+            "context_key": derive_context_key(
+                context_key=context_key,
+                topic=topic,
+                title=context_title or title or summary,
+                source_type=source_type,
+                source_id=source_id,
+            ),
+            "context": {"skipped": True, "reason": "hot_context tables unavailable"},
+            "event": {"skipped": True, "reason": "hot_context tables unavailable"},
+        }
     clean_key = derive_context_key(
         context_key=context_key,
         topic=topic,
@@ -324,7 +366,9 @@ def capture_context_event(
 
 def get_hot_context(context_key: str, include_events: bool = False, limit: int = 10) -> dict | None:
     cleanup_expired_hot_context()
-    conn = get_db()
+    conn = _core().get_db()
+    if not _table_exists(conn, "hot_context"):
+        return None
     row = conn.execute(
         "SELECT * FROM hot_context WHERE context_key = ?",
         ((context_key or "").strip(),),
@@ -363,8 +407,10 @@ def _score_text_match(query_tokens: set[str], haystack: str) -> float:
 
 def search_hot_context(query: str = "", *, hours: int = DEFAULT_CONTEXT_TTL_HOURS, limit: int = 10, state: str = "") -> list[dict]:
     cleanup_expired_hot_context()
-    conn = get_db()
-    ts = now_epoch() - clamp_ttl_hours(hours) * 3600
+    conn = _core().get_db()
+    if not _table_exists(conn, "hot_context"):
+        return []
+    ts = _core().now_epoch() - clamp_ttl_hours(hours) * 3600
     if state.strip():
         rows = conn.execute(
             "SELECT * FROM hot_context WHERE last_event_at >= ? AND state = ? ORDER BY last_event_at DESC LIMIT 200",
@@ -391,7 +437,8 @@ def search_hot_context(query: str = "", *, hours: int = DEFAULT_CONTEXT_TTL_HOUR
         score = _score_text_match(query_tokens, combined) if query_tokens else 0.5
         if query_tokens and score <= 0:
             continue
-        recency_boost = max(0.0, 1.0 - ((now_epoch() - float(item.get("last_event_at") or now_epoch())) / (clamp_ttl_hours(hours) * 3600)))
+        current_ts = _core().now_epoch()
+        recency_boost = max(0.0, 1.0 - ((current_ts - float(item.get("last_event_at") or current_ts)) / (clamp_ttl_hours(hours) * 3600)))
         item["_score"] = round(score + recency_boost * 0.35, 4)
         scored.append(item)
     scored.sort(key=lambda item: (item["_score"], item.get("last_event_at", 0)), reverse=True)
@@ -408,8 +455,10 @@ def search_recent_events(
     exclude_source: tuple[str, str] | None = None,
 ) -> list[dict]:
     cleanup_expired_hot_context()
-    conn = get_db()
-    ts = now_epoch() - clamp_ttl_hours(hours) * 3600
+    conn = _core().get_db()
+    if not _table_exists(conn, "recent_events"):
+        return []
+    ts = _core().now_epoch() - clamp_ttl_hours(hours) * 3600
     rows = conn.execute(
         "SELECT * FROM recent_events WHERE created_at >= ? ORDER BY created_at DESC LIMIT 400",
         (ts,),
@@ -444,7 +493,8 @@ def search_recent_events(
         score = _score_text_match(query_tokens, combined) if query_tokens else 0.35
         if query_tokens and score <= 0 and item.get("context_key") not in context_filter:
             continue
-        recency_boost = max(0.0, 1.0 - ((now_epoch() - float(item.get("created_at") or now_epoch())) / (clamp_ttl_hours(hours) * 3600)))
+        current_ts = _core().now_epoch()
+        recency_boost = max(0.0, 1.0 - ((current_ts - float(item.get("created_at") or current_ts)) / (clamp_ttl_hours(hours) * 3600)))
         item["_score"] = round(score + recency_boost * 0.45 + session_bonus, 4)
         scored.append(item)
     scored.sort(key=lambda item: (item["_score"], item.get("created_at", 0)), reverse=True)
@@ -452,7 +502,9 @@ def search_recent_events(
 
 
 def _find_related_items(table: str, query: str, *, hours: int = DEFAULT_CONTEXT_TTL_HOURS, limit: int = 5) -> list[dict]:
-    conn = get_db()
+    conn = _core().get_db()
+    if not _table_exists(conn, table):
+        return []
     query_tokens = _tokenize(query)
     if not query_tokens:
         return []

--- a/src/db/_learnings.py
+++ b/src/db/_learnings.py
@@ -1,8 +1,16 @@
 from __future__ import annotations
 """NEXO DB — Learnings module."""
+import importlib
 import re, time
-from db._core import get_db, now_epoch
+import sys
 from db._fts import fts_upsert, fts_search
+
+
+def _core():
+    module = sys.modules.get("db._core")
+    if module is None:
+        module = importlib.import_module("db._core")
+    return module
 
 # ── Learnings ──────────────────────────────────────────────────────
 
@@ -19,8 +27,8 @@ def create_learning(
     last_reviewed_at: float | None = None,
 ) -> dict:
     """Create a new learning entry with optional reasoning."""
-    conn = get_db()
-    now = now_epoch()
+    conn = _core().get_db()
+    now = _core().now_epoch()
     cursor = conn.execute(
         "INSERT INTO learnings "
         "(category, title, content, reasoning, prevention, applies_to, supersedes_id, status, review_due_at, last_reviewed_at, created_at, updated_at) "
@@ -39,7 +47,7 @@ def create_learning(
 
 def update_learning(id: int, **kwargs) -> dict:
     """Update any fields of a learning: category, title, content, reasoning."""
-    conn = get_db()
+    conn = _core().get_db()
     row = conn.execute("SELECT * FROM learnings WHERE id = ?", (id,)).fetchone()
     if not row:
             return {"error": f"Learning {id} not found"}
@@ -50,7 +58,7 @@ def update_learning(id: int, **kwargs) -> dict:
     updates = {k: v for k, v in kwargs.items() if k in allowed}
     if not updates:
             return dict(row)
-    updates["updated_at"] = now_epoch()
+    updates["updated_at"] = _core().now_epoch()
     set_clause = ", ".join(f"{k} = ?" for k in updates)
     values = list(updates.values()) + [id]
     conn.execute(f"UPDATE learnings SET {set_clause} WHERE id = ?", values)
@@ -63,7 +71,7 @@ def update_learning(id: int, **kwargs) -> dict:
 
 def supersede_learning(old_id: int, new_id: int, note: str = '') -> dict:
     """Mark an older learning as superseded by a newer canonical learning."""
-    conn = get_db()
+    conn = _core().get_db()
     old_row = conn.execute("SELECT * FROM learnings WHERE id = ?", (old_id,)).fetchone()
     new_row = conn.execute("SELECT * FROM learnings WHERE id = ?", (new_id,)).fetchone()
     if not old_row:
@@ -74,7 +82,7 @@ def supersede_learning(old_id: int, new_id: int, note: str = '') -> dict:
     old_reasoning = str(old_row["reasoning"] or "")
     suffix = note.strip() if note.strip() else f"Superseded by learning #{new_id}."
     combined_reasoning = f"{old_reasoning}\n{suffix}".strip() if old_reasoning else suffix
-    updated_at = now_epoch()
+    updated_at = _core().now_epoch()
     conn.execute(
         "UPDATE learnings SET status = 'superseded', updated_at = ?, reasoning = ? WHERE id = ?",
         (updated_at, combined_reasoning, old_id),
@@ -90,7 +98,7 @@ def supersede_learning(old_id: int, new_id: int, note: str = '') -> dict:
 
 def delete_learning(id: int) -> bool:
     """Delete a learning entry."""
-    conn = get_db()
+    conn = _core().get_db()
     result = conn.execute("DELETE FROM learnings WHERE id = ?", (id,))
     conn.execute("DELETE FROM unified_search WHERE source = 'learning' AND source_id = ?", (str(id),))
     conn.commit()
@@ -103,7 +111,7 @@ def search_learnings(query: str, category: str = None) -> list[dict]:
     # Try FTS5 first
     fts_results = fts_search(query, source_filter="learning", limit=30)
     if fts_results:
-        conn = get_db()
+        conn = _core().get_db()
         ids = [int(r['source_id']) for r in fts_results]
         placeholders = ','.join('?' * len(ids))
         rows = conn.execute(
@@ -116,7 +124,7 @@ def search_learnings(query: str, category: str = None) -> list[dict]:
         return filtered
 
     # Fallback to LIKE
-    conn = get_db()
+    conn = _core().get_db()
     words = query.strip().split()
     if not words:
         return []
@@ -139,7 +147,7 @@ def search_learnings(query: str, category: str = None) -> list[dict]:
 
 def list_learnings(category: str = None) -> list[dict]:
     """List all learnings, optionally filtered by category."""
-    conn = get_db()
+    conn = _core().get_db()
     if category:
         rows = conn.execute(
             "SELECT * FROM learnings WHERE category = ? ORDER BY updated_at DESC",
@@ -176,7 +184,7 @@ def find_similar_learnings(new_id: int, title: str, content: str, category: str)
     keywords_new = set(extract_keywords(f"{title} {content}"))
     if not keywords_new:
         return []
-    conn = get_db()
+    conn = _core().get_db()
     rows = conn.execute(
         "SELECT id, title, content FROM learnings WHERE category = ? AND id != ?",
         (category, new_id)
@@ -193,4 +201,3 @@ def find_similar_learnings(new_id: int, title: str, content: str, category: str)
             results.append((row['id'], round(similarity, 2)))
     results.sort(key=lambda x: x[1], reverse=True)
     return results[:5]
-


### PR DESCRIPTION
## Summary\n- stabilize the hot-context release as v3.1.8 after the pre-release v3.1.7 tag exposed CI-only regressions\n- make db reloads and core access reload-safe so test/runtime DB switches do not leak stale module state\n- make hot-context capture degrade safely on partial schemas and align release artifacts + changelog for v3.1.8\n\n## Validation\n- PYTHONPATH=src pytest tests/ -q\n- python3 scripts/verify_release_readiness.py\n- npm test\n- npm run build\n- python3 -m py_compile src/db/__init__.py src/db/_hot_context.py src/db/_learnings.py src/tools_hot_context.py src/tools_sessions.py src/plugins/protocol.py src/db/_reminders.py src/dashboard/app.py