### PR TITLE
Release v4.1.0 — Drive/Curiosity

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [4.1.0] - 2026-04-09
+
+### Drive/Curiosity — Autonomous Investigation Signals
+- Added a first-class Drive/Curiosity layer that accumulates tension-based signals during normal work (heartbeat, task close) and investigates autonomously when signals mature. Five signal types: anomaly, pattern, connection, gap, and opportunity.
+- New MCP tools `nexo_drive_signals`, `nexo_drive_reinforce`, `nexo_drive_act`, and `nexo_drive_dismiss` expose the drive surface publicly while internal detection runs passively from heartbeat and task close context hints.
+- Signals follow a lifecycle: latent (noise filtering) → rising (reinforced 2+ times) → ready (investigated silently) → acted/dismissed. Ready signals do not decay. Latent and rising signals decay daily, enforced by the maintenance scheduler.
+- Deep Sleep synthesis now includes a Drive phase that investigates ready signals, promotes rising signals with cross-area connections, and dismisses stale signals overnight. The apply phase executes drive synthesis findings automatically.
+- Heartbeat now surfaces mature drive signals in its response when relevant to the current work area, so the agent is aware of accumulated curiosity without blocking the operator.
+- Detection uses deterministic heuristics (regex patterns for anomalies, recurring patterns, knowledge gaps, and opportunities) to avoid adding latency or model calls to the heartbeat path.
+- Maximum 30 active signals enforced, with weakest latent signals dropped when the cap is reached.
+
+### Validation
+- Added comprehensive test coverage for drive signals: creation, reinforcement, tension promotion, decay, status transitions, similarity deduplication, max cap enforcement, detection heuristics, and MCP handler integration. 38 new tests, 444 total suite green.
+
 ## [4.0.1] - 2026-04-09
 
 ### Release Alignment + Protocol Reminder

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 4.0.1
+version: 4.1.0
 metadata:
   openclaw:
     requires:

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "4.0.1" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "4.1.0" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -51,6 +51,7 @@ _watchers = _load_submodule("db._watchers")
 _personal_scripts = _load_submodule("db._personal_scripts")
 _skills = _load_submodule("db._skills")
 _hot_context = _load_submodule("db._hot_context")
+_drive = _load_submodule("db._drive")
 
 # Core: connection, constants, init, utils
 from db._core import (
@@ -185,6 +186,13 @@ from db._skills import (
     import_skill_from_directory, approve_skill, collect_scriptable_skill_candidates,
     collect_skill_improvement_candidates, materialize_personal_skill_definition,
     get_skill_health_report,
+)
+
+# Drive / Curiosity signals
+from db._drive import (
+    create_drive_signal, reinforce_drive_signal, get_drive_signals,
+    get_drive_signal, update_drive_signal_status, decay_drive_signals,
+    find_similar_drive_signal, drive_signal_stats,
 )
 
 # Hot context / recent continuity

--- a/src/db/_drive.py
+++ b/src/db/_drive.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+"""NEXO DB — Drive/Curiosity signals for autonomous investigation."""
+
+import importlib
+import json
+import sys
+from datetime import datetime, timezone
+
+
+def _core():
+    module = sys.modules.get("db._core")
+    if module is None:
+        module = importlib.import_module("db._core")
+    return module
+
+
+MAX_ACTIVE_SIGNALS = 30
+REINFORCE_BOOST = 0.15
+RISING_THRESHOLD = 0.4
+READY_THRESHOLD = 0.7
+RISING_DECAY_RATE = 0.03  # slower decay once rising
+
+VALID_SIGNAL_TYPES = {"anomaly", "pattern", "connection", "gap", "opportunity"}
+VALID_STATUSES = {"latent", "rising", "ready", "acted", "dismissed"}
+
+
+def _table_exists(conn) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='drive_signals' LIMIT 1"
+    ).fetchone()
+    return row is not None
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def create_drive_signal(
+    signal_type: str,
+    source: str,
+    summary: str,
+    source_id: str = "",
+    area: str = "",
+    tension: float = 0.3,
+    decay_rate: float = 0.05,
+    evidence: list[str] | None = None,
+) -> dict:
+    """Create a new drive signal. Returns the created row as dict."""
+    conn = _core().get_db()
+    if not _table_exists(conn):
+        return {"ok": False, "error": "drive_signals table not yet created"}
+
+    if signal_type not in VALID_SIGNAL_TYPES:
+        return {"ok": False, "error": f"Invalid signal_type: {signal_type}. Must be one of {VALID_SIGNAL_TYPES}"}
+
+    tension = max(0.0, min(1.0, tension))
+    evidence_json = json.dumps(evidence or [summary[:200]], ensure_ascii=False)
+    now = _now_iso()
+
+    # Enforce max active signals — drop weakest latent if at limit
+    active_count = conn.execute(
+        "SELECT COUNT(*) FROM drive_signals WHERE status IN ('latent', 'rising', 'ready')"
+    ).fetchone()[0]
+    if active_count >= MAX_ACTIVE_SIGNALS:
+        conn.execute(
+            "DELETE FROM drive_signals WHERE id = ("
+            "  SELECT id FROM drive_signals"
+            "  WHERE status = 'latent'"
+            "  ORDER BY tension ASC, first_seen ASC"
+            "  LIMIT 1"
+            ")"
+        )
+        conn.commit()
+
+    cursor = conn.execute(
+        "INSERT INTO drive_signals "
+        "(signal_type, source, source_id, area, summary, tension, evidence, "
+        " status, first_seen, last_reinforced, decay_rate) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, 'latent', ?, ?, ?)",
+        (signal_type, source, source_id, area, summary, tension,
+         evidence_json, now, now, decay_rate),
+    )
+    conn.commit()
+    signal_id = cursor.lastrowid
+    return {"ok": True, "id": signal_id, "tension": tension, "status": "latent"}
+
+
+def reinforce_drive_signal(signal_id: int, observation: str) -> dict:
+    """Reinforce an existing signal: add evidence, boost tension, maybe promote status."""
+    conn = _core().get_db()
+    if not _table_exists(conn):
+        return {"ok": False, "error": "drive_signals table not yet created"}
+
+    row = conn.execute(
+        "SELECT * FROM drive_signals WHERE id = ?", (signal_id,)
+    ).fetchone()
+    if not row:
+        return {"ok": False, "error": f"Signal {signal_id} not found"}
+
+    status = row["status"]
+    if status in ("acted", "dismissed"):
+        return {"ok": False, "error": f"Signal {signal_id} is already {status}"}
+
+    # Update evidence
+    try:
+        evidence = json.loads(row["evidence"] or "[]")
+    except (json.JSONDecodeError, TypeError):
+        evidence = []
+    evidence.append(observation[:500])
+
+    # Boost tension
+    old_tension = float(row["tension"] or 0.3)
+    new_tension = min(1.0, old_tension + REINFORCE_BOOST)
+
+    # Status promotion
+    new_status = status
+    reinforce_count = len(evidence)
+    if new_tension >= READY_THRESHOLD or reinforce_count >= 3:
+        new_status = "ready"
+    elif new_tension >= RISING_THRESHOLD:
+        new_status = "rising"
+
+    # Rising signals decay slower
+    new_decay = RISING_DECAY_RATE if new_status in ("rising", "ready") else float(row["decay_rate"] or 0.05)
+
+    now = _now_iso()
+    conn.execute(
+        "UPDATE drive_signals SET tension = ?, evidence = ?, status = ?, "
+        "decay_rate = ?, last_reinforced = ? WHERE id = ?",
+        (new_tension, json.dumps(evidence, ensure_ascii=False),
+         new_status, new_decay, now, signal_id),
+    )
+    conn.commit()
+    return {
+        "ok": True, "id": signal_id,
+        "old_tension": old_tension, "new_tension": new_tension,
+        "old_status": status, "new_status": new_status,
+        "evidence_count": reinforce_count,
+    }
+
+
+def get_drive_signals(
+    status: str | None = None,
+    area: str | None = None,
+    limit: int = 30,
+) -> list[dict]:
+    """List active drive signals, optionally filtered."""
+    conn = _core().get_db()
+    if not _table_exists(conn):
+        return []
+
+    clauses = []
+    params: list = []
+    if status:
+        clauses.append("status = ?")
+        params.append(status)
+    else:
+        # Default: only active signals
+        clauses.append("status IN ('latent', 'rising', 'ready')")
+    if area:
+        clauses.append("area = ?")
+        params.append(area)
+
+    where = " AND ".join(clauses) if clauses else "1=1"
+    params.append(min(limit, 100))
+
+    rows = conn.execute(
+        f"SELECT * FROM drive_signals WHERE {where} ORDER BY tension DESC, last_reinforced DESC LIMIT ?",
+        params,
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def get_drive_signal(signal_id: int) -> dict | None:
+    """Get a single signal with full details."""
+    conn = _core().get_db()
+    if not _table_exists(conn):
+        return None
+
+    row = conn.execute(
+        "SELECT * FROM drive_signals WHERE id = ?", (signal_id,)
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def update_drive_signal_status(
+    signal_id: int,
+    status: str,
+    outcome: str = "",
+) -> dict:
+    """Transition a signal to a new status (acted/dismissed)."""
+    conn = _core().get_db()
+    if not _table_exists(conn):
+        return {"ok": False, "error": "drive_signals table not yet created"}
+
+    if status not in VALID_STATUSES:
+        return {"ok": False, "error": f"Invalid status: {status}"}
+
+    row = conn.execute(
+        "SELECT * FROM drive_signals WHERE id = ?", (signal_id,)
+    ).fetchone()
+    if not row:
+        return {"ok": False, "error": f"Signal {signal_id} not found"}
+
+    now = _now_iso()
+    updates = {"status": status}
+    if status == "acted":
+        updates["acted_at"] = now
+    if outcome:
+        updates["outcome"] = outcome
+
+    set_clause = ", ".join(f"{k} = ?" for k in updates)
+    params = list(updates.values()) + [signal_id]
+    conn.execute(f"UPDATE drive_signals SET {set_clause} WHERE id = ?", params)
+    conn.commit()
+    return {"ok": True, "id": signal_id, "new_status": status}
+
+
+def decay_drive_signals() -> dict:
+    """Apply daily decay to all active signals. Kill those at or below 0."""
+    conn = _core().get_db()
+    if not _table_exists(conn):
+        return {"decayed": 0, "killed": 0}
+
+    # Ready signals don't decay
+    rows = conn.execute(
+        "SELECT id, tension, decay_rate, status FROM drive_signals "
+        "WHERE status IN ('latent', 'rising')"
+    ).fetchall()
+
+    decayed = 0
+    killed = 0
+    for row in rows:
+        new_tension = float(row["tension"]) - float(row["decay_rate"] or 0.05)
+        if new_tension <= 0:
+            conn.execute("DELETE FROM drive_signals WHERE id = ?", (row["id"],))
+            killed += 1
+        else:
+            conn.execute(
+                "UPDATE drive_signals SET tension = ? WHERE id = ?",
+                (new_tension, row["id"]),
+            )
+            decayed += 1
+
+    conn.commit()
+    return {"decayed": decayed, "killed": killed}
+
+
+def find_similar_drive_signal(summary: str, area: str = "") -> dict | None:
+    """Find an existing active signal similar to the given summary.
+
+    Uses keyword overlap heuristic to avoid duplicates.
+    """
+    conn = _core().get_db()
+    if not _table_exists(conn):
+        return None
+
+    # Extract meaningful words (4+ chars) from summary
+    words = {w.lower() for w in summary.split() if len(w) >= 4}
+    if not words:
+        return None
+
+    clauses = ["status IN ('latent', 'rising', 'ready')"]
+    params: list = []
+    if area:
+        clauses.append("area = ?")
+        params.append(area)
+
+    where = " AND ".join(clauses)
+    rows = conn.execute(
+        f"SELECT * FROM drive_signals WHERE {where} ORDER BY tension DESC",
+        params,
+    ).fetchall()
+
+    best_match = None
+    best_score = 0.0
+    for row in rows:
+        row_words = {w.lower() for w in (row["summary"] or "").split() if len(w) >= 4}
+        if not row_words:
+            continue
+        overlap = len(words & row_words)
+        score = overlap / max(len(words | row_words), 1)
+        if score > best_score and score >= 0.4:  # 40% word overlap threshold
+            best_score = score
+            best_match = dict(row)
+
+    return best_match
+
+
+def drive_signal_stats() -> dict:
+    """Return aggregate stats about drive signals."""
+    conn = _core().get_db()
+    if not _table_exists(conn):
+        return {"total": 0, "by_status": {}, "by_type": {}, "by_area": {}}
+
+    total = conn.execute("SELECT COUNT(*) FROM drive_signals").fetchone()[0]
+
+    by_status = {}
+    for row in conn.execute(
+        "SELECT status, COUNT(*) as cnt FROM drive_signals GROUP BY status"
+    ).fetchall():
+        by_status[row["status"]] = row["cnt"]
+
+    by_type = {}
+    for row in conn.execute(
+        "SELECT signal_type, COUNT(*) as cnt FROM drive_signals "
+        "WHERE status IN ('latent', 'rising', 'ready') GROUP BY signal_type"
+    ).fetchall():
+        by_type[row["signal_type"]] = row["cnt"]
+
+    by_area = {}
+    for row in conn.execute(
+        "SELECT area, COUNT(*) as cnt FROM drive_signals "
+        "WHERE status IN ('latent', 'rising', 'ready') AND area != '' GROUP BY area"
+    ).fetchall():
+        by_area[row["area"]] = row["cnt"]
+
+    return {"total": total, "by_status": by_status, "by_type": by_type, "by_area": by_area}

--- a/src/db/_schema.py
+++ b/src/db/_schema.py
@@ -752,6 +752,37 @@ def _m30_hot_context_memory(conn):
     _migrate_add_index(conn, "idx_recent_events_session", "recent_events", "session_id, created_at")
 
 
+def _m31_drive_signals(conn):
+    """Drive/Curiosity layer — autonomous tension-based investigation signals."""
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS drive_signals (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            signal_type TEXT NOT NULL,
+            source TEXT NOT NULL,
+            source_id TEXT DEFAULT '',
+            area TEXT DEFAULT '',
+            summary TEXT NOT NULL,
+            tension REAL DEFAULT 0.3,
+            evidence TEXT DEFAULT '[]',
+            status TEXT DEFAULT 'latent',
+            first_seen TEXT DEFAULT (datetime('now')),
+            last_reinforced TEXT,
+            acted_at TEXT,
+            outcome TEXT,
+            decay_rate REAL DEFAULT 0.05
+        )
+    """)
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_drive_status ON drive_signals(status)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_drive_area ON drive_signals(area)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_drive_tension ON drive_signals(tension)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_drive_first_seen ON drive_signals(first_seen)")
+    # Register drive_decay in maintenance_schedule
+    conn.execute(
+        "INSERT OR IGNORE INTO maintenance_schedule (task_name, interval_hours) VALUES (?, ?)",
+        ('drive_decay', 24),
+    )
+
+
 MIGRATIONS = [
     (1, "learnings_columns", _m1_learnings_columns),
     (2, "followups_reasoning", _m2_followups_reasoning),
@@ -783,6 +814,7 @@ MIGRATIONS = [
     (28, "automation_runs", _m28_automation_runs),
     (29, "item_history_and_soft_delete", _m29_item_history_and_soft_delete),
     (30, "hot_context_memory", _m30_hot_context_memory),
+    (31, "drive_signals", _m31_drive_signals),
 ]
 
 

--- a/src/maintenance.py
+++ b/src/maintenance.py
@@ -55,5 +55,8 @@ def _run_task(task_name: str):
             prune_adaptive_log()
         except Exception:
             pass
+    elif task_name == "drive_decay":
+        from db import decay_drive_signals
+        decay_drive_signals()
     elif task_name == "graph_maintenance":
         pass  # Future: orphan cleanup, consolidation

--- a/src/plugins/protocol.py
+++ b/src/plugins/protocol.py
@@ -894,6 +894,22 @@ def handle_task_close(
         },
         ttl_hours=24,
     )
+    # ── Drive/Curiosity: detect signals from task evidence (best-effort) ──
+    try:
+        _drive_text = " ".join(filter(None, [
+            outcome_notes, clean_evidence, change_summary, change_why,
+        ]))
+        if _drive_text and len(_drive_text.strip()) >= 15:
+            from tools_drive import detect_drive_signal as _detect_drive
+            _detect_drive(
+                _drive_text[:600],
+                source="task_close",
+                source_id=task_id,
+                area=task.get("area", ""),
+            )
+    except Exception:
+        pass  # Drive detection is best-effort
+
     open_debts = list_protocol_debts(status="open", task_id=task_id, limit=20)
 
     response = {

--- a/src/scripts/deep-sleep/apply_findings.py
+++ b/src/scripts/deep-sleep/apply_findings.py
@@ -2039,6 +2039,29 @@ def main():
     except Exception as e:
         print(f"  Skill autopromotion error: {e}", file=sys.stderr)
 
+    # Apply drive synthesis (investigate/dismiss/promote signals)
+    drive_synthesis = synthesis.get("drive_synthesis", {})
+    if drive_synthesis:
+        print("[apply] Processing drive synthesis...")
+        try:
+            from db import update_drive_signal_status, reinforce_drive_signal
+            for item in drive_synthesis.get("investigated", []):
+                signal_id = item.get("signal_id")
+                action_taken = item.get("action_taken", "acted")
+                outcome = item.get("outcome", item.get("finding", ""))
+                if signal_id and outcome:
+                    update_drive_signal_status(signal_id, action_taken, outcome[:500])
+                    stats["applied"] += 1
+                    print(f"  Drive signal #{signal_id}: {action_taken}")
+            for item in drive_synthesis.get("promoted", []):
+                signal_id = item.get("signal_id")
+                reason = item.get("reason", "promoted by Deep Sleep")
+                if signal_id:
+                    reinforce_drive_signal(signal_id, f"Deep Sleep promotion: {reason}"[:500])
+                    print(f"  Drive signal #{signal_id}: promoted")
+        except Exception as e:
+            print(f"  Drive synthesis error: {e}", file=sys.stderr)
+
     # Create followups for abandoned projects
     abandoned_results = create_abandoned_followups(synthesis)
     for r in abandoned_results:

--- a/src/scripts/deep-sleep/synthesize-prompt.md
+++ b/src/scripts/deep-sleep/synthesize-prompt.md
@@ -143,6 +143,16 @@ When generating `followup_create`, prefer descriptions that start with a concret
 
 Avoid vague followups that merely restate the diagnosis.
 
+### 10. Drive/Curiosity Synthesis
+Review the active drive signals (accessible via `nexo_drive_signals`). For each READY signal:
+- Investigate silently: check metrics, recall memory, cross-reference learnings
+- If the investigation yields an actionable finding, create an action item and mark the signal as `acted`
+- If the signal is stale or no longer relevant, dismiss it with a reason
+- Cross-reference RISING signals across areas — if two signals from different domains converge, promote to READY
+- Apply decay to LATENT signals that have no recent reinforcement
+
+Drive signals represent NEXO's autonomous curiosity. Treat them as leads worth investigating, not noise to dismiss.
+
 ## Output Format
 
 Return ONLY valid JSON. No markdown code fences. No explanation text.
@@ -272,6 +282,30 @@ Return ONLY valid JSON. No markdown code fences. No explanation text.
       "recommendation": "Create followup, or ignore, or already handled"
     }
   ],
+
+  "drive_synthesis": {
+    "investigated": [
+      {
+        "signal_id": 1,
+        "summary": "What the signal was about",
+        "finding": "What investigation revealed",
+        "action_taken": "acted|dismissed",
+        "outcome": "Concrete result or reason for dismissal"
+      }
+    ],
+    "promoted": [
+      {
+        "signal_id": 2,
+        "reason": "Why this signal was promoted from rising to ready"
+      }
+    ],
+    "cross_area_connections": [
+      {
+        "signal_ids": [3, 7],
+        "connection": "How these signals from different areas relate"
+      }
+    ]
+  },
 
   "trust_calibration": {
     "score": 72,

--- a/src/server.py
+++ b/src/server.py
@@ -32,6 +32,12 @@ from tools_system_catalog import (
     handle_system_catalog,
     handle_tool_explain,
 )
+from tools_drive import (
+    handle_drive_signals,
+    handle_drive_reinforce,
+    handle_drive_act,
+    handle_drive_dismiss,
+)
 from user_context import get_context as _get_ctx
 from tools_coordination import (
     handle_track, handle_untrack, handle_files,
@@ -1141,6 +1147,62 @@ def nexo_plugin_remove(filename: str) -> str:
         return f"Plugin {filename} unregistered (had no registered tools)."
     except Exception as e:
         return f"Error removing plugin {filename}: {e}"
+
+
+# ── Drive / Curiosity (4 tools) ──────────────────────────────────
+
+@mcp.tool
+def nexo_drive_signals(status: str = "", area: str = "", limit: int = 20) -> str:
+    """List autonomous drive/curiosity signals.
+
+    Drive signals are observations NEXO accumulates during normal work.
+    When tension crosses threshold, NEXO investigates silently.
+
+    Args:
+        status: Filter by status (latent, rising, ready, acted, dismissed). Default: active only.
+        area: Filter by operational area (shopify, google-ads, wazion, nexo, etc.).
+        limit: Max signals to return (default 20).
+    """
+    return handle_drive_signals(status, area, limit)
+
+
+@mcp.tool
+def nexo_drive_reinforce(signal_id: int, observation: str) -> str:
+    """Reinforce a drive signal with a new observation.
+
+    Increases tension and may promote the signal status (latent → rising → ready).
+
+    Args:
+        signal_id: Signal ID to reinforce.
+        observation: New observation that supports this signal.
+    """
+    return handle_drive_reinforce(signal_id, observation)
+
+
+@mcp.tool
+def nexo_drive_act(signal_id: int, outcome: str) -> str:
+    """Mark a drive signal as investigated with an outcome.
+
+    Call this after NEXO has autonomously investigated a READY signal.
+
+    Args:
+        signal_id: Signal ID that was investigated.
+        outcome: What was found during investigation.
+    """
+    return handle_drive_act(signal_id, outcome)
+
+
+@mcp.tool
+def nexo_drive_dismiss(signal_id: int, reason: str) -> str:
+    """Dismiss a drive signal (archived, not deleted).
+
+    Call this when a signal is not worth investigating.
+
+    Args:
+        signal_id: Signal ID to dismiss.
+        reason: Why this signal was dismissed.
+    """
+    return handle_drive_dismiss(signal_id, reason)
 
 
 if __name__ == "__main__":

--- a/src/tools_drive.py
+++ b/src/tools_drive.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+"""NEXO Drive/Curiosity — autonomous investigation signals.
+
+Public MCP tool handlers + internal detection logic that feeds from
+heartbeat, task_close, and diary consolidation.
+"""
+
+import json
+import re
+from db import (
+    create_drive_signal, reinforce_drive_signal, get_drive_signals,
+    get_drive_signal, update_drive_signal_status, decay_drive_signals,
+    find_similar_drive_signal, drive_signal_stats,
+)
+
+
+# ── Heuristic detection keywords ─────────────────────────────────────
+
+_ANOMALY_PATTERNS = [
+    re.compile(r"\b(subió|bajó|cayó|subi[oó]|baj[oó]|dropped|spiked|jumped)\b.*\b\d+%", re.I),
+    re.compile(r"\b(inesperado|unexpected|anomal|raro|weird|strange)\b", re.I),
+    re.compile(r"\b(error rate|tasa de error|failure|fallo)\b.*\b(subi|increas|grew)\b", re.I),
+]
+
+_PATTERN_INDICATORS = [
+    re.compile(r"\b(otra vez|again|de nuevo|siempre pasa|keeps happening|recurring)\b", re.I),
+    re.compile(r"\b(cada vez que|every time|whenever)\b", re.I),
+    re.compile(r"\b(mismo (problema|error|issue)|same (problem|error|issue))\b", re.I),
+]
+
+_GAP_INDICATORS = [
+    re.compile(r"\b(no sé cómo|don'?t know how|no entiendo|unclear how)\b", re.I),
+    re.compile(r"\b(falta documentación|missing docs|undocumented)\b", re.I),
+]
+
+_OPPORTUNITY_INDICATORS = [
+    re.compile(r"\b(benchmark|media del sector|industry average)\b.*\b(bajo|low|por debajo|below)\b", re.I),
+    re.compile(r"\b(podríamos|could|se podría|we could|opportunity)\b.*\b(automatiz|improve|mejorar|optimiz)\b", re.I),
+]
+
+
+def _classify_signal(text: str) -> str | None:
+    """Classify text into a signal type, or None if nothing interesting."""
+    for pattern in _ANOMALY_PATTERNS:
+        if pattern.search(text):
+            return "anomaly"
+    for pattern in _PATTERN_INDICATORS:
+        if pattern.search(text):
+            return "pattern"
+    for pattern in _GAP_INDICATORS:
+        if pattern.search(text):
+            return "gap"
+    for pattern in _OPPORTUNITY_INDICATORS:
+        if pattern.search(text):
+            return "opportunity"
+    return None
+
+
+def _infer_area(text: str) -> str:
+    """Infer operational area from text keywords."""
+    text_lower = text.lower()
+    area_keywords = {
+        "shopify": ["shopify", "tienda", "pedido", "producto", "sku"],
+        "google-ads": ["google ads", "campaña", "campaign", "cpc", "pmax", "roas", "gads"],
+        "meta-ads": ["meta ads", "facebook", "instagram", "pixel", "capi"],
+        "wazion": ["wazion", "whatsapp", "wa ", "baileys"],
+        "nexo": ["nexo", "brain", "mcp", "cognitive"],
+        "canaririural": ["canarirural", "canari", "reserva", "hospedaje", "alojamiento", "propietario"],
+        "seo": ["seo", "search console", "indexación", "ranking"],
+        "email": ["email", "correo", "inbox", "smtp"],
+    }
+    for area, keywords in area_keywords.items():
+        for kw in keywords:
+            if kw in text_lower:
+                return area
+    return ""
+
+
+def detect_drive_signal(
+    context_hint: str,
+    source: str,
+    source_id: str = "",
+    area: str = "",
+) -> dict | None:
+    """Analyze text for interesting signals. Creates or reinforces.
+
+    Called internally from heartbeat and task_close. Not a public MCP tool.
+    Returns the signal dict if created/reinforced, None otherwise.
+    """
+    if not context_hint or len(context_hint.strip()) < 15:
+        return None
+
+    signal_type = _classify_signal(context_hint)
+    if not signal_type:
+        return None
+
+    inferred_area = area or _infer_area(context_hint)
+
+    # Check for similar existing signal
+    existing = find_similar_drive_signal(context_hint, inferred_area)
+    if existing:
+        result = reinforce_drive_signal(existing["id"], context_hint[:500])
+        return result if result.get("ok") else None
+
+    # Create new
+    result = create_drive_signal(
+        signal_type=signal_type,
+        source=source,
+        source_id=source_id,
+        area=inferred_area,
+        summary=context_hint[:300],
+    )
+    return result if result.get("ok") else None
+
+
+# ── Public MCP tool handlers ─────────────────────────────────────────
+
+def handle_drive_signals(
+    status: str = "",
+    area: str = "",
+    limit: int = 20,
+) -> str:
+    """List drive signals, optionally filtered by status and area."""
+    signals = get_drive_signals(
+        status=status or None,
+        area=area or None,
+        limit=limit,
+    )
+    if not signals:
+        return "No drive signals found."
+
+    stats = drive_signal_stats()
+    lines = [
+        f"DRIVE SIGNALS ({len(signals)} shown, {stats['total']} total):",
+        f"  By status: {json.dumps(stats.get('by_status', {}), ensure_ascii=False)}",
+        "",
+    ]
+    for s in signals:
+        evidence_count = 0
+        try:
+            evidence_count = len(json.loads(s.get("evidence") or "[]"))
+        except (json.JSONDecodeError, TypeError):
+            pass
+        tension_bar = "█" * int(float(s.get("tension", 0)) * 10)
+        lines.append(
+            f"  [{s['id']}] {s['status'].upper()} {tension_bar} "
+            f"t={s['tension']:.2f} ({s['signal_type']}) "
+            f"{'[' + s['area'] + '] ' if s.get('area') else ''}"
+            f"{s['summary'][:80]}"
+            f" ({evidence_count} obs, decay={s.get('decay_rate', 0.05):.2f})"
+        )
+    return "\n".join(lines)
+
+
+def handle_drive_reinforce(signal_id: int, observation: str) -> str:
+    """Manually reinforce a drive signal with a new observation."""
+    if not observation.strip():
+        return "ERROR: observation cannot be empty"
+    result = reinforce_drive_signal(signal_id, observation)
+    if not result.get("ok"):
+        return f"ERROR: {result.get('error', 'unknown')}"
+    return (
+        f"Signal #{signal_id} reinforced: "
+        f"tension {result['old_tension']:.2f} → {result['new_tension']:.2f}, "
+        f"status {result['old_status']} → {result['new_status']}, "
+        f"{result['evidence_count']} observations total"
+    )
+
+
+def handle_drive_act(signal_id: int, outcome: str) -> str:
+    """Mark a drive signal as investigated with an outcome."""
+    if not outcome.strip():
+        return "ERROR: outcome cannot be empty"
+    result = update_drive_signal_status(signal_id, "acted", outcome)
+    if not result.get("ok"):
+        return f"ERROR: {result.get('error', 'unknown')}"
+    return f"Signal #{signal_id} marked as ACTED. Outcome recorded."
+
+
+def handle_drive_dismiss(signal_id: int, reason: str) -> str:
+    """Dismiss a drive signal with a reason (archived, not deleted)."""
+    if not reason.strip():
+        return "ERROR: reason cannot be empty"
+    result = update_drive_signal_status(signal_id, "dismissed", reason)
+    if not result.get("ok"):
+        return f"ERROR: {result.get('error', 'unknown')}"
+    return f"Signal #{signal_id} dismissed. Reason: {reason}"

--- a/src/tools_sessions.py
+++ b/src/tools_sessions.py
@@ -518,6 +518,23 @@ def handle_heartbeat(sid: str, task: str, context_hint: str = '') -> str:
     except Exception:
         pass
 
+    # ── Drive/Curiosity: detect signals from context_hint (best-effort) ──
+    try:
+        if context_hint and len(context_hint.strip()) >= 15:
+            from tools_drive import detect_drive_signal as _detect_drive
+            _drive_result = _detect_drive(context_hint, source="heartbeat", source_id=sid)
+            if _drive_result:
+                # Check for READY signals relevant to current area
+                from db import get_drive_signals as _get_drive
+                _ready = _get_drive(status="ready", limit=3)
+                if _ready:
+                    parts.append("")
+                    parts.append(f"DRIVE: {len(_ready)} mature signal(s) ready for investigation")
+                    for _ds in _ready[:2]:
+                        parts.append(f"  [{_ds['id']}] {_ds['signal_type']}: {_ds['summary'][:80]}")
+    except Exception:
+        pass  # Drive detection is best-effort, never block heartbeat
+
     # ── Layer 3: DIARY_OVERDUE signal based on heartbeat count + time ──
     conn = get_db()
     row = conn.execute("SELECT started_epoch FROM sessions WHERE sid = ?", (sid,)).fetchone()

--- a/tests/test_drive.py
+++ b/tests/test_drive.py
@@ -1,0 +1,282 @@
+"""Tests for the Drive/Curiosity signal layer."""
+from __future__ import annotations
+
+import json
+
+from db import (
+    create_drive_signal, reinforce_drive_signal, get_drive_signals,
+    get_drive_signal, update_drive_signal_status, decay_drive_signals,
+    find_similar_drive_signal, drive_signal_stats,
+)
+from tools_drive import (
+    detect_drive_signal,
+    handle_drive_signals, handle_drive_reinforce,
+    handle_drive_act, handle_drive_dismiss,
+)
+
+
+# ── DB layer tests ───────────────────────────────────────────────────
+
+class TestCreateSignal:
+    def test_basic_create(self):
+        result = create_drive_signal("anomaly", "heartbeat", "CPC subió 40% sin cambios")
+        assert result["ok"]
+        assert result["tension"] == 0.3
+        assert result["status"] == "latent"
+
+    def test_invalid_type_rejected(self):
+        result = create_drive_signal("invalid_type", "heartbeat", "test")
+        assert not result["ok"]
+        assert "Invalid signal_type" in result.get("error", "")
+
+    def test_tension_clamped(self):
+        result = create_drive_signal("anomaly", "test", "overflow", tension=5.0)
+        assert result["ok"]
+        assert result["tension"] == 1.0
+
+    def test_retrievable_after_create(self):
+        result = create_drive_signal("gap", "task_close", "No model for ICNEA pricing", area="canaririural")
+        signal = get_drive_signal(result["id"])
+        assert signal is not None
+        assert signal["signal_type"] == "gap"
+        assert signal["area"] == "canaririural"
+        assert signal["status"] == "latent"
+
+
+class TestReinforce:
+    def test_tension_increases(self):
+        created = create_drive_signal("pattern", "heartbeat", "María pregunta lo mismo cada trimestre")
+        result = reinforce_drive_signal(created["id"], "María preguntó otra vez por lo mismo")
+        assert result["ok"]
+        assert result["new_tension"] > result["old_tension"]
+
+    def test_promotes_to_rising(self):
+        created = create_drive_signal("anomaly", "test", "test signal", tension=0.3)
+        result = reinforce_drive_signal(created["id"], "second observation")
+        assert result["new_status"] in ("rising", "ready")
+
+    def test_promotes_to_ready_on_three_reinforcements(self):
+        created = create_drive_signal("pattern", "test", "recurring issue", tension=0.2)
+        reinforce_drive_signal(created["id"], "obs 2")
+        result = reinforce_drive_signal(created["id"], "obs 3")
+        assert result["new_status"] == "ready"
+        assert result["evidence_count"] >= 3
+
+    def test_cannot_reinforce_acted(self):
+        created = create_drive_signal("anomaly", "test", "already done")
+        update_drive_signal_status(created["id"], "acted", "investigated")
+        result = reinforce_drive_signal(created["id"], "new obs")
+        assert not result["ok"]
+
+    def test_cannot_reinforce_dismissed(self):
+        created = create_drive_signal("anomaly", "test", "dismissed one")
+        update_drive_signal_status(created["id"], "dismissed", "not worth it")
+        result = reinforce_drive_signal(created["id"], "new obs")
+        assert not result["ok"]
+
+
+class TestDecay:
+    def test_decay_reduces_tension(self):
+        created = create_drive_signal("anomaly", "test", "will decay", tension=0.5, decay_rate=0.1)
+        result = decay_drive_signals()
+        assert result["decayed"] >= 1
+        signal = get_drive_signal(created["id"])
+        assert signal is not None
+        assert float(signal["tension"]) < 0.5
+
+    def test_decay_kills_weak_signals(self):
+        created = create_drive_signal("anomaly", "test", "will die", tension=0.05, decay_rate=0.1)
+        result = decay_drive_signals()
+        assert result["killed"] >= 1
+        signal = get_drive_signal(created["id"])
+        assert signal is None
+
+    def test_ready_signals_do_not_decay(self):
+        created = create_drive_signal("anomaly", "test", "stable ready", tension=0.8)
+        update_drive_signal_status(created["id"], "ready")
+        # Override status directly for test
+        from db import get_db
+        get_db().execute("UPDATE drive_signals SET status = 'ready' WHERE id = ?", (created["id"],))
+        get_db().commit()
+        decay_drive_signals()
+        signal = get_drive_signal(created["id"])
+        assert signal is not None
+        assert float(signal["tension"]) == 0.8
+
+
+class TestStatusTransitions:
+    def test_latent_to_acted(self):
+        created = create_drive_signal("opportunity", "test", "cross-sell potential")
+        result = update_drive_signal_status(created["id"], "acted", "investigated: 12% uplift possible")
+        assert result["ok"]
+        signal = get_drive_signal(result["id"])
+        assert signal["status"] == "acted"
+        assert signal["acted_at"] is not None
+        assert signal["outcome"] == "investigated: 12% uplift possible"
+
+    def test_latent_to_dismissed(self):
+        created = create_drive_signal("gap", "test", "minor gap")
+        result = update_drive_signal_status(created["id"], "dismissed", "not actionable")
+        assert result["ok"]
+        signal = get_drive_signal(result["id"])
+        assert signal["status"] == "dismissed"
+
+    def test_invalid_status_rejected(self):
+        created = create_drive_signal("anomaly", "test", "test")
+        result = update_drive_signal_status(created["id"], "invalid_status")
+        assert not result["ok"]
+
+    def test_nonexistent_signal(self):
+        result = update_drive_signal_status(99999, "acted", "test")
+        assert not result["ok"]
+
+
+class TestFindSimilar:
+    def test_finds_similar_signal(self):
+        create_drive_signal("anomaly", "test", "CPC increased significantly in search campaign")
+        similar = find_similar_drive_signal("CPC increased dramatically in search campaign")
+        assert similar is not None
+
+    def test_no_match_for_unrelated(self):
+        create_drive_signal("anomaly", "test", "CPC increased significantly in search campaign")
+        similar = find_similar_drive_signal("The weather is nice today in Mallorca")
+        assert similar is None
+
+    def test_area_scoping(self):
+        create_drive_signal("anomaly", "test", "metric anomaly detected", area="shopify")
+        similar = find_similar_drive_signal("metric anomaly detected", area="google-ads")
+        assert similar is None
+
+
+class TestMaxActiveSignals:
+    def test_cap_at_30(self):
+        for i in range(32):
+            create_drive_signal("anomaly", "test", f"signal number {i}", tension=0.1 + (i * 0.01))
+        signals = get_drive_signals(limit=50)
+        assert len(signals) <= 30
+
+
+class TestStats:
+    def test_empty_stats(self):
+        stats = drive_signal_stats()
+        assert stats["total"] == 0
+
+    def test_counts_by_status(self):
+        create_drive_signal("anomaly", "test", "one")
+        create_drive_signal("pattern", "test", "two")
+        s = create_drive_signal("gap", "test", "three")
+        update_drive_signal_status(s["id"], "dismissed", "reason")
+        stats = drive_signal_stats()
+        assert stats["total"] == 3
+        assert stats["by_status"].get("latent", 0) == 2
+        assert stats["by_status"].get("dismissed", 0) == 1
+
+
+# ── Detection heuristic tests ────────────────────────────────────────
+
+class TestDetection:
+    def test_anomaly_detected(self):
+        result = detect_drive_signal(
+            "El CPC subió 40% en los últimos 3 días sin cambio de campaña",
+            source="heartbeat", source_id="test-sid",
+        )
+        assert result is not None
+        assert result.get("ok") or result.get("new_tension")
+
+    def test_pattern_detected(self):
+        result = detect_drive_signal(
+            "María pregunta otra vez por el resumen trimestral, siempre pasa lo mismo",
+            source="heartbeat", source_id="test-sid",
+        )
+        assert result is not None
+
+    def test_gap_detected(self):
+        result = detect_drive_signal(
+            "No sé cómo funciona el pricing de ICNEA para las agencias",
+            source="task_close", source_id="task-123",
+        )
+        assert result is not None
+
+    def test_opportunity_detected(self):
+        result = detect_drive_signal(
+            "El recovery de carritos tiene 12% open rate, el benchmark media del sector está bajo",
+            source="task_close", source_id="task-456",
+        )
+        assert result is not None
+
+    def test_normal_text_ignored(self):
+        result = detect_drive_signal(
+            "Procesando los emails de hoy, todo normal",
+            source="heartbeat", source_id="test-sid",
+        )
+        assert result is None
+
+    def test_short_text_ignored(self):
+        result = detect_drive_signal("ok", source="heartbeat", source_id="test")
+        assert result is None
+
+    def test_area_inferred(self):
+        result = detect_drive_signal(
+            "El CPC de Google Ads subió 40% inesperadamente",
+            source="heartbeat", source_id="test-sid",
+        )
+        assert result is not None
+        signal = get_drive_signals(area="google-ads")
+        assert len(signal) >= 1
+
+    def test_reinforces_existing_on_similar(self):
+        detect_drive_signal(
+            "CPC subió 30% sin cambios en la campaña de search",
+            source="heartbeat", source_id="sid1",
+        )
+        result = detect_drive_signal(
+            "CPC subió 25% sin cambios en la campaña de search otra vez",
+            source="heartbeat", source_id="sid2",
+        )
+        # Should reinforce, not create new
+        assert result is not None
+        signals = get_drive_signals()
+        # Should have at most 1 signal for this topic
+        cpc_signals = [s for s in signals if "CPC" in s["summary"]]
+        assert len(cpc_signals) <= 1
+
+
+# ── MCP handler tests ────────────────────────────────────────────────
+
+class TestHandlers:
+    def test_list_empty(self):
+        output = handle_drive_signals()
+        assert "No drive signals" in output
+
+    def test_list_with_data(self):
+        create_drive_signal("anomaly", "test", "test signal for listing")
+        output = handle_drive_signals()
+        assert "DRIVE SIGNALS" in output
+        assert "test signal" in output
+
+    def test_reinforce_handler(self):
+        created = create_drive_signal("anomaly", "test", "reinforce me")
+        output = handle_drive_reinforce(created["id"], "new observation")
+        assert "reinforced" in output
+
+    def test_reinforce_empty_observation(self):
+        output = handle_drive_reinforce(1, "")
+        assert "ERROR" in output
+
+    def test_act_handler(self):
+        created = create_drive_signal("opportunity", "test", "act on me")
+        output = handle_drive_act(created["id"], "found 15% improvement opportunity")
+        assert "ACTED" in output
+
+    def test_act_empty_outcome(self):
+        output = handle_drive_act(1, "")
+        assert "ERROR" in output
+
+    def test_dismiss_handler(self):
+        created = create_drive_signal("gap", "test", "dismiss me")
+        output = handle_drive_dismiss(created["id"], "not actionable")
+        assert "dismissed" in output
+
+    def test_dismiss_empty_reason(self):
+        output = handle_drive_dismiss(1, "")
+        assert "ERROR" in output


### PR DESCRIPTION
## Summary
- New core Drive/Curiosity layer: tension-based signals accumulate during normal work and mature into autonomous investigations
- 5 signal types (anomaly, pattern, connection, gap, opportunity) with full lifecycle (latent → rising → ready → acted/dismissed)
- 4 new MCP tools: `nexo_drive_signals`, `nexo_drive_reinforce`, `nexo_drive_act`, `nexo_drive_dismiss`
- Heartbeat and task_close feed signals passively via deterministic heuristics
- Deep Sleep synthesis + apply phases handle overnight investigation
- Maintenance scheduler handles daily decay
- 38 new tests, 444 total suite green

## Files changed (17)
- **New:** `src/db/_drive.py`, `src/tools_drive.py`, `tests/test_drive.py`
- **Modified:** `src/db/__init__.py`, `src/db/_schema.py` (migration 31), `src/server.py`, `src/tools_sessions.py`, `src/plugins/protocol.py`, `src/maintenance.py`, Deep Sleep synthesize-prompt + apply_findings
- **Version bump:** `package.json`, `.claude-plugin/plugin.json`, `clawhub-skill/SKILL.md`, `openclaw-plugin/package.json`, `openclaw-plugin/src/mcp-bridge.ts`, `CHANGELOG.md`

## Test plan
- [x] `tests/test_drive.py` — 38 tests covering all DB operations, detection heuristics, and MCP handlers
- [x] Full suite: 444 passed in 44s
- [x] `verify_release_readiness.py` passes (only gh-pages drift expected pre-release)
- [x] `verify_client_parity.py` passes
- [x] `sync_release_artifacts.py` synced all 4 artifact files

🤖 Generated with [Claude Code](https://claude.com/claude-code)