### PR TITLE
feat: remind after user corrections without learning capture

### DIFF
--- a/src/tools_sessions.py
+++ b/src/tools_sessions.py
@@ -542,6 +542,17 @@ def handle_heartbeat(sid: str, task: str, context_hint: str = '') -> str:
         except Exception:
             pass  # guard_log table may not exist in older installs
 
+    if context_hint and _hint_suggests_correction(context_hint):
+        try:
+            if not _recent_learning_capture_exists(conn, sid, window_seconds=300):
+                parts.append("")
+                parts.append(
+                    "⚠ LEARNING REMINDER: This looks like a user correction and no recent learning was captured. "
+                    "If it revealed a reusable pattern, write `nexo_learning_add` NOW."
+                )
+        except Exception:
+            pass  # Best-effort reminder only
+
     return "\n".join(parts)
 
 
@@ -814,6 +825,64 @@ def _hint_suggests_code_edit(hint: str) -> bool:
                     'change code', 'update script', 'write code', '.py', '.js', '.ts', '.php',
                     'commit', 'arregl', 'modific', 'implement', 'correg']
     return any(signal in hint_lower for signal in edit_signals)
+
+
+def _hint_suggests_correction(hint: str) -> bool:
+    """Detect explicit user correction signals in a heartbeat context hint."""
+    hint_lower = hint.lower()
+    correction_signals = [
+        "that's wrong",
+        "that is wrong",
+        "wrong approach",
+        "not like that",
+        "fix this",
+        "fix it",
+        "está mal",
+        "esta mal",
+        "mal hecho",
+        "incorrecto",
+        "te equivocas",
+        "te has equivocado",
+        "lo hiciste mal",
+        "no era eso",
+        "corrige esto",
+        "corrígelo",
+        "corrigelo",
+        "ya te dije",
+        "otra vez el mismo",
+        "de nuevo el mismo",
+        "no deberías",
+        "no deberias",
+        "shouldn't have",
+        "should not have",
+    ]
+    return any(signal in hint_lower for signal in correction_signals)
+
+
+def _recent_learning_capture_exists(conn, sid: str, window_seconds: int = 300) -> bool:
+    """Check whether a recent learning was captured manually or via protocol task close."""
+    cutoff_epoch = time.time() - window_seconds
+
+    row = conn.execute(
+        "SELECT 1 FROM learnings WHERE created_at >= ? LIMIT 1",
+        (cutoff_epoch,),
+    ).fetchone()
+    if row:
+        return True
+
+    row = conn.execute(
+        """
+        SELECT 1
+        FROM protocol_tasks
+        WHERE session_id = ?
+          AND learning_id IS NOT NULL
+          AND closed_at IS NOT NULL
+          AND CAST(strftime('%s', closed_at) AS INTEGER) >= ?
+        LIMIT 1
+        """,
+        (sid, int(cutoff_epoch)),
+    ).fetchone()
+    return bool(row)
 
 
 def _toolbox_summary(conn) -> str:

--- a/tests/test_hot_context.py
+++ b/tests/test_hot_context.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import json
+import time
 
 
 def _register_session(sid: str):
@@ -111,3 +112,56 @@ def test_followup_and_reminder_changes_feed_hot_context(isolated_db):
     assert followup_contexts
     assert reminder_contexts
     assert any(event["event_type"] == "followup_note" for event in bundle["events"])
+
+
+def test_heartbeat_warns_when_user_correction_has_no_recent_learning(isolated_db):
+    import tools_sessions
+
+    importlib.reload(tools_sessions)
+
+    sid = _register_session("nexo-3001-4001")
+    output = tools_sessions.handle_heartbeat(
+        sid,
+        "Ajustar flujo",
+        "Eso está mal, corrige esto y no repitas el mismo error.",
+    )
+
+    assert "LEARNING REMINDER" in output
+    assert "nexo_learning_add" in output
+
+
+def test_heartbeat_skips_learning_reminder_when_recent_learning_exists(isolated_db):
+    import db
+    import tools_sessions
+
+    importlib.reload(tools_sessions)
+
+    sid = _register_session("nexo-3002-4002")
+    now = time.time()
+    conn = db.get_db()
+    conn.execute(
+        """
+        INSERT INTO learnings (category, title, content, reasoning, prevention, applies_to, status, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "nexo",
+            "Recent correction learning",
+            "Keep correction learnings fresh.",
+            "",
+            "",
+            "",
+            "active",
+            now,
+            now,
+        ),
+    )
+    conn.commit()
+
+    output = tools_sessions.handle_heartbeat(
+        sid,
+        "Ajustar flujo",
+        "Wrong approach. Corrígelo y evita repetirlo.",
+    )
+
+    assert "LEARNING REMINDER" not in output


### PR DESCRIPTION
## Summary
- add a heartbeat reminder when a context hint clearly looks like a user correction
- suppress the reminder when a recent learning already exists or a protocol task recently captured one
- cover the new behavior with focused hot-context tests

## Testing
- pytest -q tests/test_hot_context.py tests/test_protocol.py
- python3 -m py_compile src/tools_sessions.py