### PR TITLE
Release v5.0.2: deep doctor schema drift hotfix

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [5.0.2] - 2026-04-10
+
+### Doctor Schema Drift Hotfix
+- Fixed the deep-doctor learning-count check so it reads the live `learnings` schema correctly on both current installs (`status`) and older installs (`archived`) instead of reporting a misleading skipped check on healthy runtimes.
+- Revalidated the corrected path on a real upgraded install: `nexo update`, `nexo doctor --tier deep`, and `nexo doctor --tier all` all pass cleanly after the sync.
+- Re-ran a real Claude Code startup smoke after the runtime sync so the patch ships with fresh evidence that the corrected install path still boots cleanly end to end.
+
+### Validation
+- Added regression coverage for both schema variants in the deep doctor suite, so future releases cannot silently drift back to the stale `archived`-only assumption.
+
 ## [5.0.1] - 2026-04-10
 
 ### Upgrade Path + Client Sync Hardening

--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ Versions `3.1.7` through `3.2.0` close the recent-memory gap:
 - when even that misses, NEXO now exposes raw transcript fallback tools for Claude Code and Codex session stores
 - NEXO can now inspect itself through a live system catalog derived from canonical sources instead of relying only on stale docs or operator memory
 
+Version `5.0.2` closes the small post-5.0.1 doctor drift:
+
+- deep doctor now reads the live `learnings` schema correctly whether the install uses `status` or the older `archived` flag
+- a real upgraded runtime was revalidated with `nexo update`, `nexo doctor --tier deep`, `nexo doctor --tier all`, and a fresh Claude Code startup smoke
+
 Version `5.0.1` hardens the live 5.0 upgrade path:
 
 - managed Claude Code hooks are now cleaned up when an older release left obsolete core-managed entries behind

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 5.0.1
+version: 5.0.2
 metadata:
   openclaw:
     requires:

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.0.1" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.0.2" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/release-contracts/smoke/v5.0.2.json
+++ b/release-contracts/smoke/v5.0.2.json
@@ -1,0 +1,132 @@
+{
+  "release_line": "v5.0",
+  "version": "5.0.2",
+  "generated_at": "2026-04-10T18:56:29.930589+00:00",
+  "ok": true,
+  "groups": [
+    {
+      "id": "goal_engine",
+      "description": "goal profiles exist, resolve coherently, and show up in cortex traces",
+      "command": [
+        "/opt/homebrew/opt/python@3.14/bin/python3.14",
+        "-m",
+        "pytest",
+        "-q",
+        "tests/test_goal_engine.py"
+      ],
+      "targets": [
+        "tests/test_goal_engine.py"
+      ],
+      "returncode": 0,
+      "ok": true,
+      "duration_seconds": 2.95,
+      "stdout": "...                                                                      [100%]Running teardown with pytest sessionfinish...\n\n3 passed in 0.22s\n",
+      "stderr": ""
+    },
+    {
+      "id": "decision_cortex_v2",
+      "description": "decision cortex ranks alternatives with outcomes, goals, and structured signals",
+      "command": [
+        "/opt/homebrew/opt/python@3.14/bin/python3.14",
+        "-m",
+        "pytest",
+        "-q",
+        "tests/test_cortex_decisions.py",
+        "tests/test_protocol.py"
+      ],
+      "targets": [
+        "tests/test_cortex_decisions.py",
+        "tests/test_protocol.py"
+      ],
+      "returncode": 0,
+      "ok": true,
+      "duration_seconds": 80.92,
+      "stdout": ".............................                                            [100%]Running teardown with pytest sessionfinish...\n\n29 passed in 79.05s (0:01:19)\n",
+      "stderr": ""
+    },
+    {
+      "id": "structured_learning",
+      "description": "repeated outcome patterns become learnings and can influence later decisions",
+      "command": [
+        "/opt/homebrew/opt/python@3.14/bin/python3.14",
+        "-m",
+        "pytest",
+        "-q",
+        "tests/test_outcomes.py",
+        "tests/test_cortex_decisions.py"
+      ],
+      "targets": [
+        "tests/test_outcomes.py",
+        "tests/test_cortex_decisions.py"
+      ],
+      "returncode": 0,
+      "ok": true,
+      "duration_seconds": 4.03,
+      "stdout": "................                                                         [100%]Running teardown with pytest sessionfinish...\n\n16 passed in 1.08s\n",
+      "stderr": ""
+    },
+    {
+      "id": "skill_evolution",
+      "description": "skills can be seeded, promoted, ranked, or retired from outcome-backed evidence",
+      "command": [
+        "/opt/homebrew/opt/python@3.14/bin/python3.14",
+        "-m",
+        "pytest",
+        "-q",
+        "tests/test_skills_v2.py"
+      ],
+      "targets": [
+        "tests/test_skills_v2.py"
+      ],
+      "returncode": 0,
+      "ok": true,
+      "duration_seconds": 3.42,
+      "stdout": "..............                                                           [100%]Running teardown with pytest sessionfinish...\n\n14 passed in 1.42s\n",
+      "stderr": ""
+    },
+    {
+      "id": "benchmark_pack",
+      "description": "runtime benchmark pack and public scorecard builders stay reproducible",
+      "command": [
+        "/opt/homebrew/opt/python@3.14/bin/python3.14",
+        "-m",
+        "pytest",
+        "-q",
+        "tests/test_build_runtime_benchmark_pack.py",
+        "tests/test_build_public_scorecard.py"
+      ],
+      "targets": [
+        "tests/test_build_runtime_benchmark_pack.py",
+        "tests/test_build_public_scorecard.py"
+      ],
+      "returncode": 0,
+      "ok": true,
+      "duration_seconds": 2.37,
+      "stdout": "....                                                                     [100%]Running teardown with pytest sessionfinish...\n\n4 passed in 0.20s\n",
+      "stderr": ""
+    },
+    {
+      "id": "runtime_audit",
+      "description": "protocol debt maintenance, doctor scoring, and update/cron integrity remain healthy",
+      "command": [
+        "/opt/homebrew/opt/python@3.14/bin/python3.14",
+        "-m",
+        "pytest",
+        "-q",
+        "tests/test_protocol.py",
+        "tests/test_doctor.py",
+        "tests/test_cron_sync.py"
+      ],
+      "targets": [
+        "tests/test_protocol.py",
+        "tests/test_doctor.py",
+        "tests/test_cron_sync.py"
+      ],
+      "returncode": 0,
+      "ok": true,
+      "duration_seconds": 96.7,
+      "stdout": "........................................................................ [ 65%]\n......................................                                   [100%]Running teardown with pytest sessionfinish...\n\n110 passed in 94.76s (0:01:34)\n",
+      "stderr": ""
+    }
+  ]
+}

--- a/release-contracts/v5.0.2.json
+++ b/release-contracts/v5.0.2.json
@@ -1,0 +1,58 @@
+{
+  "release_line": "v5.0",
+  "target_version": "5.0.2",
+  "scope_owner": "NEXO",
+  "distribution": {
+    "git_updates_on": "merge_to_main",
+    "packaged_release_on": "tag_publish"
+  },
+  "required_repo_files": [
+    "scripts/verify_release_readiness.py",
+    "scripts/run_v5_0_smoke.py",
+    "release-contracts/v5.0.2.json",
+    "src/doctor/providers/deep.py",
+    "tests/test_doctor.py",
+    "compare/README.md",
+    "compare/scorecard.json"
+  ],
+  "required_website_files": [
+    "index.html",
+    "changelog/index.html",
+    "compare/index.html",
+    "docs/index.html"
+  ],
+  "gates": [
+    {
+      "id": "doctor_schema_drift",
+      "title": "Deep doctor reads both current and legacy learnings schemas",
+      "status": "complete",
+      "evidence_required": [
+        "status-column schema reports non-archived learnings cleanly",
+        "legacy archived-column schema still passes",
+        "real upgraded runtime no longer shows the archived-column warning"
+      ]
+    },
+    {
+      "id": "runtime_revalidation",
+      "title": "Live runtime revalidated after sync",
+      "status": "complete",
+      "evidence_required": [
+        "nexo update passes on a real install",
+        "nexo doctor --tier deep passes cleanly",
+        "nexo doctor --tier all stays healthy",
+        "Claude Code startup smoke returns OK STARTUP"
+      ]
+    },
+    {
+      "id": "release_package",
+      "title": "Release package aligned",
+      "status": "complete",
+      "evidence_required": [
+        "Version and changelog aligned",
+        "Release artifacts synced",
+        "Website home and changelog updated to v5.0.2",
+        "Smoke + readiness checks pass"
+      ]
+    }
+  ]
+}

--- a/scripts/run_v5_0_smoke.py
+++ b/scripts/run_v5_0_smoke.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-DEFAULT_OUTPUT = ROOT / "release-contracts" / "smoke" / "v5.0.1.json"
+DEFAULT_OUTPUT = ROOT / "release-contracts" / "smoke" / "v5.0.2.json"
 
 SMOKE_GROUPS = [
     {

--- a/src/doctor/providers/deep.py
+++ b/src/doctor/providers/deep.py
@@ -264,7 +264,20 @@ def check_learning_count() -> DoctorCheck:
                     severity="info",
                     summary="No learnings table yet",
                 )
-            count = conn.execute("SELECT COUNT(*) FROM learnings WHERE archived=0").fetchone()[0]
+            columns = {
+                row[1]
+                for row in conn.execute("PRAGMA table_info(learnings)").fetchall()
+            }
+            if "status" in columns:
+                count = conn.execute(
+                    "SELECT COUNT(*) FROM learnings WHERE COALESCE(status, 'active') != 'archived'"
+                ).fetchone()[0]
+            elif "archived" in columns:
+                count = conn.execute(
+                    "SELECT COUNT(*) FROM learnings WHERE archived=0"
+                ).fetchone()[0]
+            else:
+                count = conn.execute("SELECT COUNT(*) FROM learnings").fetchone()[0]
         finally:
             conn.close()
         return DoctorCheck(
@@ -272,15 +285,16 @@ def check_learning_count() -> DoctorCheck:
             tier="deep",
             status="healthy",
             severity="info",
-            summary=f"{count} active learnings in memory",
+            summary=f"{count} non-archived learnings in memory",
         )
     except Exception as e:
         return DoctorCheck(
             id="deep.learning_count",
             tier="deep",
-            status="healthy",
-            severity="info",
-            summary=f"Learning check skipped: {e}",
+            status="degraded",
+            severity="warn",
+            summary=f"Learning check unreadable: {e}",
+            evidence=[str(e)],
         )
 
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1741,6 +1741,57 @@ class TestDeepChecks:
         check = check_watchdog_smoke()
         assert check.status == "critical"
 
+    def test_learning_count_uses_status_column(self, nexo_home):
+        db_path = nexo_home / "data" / "nexo.db"
+        _create_learnings_table(db_path)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO learnings (category, title, content, status) VALUES (?, ?, ?, ?)",
+            ("ops", "Active", "content", "active"),
+        )
+        conn.execute(
+            "INSERT INTO learnings (category, title, content, status) VALUES (?, ?, ?, ?)",
+            ("ops", "Archived", "content", "archived"),
+        )
+        conn.commit()
+        conn.close()
+
+        from doctor.providers.deep import check_learning_count
+
+        check = check_learning_count()
+        assert check.status == "healthy"
+        assert check.summary == "1 non-archived learnings in memory"
+
+    def test_learning_count_supports_legacy_archived_column(self, nexo_home):
+        db_path = nexo_home / "data" / "nexo.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("DROP TABLE IF EXISTS learnings")
+        conn.execute(
+            """CREATE TABLE learnings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                category TEXT NOT NULL,
+                title TEXT NOT NULL,
+                content TEXT NOT NULL,
+                archived INTEGER DEFAULT 0
+            )"""
+        )
+        conn.execute(
+            "INSERT INTO learnings (category, title, content, archived) VALUES (?, ?, ?, ?)",
+            ("ops", "Active", "content", 0),
+        )
+        conn.execute(
+            "INSERT INTO learnings (category, title, content, archived) VALUES (?, ?, ?, ?)",
+            ("ops", "Archived", "content", 1),
+        )
+        conn.commit()
+        conn.close()
+
+        from doctor.providers.deep import check_learning_count
+
+        check = check_learning_count()
+        assert check.status == "healthy"
+        assert check.summary == "1 non-archived learnings in memory"
+
 
 class TestOrchestrator:
     def test_boot_tier(self, nexo_home):


### PR DESCRIPTION
## Summary
- fix the deep doctor learning-count check to support both current and legacy learnings schemas
- add regression coverage for status-based and archived-based installs
- bump release surfaces to v5.0.2 and refresh smoke/readiness artifacts

## Validation
- pytest -q tests/test_doctor.py
- python3 scripts/run_v5_0_smoke.py
- python3 scripts/verify_release_readiness.py --contract release-contracts/v5.0.2.json --require-contract-complete
- nexo update --json
- nexo doctor --tier deep
- nexo doctor --tier all
- Claude Code startup smoke -> OK STARTUP