### PR TITLE
chore: close v5.0.0 release contract

### DIFF
--- a/release-contracts/v5.0.0.json
+++ b/release-contracts/v5.0.0.json
@@ -97,7 +97,7 @@
     {
       "id": "release_package",
       "title": "Release Package",
-      "status": "pending",
+      "status": "complete",
       "evidence_required": [
         "Version and changelog aligned",
         "Release notes exist",


### PR DESCRIPTION
Marks the v5.0.0 release contract release_package gate as complete now that the release has been published, GitHub Release exists, npm packages are live, and post-release update smoke has passed.