### PR TITLE
release: cut v4.0.1 alignment patch

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [4.0.1] - 2026-04-09
+
+### Release Alignment + Protocol Reminder
+- Published the post-`v4.0.0` mainline fix as a real patch release so git installs, npm installs, GitHub Releases, and the public website converge on the same shipped state instead of leaving `main` ahead of the public release tag.
+- Added a correction-aware heartbeat reminder in `tools_sessions`: when the operator clearly corrects the agent and no recent learning was captured, NEXO now emits a `LEARNING REMINDER` instead of relying on model discipline alone.
+- Finished the `datetime.UTC` cleanup in the trust-history and user-state paths, so the shipped runtime now matches the Python 3.14 warning cleanup already claimed by the 4.0 release notes.
+- Kept the broader `4.0.0` memory-surface package intact while making the public release channels honest again about what is actually shipped.
+
 ## [4.0.0] - 2026-04-09
 
 ### Memory Surfaces Become Product Surfaces

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Versions `3.1.7` through `3.2.0` close the recent-memory gap:
 - when even that misses, NEXO now exposes raw transcript fallback tools for Claude Code and Codex session stores
 - NEXO can now inspect itself through a live system catalog derived from canonical sources instead of relying only on stale docs or operator memory
 
-Version `4.0.0` closes the next memory-surface gap:
+Version `4.0.1` keeps the 4.0 release aligned across channels while preserving the next memory-surface gap closure:
 
 - non-text artifacts now have a first-class multimodal reference layer instead of living outside the memory model
 - pre-compaction auto-flush now persists actionable session state before context compression can erase it

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 4.0.0
+version: 4.0.1
 metadata:
   openclaw:
     requires:

--- a/openclaw-plugin/package-lock.json
+++ b/openclaw-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "3.2.0",
+  "version": "4.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wazionapps/openclaw-memory-nexo-brain",
-      "version": "3.2.0",
+      "version": "4.0.1",
       "license": "AGPL-3.0",
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "4.0.0" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "4.0.1" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/src/cognitive/_trust.py
+++ b/src/cognitive/_trust.py
@@ -1,7 +1,7 @@
 """NEXO Cognitive — Trust scoring, sentiment, dissonance."""
 import re
 import numpy as np
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from cognitive._core import _get_db, embed, cosine_similarity, _blob_to_array
 from cognitive._core import POSITIVE_SIGNALS, NEGATIVE_SIGNALS, URGENCY_SIGNALS
 
@@ -412,7 +412,7 @@ def adjust_trust(event: str, context: str = "", custom_delta: float = None) -> d
 def get_trust_history(days: int = 7) -> dict:
     """Get trust score history and sentiment summary."""
     db = _get_db()
-    cutoff = (datetime.now(UTC) - timedelta(days=days)).isoformat()
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
 
     # Trust events
     events = db.execute(

--- a/src/hook_guardrails.py
+++ b/src/hook_guardrails.py
@@ -16,6 +16,28 @@ WRITE_LIKE_TOOLS = {"Edit", "MultiEdit", "Write"}
 DELETE_LIKE_TOOLS = {"Delete"}
 NEXO_CODE_ROOT = Path(os.environ.get("NEXO_CODE", str(Path(__file__).resolve().parent))).expanduser().resolve()
 LIVE_REPO_ROOT = NEXO_CODE_ROOT.parent if NEXO_CODE_ROOT.name == "src" else NEXO_CODE_ROOT
+PUBLIC_REPO_DIRS = {
+    ".claude-plugin",
+    ".github",
+    "bin",
+    "clawhub-skill",
+    "community",
+    "docs",
+    "hooks",
+    "openclaw-plugin",
+    "src",
+    "templates",
+    "tests",
+}
+PUBLIC_REPO_FILES = {
+    ".mcp.json",
+    "CHANGELOG.md",
+    "LICENSE",
+    "README.md",
+    "docker-compose.yml",
+    "package-lock.json",
+    "package.json",
+}
 
 
 def _operation_kind(tool_name: str) -> str:
@@ -54,11 +76,31 @@ def _automation_live_repo_guard_enabled() -> bool:
     )
 
 
+def _has_git_marker(root: Path) -> bool:
+    return (root / ".git").exists()
+
+
+def _is_public_repo_surface(candidate: Path) -> bool:
+    try:
+        relative = candidate.relative_to(LIVE_REPO_ROOT)
+    except ValueError:
+        return False
+
+    parts = relative.parts
+    if not parts:
+        return False
+    if parts[0] in PUBLIC_REPO_DIRS:
+        return True
+    return len(parts) == 1 and parts[0] in PUBLIC_REPO_FILES
+
+
 def _is_live_repo_path(path: str) -> bool:
     if not str(path or "").strip():
         return False
     try:
-        return _is_relative_to(_resolve_runtime_path(path), LIVE_REPO_ROOT)
+        if not _has_git_marker(LIVE_REPO_ROOT):
+            return False
+        return _is_public_repo_surface(_resolve_runtime_path(path))
     except Exception:
         return False
 

--- a/src/user_state_model.py
+++ b/src/user_state_model.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 """Inspectable user-state model built from multiple NEXO signals."""
 
 import json
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import cognitive
 from db import get_db
@@ -32,7 +32,7 @@ def init_tables() -> None:
 
 
 def _recent_correction_count(days: int) -> int:
-    cutoff = (datetime.now(UTC) - timedelta(days=days)).isoformat()
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
     row = cognitive._get_db().execute(
         "SELECT COUNT(*) FROM memory_corrections WHERE created_at >= ?",
         (cutoff,),
@@ -41,7 +41,7 @@ def _recent_correction_count(days: int) -> int:
 
 
 def _recent_trust_event_count(days: int, event_name: str) -> int:
-    cutoff = (datetime.now(UTC) - timedelta(days=days)).isoformat()
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
     row = cognitive._get_db().execute(
         "SELECT COUNT(*) FROM trust_score WHERE created_at >= ? AND event = ?",
         (cutoff, event_name),
@@ -50,7 +50,7 @@ def _recent_trust_event_count(days: int, event_name: str) -> int:
 
 
 def _recent_diary_signal_count(days: int) -> int:
-    cutoff = (datetime.now(UTC) - timedelta(days=days)).isoformat(timespec="seconds")
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat(timespec="seconds")
     row = get_db().execute(
         "SELECT COUNT(*) FROM session_diary WHERE created_at >= ? AND user_signals != ''",
         (cutoff,),
@@ -157,7 +157,7 @@ def list_user_state_snapshots(limit: int = 20) -> list[dict]:
 
 def user_state_stats(days: int = 30) -> dict:
     init_tables()
-    cutoff = (datetime.now(UTC) - timedelta(days=days)).isoformat(timespec="seconds")
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat(timespec="seconds")
     rows = get_db().execute(
         "SELECT state_label, COUNT(*) AS cnt FROM user_state_snapshots WHERE created_at >= ? GROUP BY state_label",
         (cutoff,),

--- a/tests/test_hook_guardrails.py
+++ b/tests/test_hook_guardrails.py
@@ -293,3 +293,40 @@ def test_process_pre_tool_event_allows_public_contribution_checkout(guardrail_en
         "SELECT COUNT(*) AS count FROM protocol_debt WHERE debt_type = 'automation_live_repo_write_blocked'"
     ).fetchone()
     assert debt["count"] == 0
+
+
+def test_process_pre_tool_event_does_not_treat_runtime_home_as_live_repo_when_not_git_checkout(
+    guardrail_env,
+    monkeypatch,
+):
+    runtime_file = guardrail_env / "operations" / "orchestrator-state.json"
+    runtime_file.parent.mkdir(parents=True, exist_ok=True)
+    runtime_file.write_text("{}")
+    (guardrail_env / ".git").write_text("gitdir: /tmp/fake-git\n")
+
+    monkeypatch.setenv("NEXO_CODE", str(guardrail_env))
+    monkeypatch.setenv("NEXO_AUTOMATION", "1")
+    monkeypatch.delenv("NEXO_PUBLIC_CONTRIBUTION", raising=False)
+    db, hook_guardrails = _reload_guardrail_stack()
+    db.init_db()
+    db.register_session(
+        "nexo-2008-3008",
+        "automation runtime write",
+        external_session_id="claude-auto-3",
+        session_client="claude_code",
+    )
+
+    result = hook_guardrails.process_pre_tool_event(
+        {
+            "session_id": "claude-auto-3",
+            "tool_name": "Edit",
+            "tool_input": {"file_path": str(runtime_file)},
+        }
+    )
+
+    assert result["skipped"] is True
+    assert result["reason"] == "lenient mode"
+    debt = db.get_db().execute(
+        "SELECT COUNT(*) AS count FROM protocol_debt WHERE debt_type = 'automation_live_repo_write_blocked'"
+    ).fetchone()
+    assert debt["count"] == 0


### PR DESCRIPTION
## Summary
- cut `v4.0.1` as the real post-`v4.0.0` patch release from `main`
- align public release artifacts (`package.json`, Claude plugin, ClawHub skill, OpenClaw bridge/package)
- fix automation live-repo guardrails so mutable runtime state paths under `NEXO_HOME` stop generating false protocol debt
- finish the `datetime.UTC` cleanup in trust/user-state paths

## Validation
- `pytest -q` → `406 passed`
- `pytest -q tests/test_hook_guardrails.py tests/test_hot_context.py tests/test_protocol.py` → `26 passed`
- `python3 scripts/verify_client_parity.py` → `126 passed`
- `python3 scripts/verify_release_readiness.py` → `OK`
- `npm pack --dry-run`
- `cd openclaw-plugin && npm pack --dry-run`

## Notes
- `gh-pages` is updated locally in the separate website worktree and will be pushed after merge/publish so the site does not advertise `4.0.1` before the release exists.
