### PR TITLE
v5.0.1: purge obsolete managed Claude hooks on upgrade

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [5.0.1] - 2026-04-10
+
+### Upgrade Path + Client Sync Hardening
+- Fixed `client_sync` so managed Claude Code hooks from older releases are purged when they no longer belong to the current core hook set, instead of surviving forever as stale managed entries.
+- Eliminated the legacy `heartbeat-guard.sh` drift path that could leave upgraded installs showing noisy PostToolUse errors and an apparent "NEXO is hanging" symptom even though the runtime itself was still healthy.
+- Kept custom operator hooks intact while removing only obsolete managed identities, so hook cleanup does not regress local customizations.
+- Revalidated the live upgrade path on a real install after the fix: client sync, Codex/Claude Code headless runtime access, inbox processing, email monitor health, and `nexo update` all pass again on the corrected runtime.
+
+### Validation
+- Added a dedicated regression test proving that sync removes obsolete managed Claude Code hooks while preserving custom hooks.
+- Refreshed the v5 smoke artifact and release contract so the shipped evidence reflects the real post-5.0 upgrade path instead of only the original feature-line release.
+
 ## [5.0.0] - 2026-04-10
 
 ### Goal-Driven Decisions + Outcome Learning

--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ Versions `3.1.7` through `3.2.0` close the recent-memory gap:
 - when even that misses, NEXO now exposes raw transcript fallback tools for Claude Code and Codex session stores
 - NEXO can now inspect itself through a live system catalog derived from canonical sources instead of relying only on stale docs or operator memory
 
+Version `5.0.1` hardens the live 5.0 upgrade path:
+
+- managed Claude Code hooks are now cleaned up when an older release left obsolete core-managed entries behind
+- upgrades no longer preserve the stale `heartbeat-guard.sh` path that could create warning storms and fake "hung" symptoms after `nexo update`
+- the corrected path has been revalidated on a real install with `nexo clients sync`, Codex/Claude Code headless runtime access, email-monitor recovery, and a full `nexo update`
+
 Version `5.0.0` closes the loop between memory, decisions, outcomes, and reusable behavior:
 
 - goal profiles are now explicit and auditable instead of living as hidden heuristics

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 5.0.0
+version: 5.0.1
 metadata:
   openclaw:
     requires:

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.0.0" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.0.1" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/release-contracts/smoke/v5.0.1.json
+++ b/release-contracts/smoke/v5.0.1.json
@@ -1,0 +1,132 @@
+{
+  "release_line": "v5.0",
+  "version": "5.0.1",
+  "generated_at": "2026-04-10T18:12:56.849140+00:00",
+  "ok": true,
+  "groups": [
+    {
+      "id": "goal_engine",
+      "description": "goal profiles exist, resolve coherently, and show up in cortex traces",
+      "command": [
+        "/opt/homebrew/opt/python@3.14/bin/python3.14",
+        "-m",
+        "pytest",
+        "-q",
+        "tests/test_goal_engine.py"
+      ],
+      "targets": [
+        "tests/test_goal_engine.py"
+      ],
+      "returncode": 0,
+      "ok": true,
+      "duration_seconds": 2.42,
+      "stdout": "...                                                                      [100%]Running teardown with pytest sessionfinish...\n\n3 passed in 0.19s\n",
+      "stderr": ""
+    },
+    {
+      "id": "decision_cortex_v2",
+      "description": "decision cortex ranks alternatives with outcomes, goals, and structured signals",
+      "command": [
+        "/opt/homebrew/opt/python@3.14/bin/python3.14",
+        "-m",
+        "pytest",
+        "-q",
+        "tests/test_cortex_decisions.py",
+        "tests/test_protocol.py"
+      ],
+      "targets": [
+        "tests/test_cortex_decisions.py",
+        "tests/test_protocol.py"
+      ],
+      "returncode": 0,
+      "ok": true,
+      "duration_seconds": 94.22,
+      "stdout": ".............................                                            [100%]Running teardown with pytest sessionfinish...\n\n29 passed in 92.00s (0:01:32)\n",
+      "stderr": ""
+    },
+    {
+      "id": "structured_learning",
+      "description": "repeated outcome patterns become learnings and can influence later decisions",
+      "command": [
+        "/opt/homebrew/opt/python@3.14/bin/python3.14",
+        "-m",
+        "pytest",
+        "-q",
+        "tests/test_outcomes.py",
+        "tests/test_cortex_decisions.py"
+      ],
+      "targets": [
+        "tests/test_outcomes.py",
+        "tests/test_cortex_decisions.py"
+      ],
+      "returncode": 0,
+      "ok": true,
+      "duration_seconds": 3.36,
+      "stdout": "................                                                         [100%]Running teardown with pytest sessionfinish...\n\n16 passed in 1.13s\n",
+      "stderr": ""
+    },
+    {
+      "id": "skill_evolution",
+      "description": "skills can be seeded, promoted, ranked, or retired from outcome-backed evidence",
+      "command": [
+        "/opt/homebrew/opt/python@3.14/bin/python3.14",
+        "-m",
+        "pytest",
+        "-q",
+        "tests/test_skills_v2.py"
+      ],
+      "targets": [
+        "tests/test_skills_v2.py"
+      ],
+      "returncode": 0,
+      "ok": true,
+      "duration_seconds": 3.27,
+      "stdout": "..............                                                           [100%]Running teardown with pytest sessionfinish...\n\n14 passed in 1.38s\n",
+      "stderr": ""
+    },
+    {
+      "id": "benchmark_pack",
+      "description": "runtime benchmark pack and public scorecard builders stay reproducible",
+      "command": [
+        "/opt/homebrew/opt/python@3.14/bin/python3.14",
+        "-m",
+        "pytest",
+        "-q",
+        "tests/test_build_runtime_benchmark_pack.py",
+        "tests/test_build_public_scorecard.py"
+      ],
+      "targets": [
+        "tests/test_build_runtime_benchmark_pack.py",
+        "tests/test_build_public_scorecard.py"
+      ],
+      "returncode": 0,
+      "ok": true,
+      "duration_seconds": 2.24,
+      "stdout": "....                                                                     [100%]Running teardown with pytest sessionfinish...\n\n4 passed in 0.20s\n",
+      "stderr": ""
+    },
+    {
+      "id": "runtime_audit",
+      "description": "protocol debt maintenance, doctor scoring, and update/cron integrity remain healthy",
+      "command": [
+        "/opt/homebrew/opt/python@3.14/bin/python3.14",
+        "-m",
+        "pytest",
+        "-q",
+        "tests/test_protocol.py",
+        "tests/test_doctor.py",
+        "tests/test_cron_sync.py"
+      ],
+      "targets": [
+        "tests/test_protocol.py",
+        "tests/test_doctor.py",
+        "tests/test_cron_sync.py"
+      ],
+      "returncode": 0,
+      "ok": true,
+      "duration_seconds": 93.09,
+      "stdout": "........................................................................ [ 66%]\n....................................                                     [100%]Running teardown with pytest sessionfinish...\n\n108 passed in 91.29s (0:01:31)\n",
+      "stderr": ""
+    }
+  ]
+}

--- a/release-contracts/v5.0.1.json
+++ b/release-contracts/v5.0.1.json
@@ -1,0 +1,57 @@
+{
+  "release_line": "v5.0",
+  "target_version": "5.0.1",
+  "scope_owner": "NEXO",
+  "distribution": {
+    "git_updates_on": "merge_to_main",
+    "packaged_release_on": "tag_publish"
+  },
+  "required_repo_files": [
+    "scripts/verify_release_readiness.py",
+    "scripts/run_v5_0_smoke.py",
+    "release-contracts/v5.0.1.json",
+    "src/client_sync.py",
+    "tests/test_client_sync.py",
+    "compare/README.md",
+    "compare/scorecard.json"
+  ],
+  "required_website_files": [
+    "index.html",
+    "changelog/index.html",
+    "compare/index.html",
+    "docs/index.html"
+  ],
+  "gates": [
+    {
+      "id": "legacy_hook_cleanup",
+      "title": "Legacy managed hooks are purged safely",
+      "status": "complete",
+      "evidence_required": [
+        "Stale managed Claude Code hooks are removed",
+        "Custom hooks remain intact",
+        "Live client sync no longer references heartbeat-guard.sh"
+      ]
+    },
+    {
+      "id": "runtime_revalidation",
+      "title": "Runtime and automation paths revalidated",
+      "status": "complete",
+      "evidence_required": [
+        "Codex headless runtime access works",
+        "Claude Code headless runtime access works",
+        "Email monitor and lifecycle watcher recover to healthy"
+      ]
+    },
+    {
+      "id": "release_package",
+      "title": "Release package aligned",
+      "status": "complete",
+      "evidence_required": [
+        "Version and changelog aligned",
+        "Release artifacts synced",
+        "Website home and changelog updated to v5.0.1",
+        "Smoke + readiness checks pass"
+      ]
+    }
+  ]
+}

--- a/scripts/run_v5_0_smoke.py
+++ b/scripts/run_v5_0_smoke.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-DEFAULT_OUTPUT = ROOT / "release-contracts" / "smoke" / "v5.0.0.json"
+DEFAULT_OUTPUT = ROOT / "release-contracts" / "smoke" / "v5.0.1.json"
 
 SMOKE_GROUPS = [
     {

--- a/src/client_sync.py
+++ b/src/client_sync.py
@@ -386,6 +386,32 @@ CORE_HOOK_SPECS = [
     },
 ]
 
+LEGACY_CORE_HOOK_IDENTITIES_BY_EVENT = {
+    "PostToolUse": {
+        "heartbeat-guard.sh",
+    },
+}
+
+
+def _current_core_hook_identities_by_event() -> dict[str, set[str]]:
+    identities: dict[str, set[str]] = {}
+    for spec in CORE_HOOK_SPECS:
+        identities.setdefault(spec["event"], set()).add(spec["identity"])
+    return identities
+
+
+CURRENT_CORE_HOOK_IDENTITIES_BY_EVENT = _current_core_hook_identities_by_event()
+
+
+def _managed_core_hook_identities_by_event() -> dict[str, set[str]]:
+    managed = {event: set(identities) for event, identities in CURRENT_CORE_HOOK_IDENTITIES_BY_EVENT.items()}
+    for event, identities in LEGACY_CORE_HOOK_IDENTITIES_BY_EVENT.items():
+        managed.setdefault(event, set()).update(identities)
+    return managed
+
+
+MANAGED_CORE_HOOK_IDENTITIES_BY_EVENT = _managed_core_hook_identities_by_event()
+
 
 def _resolve_hook_source_dir(runtime_root: Path) -> Path:
     direct = runtime_root / "hooks"
@@ -449,6 +475,25 @@ def _merge_core_hooks(existing_hooks, *, runtime_root: Path, nexo_home: Path) ->
     hooks_payload = dict(existing_hooks) if isinstance(existing_hooks, dict) else {}
     hooks_dir = _resolve_hook_source_dir(runtime_root)
     managed_count = 0
+
+    for event, managed_identities in MANAGED_CORE_HOOK_IDENTITIES_BY_EVENT.items():
+        sections = _normalize_hook_sections(hooks_payload.get(event))
+        desired_identities = CURRENT_CORE_HOOK_IDENTITIES_BY_EVENT.get(event, set())
+        cleaned_sections: list[dict] = []
+        for section in sections:
+            cleaned_hooks = []
+            for hook in section["hooks"]:
+                identity = _hook_identity(hook.get("command", ""))
+                if identity in managed_identities and identity not in desired_identities:
+                    continue
+                cleaned_hooks.append(hook)
+            cleaned_sections.append(
+                {
+                    "matcher": section.get("matcher", "*") or "*",
+                    "hooks": cleaned_hooks,
+                }
+            )
+        hooks_payload[event] = cleaned_sections
 
     for spec in CORE_HOOK_SPECS:
         event = spec["event"]

--- a/tests/test_client_sync.py
+++ b/tests/test_client_sync.py
@@ -83,6 +83,54 @@ def test_sync_claude_code_preserves_existing_settings(tmp_path):
     assert "Evolution" in bootstrap_text
 
 
+def test_sync_claude_code_removes_legacy_managed_hooks_but_keeps_custom_hooks(tmp_path):
+    import client_sync
+
+    runtime = _make_runtime(tmp_path)
+    home = tmp_path / "home"
+    settings_path = home / ".claude" / "settings.json"
+    settings_path.parent.mkdir(parents=True)
+    settings_path.write_text(json.dumps({
+        "hooks": {
+            "PostToolUse": [
+                {
+                    "matcher": "*",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "NEXO_HOME=/Users/franciscoc/claude bash /Users/franciscoc/claude/hooks/heartbeat-guard.sh",
+                            "timeout": 5,
+                        },
+                        {
+                            "type": "command",
+                            "command": "bash /tmp/custom-post-tool.sh",
+                            "timeout": 9,
+                        },
+                    ],
+                }
+            ]
+        }
+    }))
+
+    result = client_sync.sync_claude_code(
+        nexo_home=runtime,
+        runtime_root=runtime,
+        operator_name="Atlas",
+        user_home=home,
+    )
+
+    assert result["ok"] is True
+    payload = json.loads(settings_path.read_text())
+    post_tool_hooks = payload["hooks"]["PostToolUse"][0]["hooks"]
+    commands = [hook["command"] for hook in post_tool_hooks]
+    assert not any("heartbeat-guard.sh" in command for command in commands)
+    assert any("custom-post-tool.sh" in command for command in commands)
+    assert any("capture-tool-logs.sh" in command for command in commands)
+    assert any("capture-session.sh" in command for command in commands)
+    assert any("inbox-hook.sh" in command for command in commands)
+    assert any("protocol-guardrail.sh" in command for command in commands)
+
+
 def test_sync_claude_desktop_preserves_preferences(tmp_path):
     import client_sync
 


### PR DESCRIPTION
## Summary
- purge obsolete managed Claude Code hooks during client sync while preserving custom hooks
- version the hotfix as v5.0.1 and sync release artifacts
- add release contract + smoke artifact for the post-5.0 upgrade-path fix

## Why
Older upgraded installs could keep stale core-managed hook entries such as `heartbeat-guard.sh`, creating noisy PostToolUse errors and an apparent "NEXO is hanging" symptom even when the runtime itself was healthy.

## Validation
- `pytest -q tests/test_client_sync.py`
- `python3 scripts/run_v5_0_smoke.py`
- `python3 scripts/verify_release_readiness.py --contract release-contracts/v5.0.1.json --require-contract-complete`
- live `nexo clients sync --json`
- real headless Codex + Claude Code runtime smokes
- live email-monitor / lifecycle recovery checks
