### PR TITLE
Fix runtime update bootstrap for new hot context modules

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.1.9] - 2026-04-08
+
+### Runtime Update Bootstrap Fix For Hot Context
+- Hardened `nexo update` so it no longer depends on a hand-maintained root-module list when new top-level runtime modules are introduced. The updater now discovers and copies all top-level `.py` runtime modules dynamically.
+- This specifically fixes the bootstrap gap where an installed runtime could copy the new `server.py` from the hot-context release but fail before importing because the old updater did not know it also had to copy `tools_hot_context.py`.
+- Added regression coverage for runtime updates copying the new `tools_hot_context.py` module into installed runtimes, so future public releases can add root runtime modules without silently breaking the upgrade path.
+
 ## [3.1.8] - 2026-04-08
 
 ### Hot Context Release Stabilization

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 3.1.8
+version: 3.1.9
 metadata:
   openclaw:
     requires:

--- a/openclaw-plugin/package-lock.json
+++ b/openclaw-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wazionapps/openclaw-memory-nexo-brain",
-      "version": "3.1.8",
+      "version": "3.1.9",
       "license": "AGPL-3.0",
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "3.1.8" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "3.1.9" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/src/auto_update.py
+++ b/src/auto_update.py
@@ -1186,27 +1186,38 @@ def _source_repo_status(repo_dir: Path) -> dict:
     }
 
 
+def _discover_runtime_root_python_modules(base_dir: Path) -> list[str]:
+    """Return every top-level runtime `.py` module in the source/runtime root."""
+    if not base_dir.is_dir():
+        return []
+    modules: list[str] = []
+    for item in sorted(base_dir.iterdir(), key=lambda path: path.name):
+        if not item.is_file() or item.suffix != ".py":
+            continue
+        if item.name.startswith(".") or item.name == "__init__.py":
+            continue
+        modules.append(item.name)
+    return modules
+
+
+def _runtime_flat_files(base_dir: Path) -> list[str]:
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for name in _discover_runtime_root_python_modules(base_dir) + ["requirements.txt", "package.json", "version.json"]:
+        if name in seen:
+            continue
+        seen.add(name)
+        ordered.append(name)
+    return ordered
+
+
 def _backup_runtime_tree(dest: Path = NEXO_HOME) -> str:
     timestamp = time.strftime("%Y-%m-%d-%H%M%S")
     backup_dir = NEXO_HOME / "backups" / f"runtime-tree-{timestamp}"
     backup_dir.mkdir(parents=True, exist_ok=True)
 
     code_dirs = ["hooks", "plugins", "db", "cognitive", "dashboard", "rules", "crons", "scripts", "doctor", "skills-core"]
-    flat_files = [
-        "server.py", "plugin_loader.py", "knowledge_graph.py", "kg_populate.py",
-        "maintenance.py", "storage_router.py", "claim_graph.py", "hnsw_index.py",
-        "evolution_cycle.py", "migrate_embeddings.py", "auto_close_sessions.py",
-        "client_sync.py",
-        "client_preferences.py", "agent_runner.py", "bootstrap_docs.py",
-        "hook_guardrails.py", "protocol_settings.py", "public_evolution_queue.py",
-        "auto_update.py", "tools_sessions.py", "tools_coordination.py",
-        "tools_hot_context.py",
-        "tools_reminders.py", "tools_reminders_crud.py", "tools_learnings.py",
-        "tools_credentials.py", "tools_task_history.py", "tools_menu.py",
-        "cli.py", "script_registry.py", "skills_runtime.py", "user_context.py",
-        "public_contribution.py",
-        "cron_recovery.py", "runtime_power.py", "requirements.txt", "package.json", "version.json",
-    ]
+    flat_files = _runtime_flat_files(dest)
     for name in code_dirs:
         src = dest / name
         if src.is_dir():
@@ -1244,21 +1255,7 @@ def _copy_runtime_from_source(src_dir: Path, repo_dir: Path, dest: Path = NEXO_H
     import shutil
 
     packages = ["db", "cognitive", "doctor", "dashboard", "rules", "crons", "hooks"]
-    flat_files = [
-        "server.py", "plugin_loader.py", "knowledge_graph.py", "kg_populate.py",
-        "maintenance.py", "storage_router.py", "claim_graph.py", "hnsw_index.py",
-        "evolution_cycle.py", "migrate_embeddings.py", "auto_close_sessions.py",
-        "client_sync.py",
-        "client_preferences.py", "agent_runner.py", "bootstrap_docs.py",
-        "hook_guardrails.py", "protocol_settings.py", "public_evolution_queue.py",
-        "auto_update.py", "tools_sessions.py", "tools_coordination.py",
-        "tools_hot_context.py",
-        "tools_reminders.py", "tools_reminders_crud.py", "tools_learnings.py",
-        "tools_credentials.py", "tools_task_history.py", "tools_menu.py",
-        "cli.py", "script_registry.py", "skills_runtime.py", "user_context.py",
-        "public_contribution.py",
-        "cron_recovery.py", "runtime_power.py", "requirements.txt",
-    ]
+    flat_files = _runtime_flat_files(src_dir)
     copied_packages = 0
     copied_files = 0
 

--- a/tests/test_cli_scripts.py
+++ b/tests/test_cli_scripts.py
@@ -143,6 +143,7 @@ class TestRuntimeUpdate:
             "client_preferences.py", "agent_runner.py", "bootstrap_docs.py",
             "hook_guardrails.py", "protocol_settings.py", "public_evolution_queue.py",
             "auto_update.py", "tools_sessions.py", "tools_coordination.py",
+            "tools_hot_context.py",
             "tools_reminders.py", "tools_reminders_crud.py", "tools_learnings.py",
             "tools_credentials.py", "tools_task_history.py", "tools_menu.py",
             "cli.py", "script_registry.py", "skills_runtime.py", "user_context.py",
@@ -179,6 +180,7 @@ class TestRuntimeUpdate:
         assert (runtime_home / "hook_guardrails.py").read_text() == "x = 1\n"
         assert (runtime_home / "protocol_settings.py").read_text() == "x = 1\n"
         assert (runtime_home / "public_evolution_queue.py").read_text() == "x = 1\n"
+        assert (runtime_home / "tools_hot_context.py").read_text() == "x = 1\n"
         assert (runtime_home / "scripts" / "nexo-watchdog.sh").read_text() == "#!/bin/bash\nexit 0\n"
 
     def test_installed_runtime_update_repairs_missing_public_contribution_module(self, tmp_path):
@@ -251,6 +253,7 @@ class TestRuntimeUpdate:
             "maintenance.py", "storage_router.py", "claim_graph.py", "hnsw_index.py",
             "evolution_cycle.py", "migrate_embeddings.py", "auto_close_sessions.py",
             "client_sync.py", "client_preferences.py", "agent_runner.py", "bootstrap_docs.py", "auto_update.py", "tools_sessions.py", "tools_coordination.py",
+            "tools_hot_context.py",
             "tools_reminders.py", "tools_reminders_crud.py", "tools_learnings.py",
             "tools_credentials.py", "tools_task_history.py", "tools_menu.py", "cli.py",
             "skills_runtime.py", "user_context.py", "public_contribution.py",
@@ -281,6 +284,7 @@ class TestRuntimeUpdate:
         assert payload["ok"] is True
         assert payload["public_contribution_mode"] == "disabled"
         assert (runtime_home / "public_contribution.py").is_file()
+        assert (runtime_home / "tools_hot_context.py").is_file()
 
     def test_update_reports_personal_schedule_self_heal(self, tmp_path):
         runtime_home = tmp_path / "runtime"
@@ -339,6 +343,7 @@ class TestRuntimeUpdate:
             "maintenance.py", "storage_router.py", "claim_graph.py", "hnsw_index.py",
             "evolution_cycle.py", "migrate_embeddings.py", "auto_close_sessions.py",
             "client_sync.py", "client_preferences.py", "agent_runner.py", "bootstrap_docs.py", "auto_update.py", "tools_sessions.py", "tools_coordination.py",
+            "tools_hot_context.py",
             "tools_reminders.py", "tools_reminders_crud.py", "tools_learnings.py",
             "tools_credentials.py", "tools_task_history.py", "tools_menu.py", "cli.py",
             "skills_runtime.py", "user_context.py", "public_contribution.py",


### PR DESCRIPTION
## Summary\n- make [NEXO] Checking recorded source repository...
[NEXO] Creating runtime backups...
[NEXO] Syncing runtime files...
[NEXO] Copying core packages...
[NEXO] Copying core modules...
[NEXO] Copying plugin modules...
[NEXO] Copying scripts...
[NEXO] Copying templates and version metadata...
[NEXO] Copying core skills and runtime wrapper...
[NEXO] Reconciling runtime state...
[NEXO] Initializing database and reconciling personal schedules...
[NEXO] Reconciling Python dependencies...
[NEXO] Syncing core cron definitions...
[NEXO] Refreshing runtime power helper...
[NEXO] Refreshing shared client configs...
[NEXO] Verifying runtime imports...
[NEXO] Update failed; restoring previous runtime state... discover top-level runtime modules dynamically instead of relying on a frozen allowlist\n- fix the hot-context bootstrap gap where installed runtimes could receive the new server but miss \n- version the public fix as v3.1.9 and update website/release artifacts accordingly\n\n## Validation\n- PYTHONPATH=src pytest tests/ -q\n- pytest -q tests/test_cli_scripts.py -k RuntimeUpdate\n- npm test\n- npm run build\n- python3 -m py_compile src/auto_update.py tests/test_cli_scripts.py