### PR TITLE
fix(audit-fase1): wal_autocheckpoint + item_read_tokens cleanup (2/9 items)

### DIFF
--- a/src/db/_core.py
+++ b/src/db/_core.py
@@ -53,7 +53,7 @@ def get_db() -> sqlite3.Connection:
         raw.execute("PRAGMA journal_mode=WAL")
         raw.execute("PRAGMA busy_timeout=30000")
         raw.execute("PRAGMA foreign_keys=ON")
-        raw.execute("PRAGMA wal_autocheckpoint=100")
+        raw.execute("PRAGMA wal_autocheckpoint=1000")
         raw.row_factory = sqlite3.Row
         _shared_conn = _SerializedConnection(raw)
     return _shared_conn

--- a/src/db/_reminders.py
+++ b/src/db/_reminders.py
@@ -14,6 +14,35 @@ from db._hot_context import capture_context_event
 ACTIVE_EXCLUDED_STATUSES = {"DELETED", "archived", "blocked", "waiting"}
 READ_TOKEN_TTL_SECONDS = 30 * 60
 
+# Opportunistic cleanup of expired item_read_tokens: runs at most once every
+# _READ_TOKEN_PURGE_INTERVAL seconds from inside _issue_item_read_token. This
+# avoids unbounded growth of expired tokens without adding a new cron or
+# relying on maintenance_schedule (which is currently not wired up — its
+# runner check_and_run_overdue is defined but never invoked from anywhere).
+_READ_TOKEN_PURGE_INTERVAL = 3600  # 1 hour
+_last_read_token_purge: float = 0.0
+
+
+def _purge_expired_read_tokens_if_due(conn: sqlite3.Connection, now: float) -> None:
+    """Delete expired item_read_tokens in-band with a 1h throttle.
+
+    Called from _issue_item_read_token so cleanup rides on normal activity and
+    does not require a separate scheduler. Failures are swallowed because
+    token issuance must never be blocked by cleanup problems.
+    """
+    global _last_read_token_purge
+    if now - _last_read_token_purge < _READ_TOKEN_PURGE_INTERVAL:
+        return
+    _last_read_token_purge = now
+    try:
+        conn.execute(
+            "DELETE FROM item_read_tokens WHERE expires_at < ?",
+            (now,),
+        )
+    except Exception:
+        # Cleanup must never block token issuance. Swallow and move on.
+        pass
+
 
 def _table_exists(conn: sqlite3.Connection, table_name: str) -> bool:
     row = conn.execute(
@@ -133,6 +162,13 @@ def get_item_history(item_type: str, item_id: str, limit: int = 20) -> list[dict
 def _issue_item_read_token(item_type: str, item_id: str, ttl_seconds: int = READ_TOKEN_TTL_SECONDS) -> str:
     conn = get_db()
     now = now_epoch()
+    # Opportunistic cleanup of expired tokens so the table does not grow
+    # unbounded. Throttled to once per hour. Wrapped defensively: any
+    # failure inside the cleanup helper must never block token issuance.
+    try:
+        _purge_expired_read_tokens_if_due(conn, now)
+    except Exception:
+        pass
     token = "IRT-" + secrets.token_hex(12)
     history_seq = _latest_history_seq(conn, item_type, item_id)
     conn.execute(

--- a/tests/test_item_read_tokens_cleanup.py
+++ b/tests/test_item_read_tokens_cleanup.py
@@ -1,0 +1,135 @@
+"""Tests for the opportunistic cleanup of expired item_read_tokens.
+
+Covers the NEXO-AUDIT-2026-04-11 item 9 fix: token issuance drives an
+in-band purge of expired rows throttled to once per hour, with failures
+swallowed so cleanup never blocks the issue path.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def reminders_mod():
+    """Re-import db._reminders for every test so module-level throttle state
+    does not leak between tests (the conftest reset_repo_import_state hook
+    recycles modules, but any prior call from other suites may have bumped
+    _last_read_token_purge to now())."""
+    import db._reminders as mod
+    mod = importlib.reload(mod)
+    mod._last_read_token_purge = 0.0
+    return mod
+
+
+@pytest.fixture
+def db_handles():
+    """Return fresh (get_db, now_epoch) bindings from db._core."""
+    import db._core as core
+    return core.get_db, core.now_epoch
+
+
+def _insert_token(get_db, now_epoch, token: str, item_type: str, item_id: str, expires_offset: float) -> None:
+    conn = get_db()
+    now = now_epoch()
+    conn.execute(
+        "INSERT INTO item_read_tokens (token, item_type, item_id, history_seq, issued_at, expires_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (token, item_type, item_id, 0, now, now + expires_offset),
+    )
+    conn.commit()
+
+
+def _count_tokens(get_db) -> int:
+    conn = get_db()
+    return conn.execute("SELECT COUNT(*) FROM item_read_tokens").fetchone()[0]
+
+
+def test_purge_expired_read_tokens_removes_only_past_expiration(reminders_mod, db_handles):
+    """Expired tokens are deleted; future ones survive."""
+    get_db, now_epoch = db_handles
+
+    # Two expired (expires in the past), one alive (expires in the future)
+    _insert_token(get_db, now_epoch, "IRT-expired-1", "reminder", "R-1", -10.0)
+    _insert_token(get_db, now_epoch, "IRT-expired-2", "followup", "F-1", -3600.0)
+    _insert_token(get_db, now_epoch, "IRT-alive-1", "reminder", "R-2", +1800.0)
+
+    assert _count_tokens(get_db) == 3
+
+    conn = get_db()
+    reminders_mod._purge_expired_read_tokens_if_due(conn, now=now_epoch())
+
+    remaining = [
+        r["token"]
+        for r in conn.execute("SELECT token FROM item_read_tokens ORDER BY token").fetchall()
+    ]
+    assert remaining == ["IRT-alive-1"]
+
+
+def test_purge_is_throttled_to_once_per_interval(reminders_mod, db_handles):
+    """A second call within the throttle window must not re-run the DELETE."""
+    get_db, now_epoch = db_handles
+
+    _insert_token(get_db, now_epoch, "IRT-expired-A", "reminder", "R-A", -10.0)
+    conn = get_db()
+    t0 = now_epoch()
+
+    # First call purges (sets _last_read_token_purge to now)
+    reminders_mod._purge_expired_read_tokens_if_due(conn, now=t0)
+    assert _count_tokens(get_db) == 0
+
+    # Add a new expired token and call again immediately — the throttle
+    # must skip the DELETE so the new token stays.
+    _insert_token(get_db, now_epoch, "IRT-expired-B", "reminder", "R-B", -10.0)
+    reminders_mod._purge_expired_read_tokens_if_due(conn, now=t0 + 10)
+    assert _count_tokens(get_db) == 1
+
+    # After the throttle interval passes (simulated by passing a far-future now),
+    # the purge runs again.
+    reminders_mod._purge_expired_read_tokens_if_due(
+        conn, now=t0 + reminders_mod._READ_TOKEN_PURGE_INTERVAL + 5
+    )
+    assert _count_tokens(get_db) == 0
+
+
+def test_issue_token_triggers_cleanup_at_first_call(reminders_mod, db_handles):
+    """Issuing a token after startup performs an initial purge of stale rows."""
+    get_db, now_epoch = db_handles
+
+    _insert_token(get_db, now_epoch, "IRT-stale-1", "reminder", "R-STALE", -60.0)
+    _insert_token(get_db, now_epoch, "IRT-stale-2", "followup", "F-STALE", -60.0)
+    assert _count_tokens(get_db) == 2
+
+    # Any issue path triggers the cleanup
+    token = reminders_mod._issue_item_read_token("reminder", "R-FRESH")
+    assert token.startswith("IRT-")
+
+    conn = get_db()
+    rows = conn.execute("SELECT token FROM item_read_tokens ORDER BY token").fetchall()
+    remaining = [r["token"] for r in rows]
+    # Only the freshly issued token should remain (the 2 stale ones are gone).
+    assert remaining == [token]
+
+
+def test_cleanup_failure_does_not_block_issue(reminders_mod, db_handles):
+    """If the DELETE raises, token issuance must still succeed."""
+    # db_handles not used here but the fixture still ensures isolated_db ran
+
+    # Monkey-patch the helper to raise — simulating a transient DB error
+    original = reminders_mod._purge_expired_read_tokens_if_due
+
+    def boom(_conn, _now):  # noqa: ANN001
+        raise RuntimeError("simulated DB glitch")
+
+    reminders_mod._purge_expired_read_tokens_if_due = boom  # type: ignore[assignment]
+    try:
+        # Should NOT raise — the issue path is resilient
+        try:
+            token = reminders_mod._issue_item_read_token("reminder", "R-RESILIENT")
+        except Exception:
+            raise AssertionError("issue path must not propagate cleanup errors")
+        assert token.startswith("IRT-")
+    finally:
+        reminders_mod._purge_expired_read_tokens_if_due = original  # type: ignore[assignment]


### PR DESCRIPTION
## Summary

Fase 1 of the NEXO-AUDIT-2026-04-11 review. Two real fixes, six false positives documented and ignored. Every audited item was verified empirically against the production DB and codebase before any code change.

### Real fixes (2 commits)

- `ef74c2c` **fix(db): raise wal_autocheckpoint from 100 to 1000** — the previous value forced WAL checkpoints every ~400 KB, causing unnecessary I/O compared to SQLite's default of ~4 MB. The value was introduced without justification in the `d7879dc` modularize refactor.

- `caeb26b` **fix(reminders): opportunistic cleanup of expired `item_read_tokens`** — the table was growing unbounded because nothing deleted rows whose `expires_at` had passed. On production 2691 of 2721 rows (98.9%) were already expired. The fix rides on `_issue_item_read_token` with a 1h throttle and a double `try/except` so cleanup can never block token issuance. `maintenance_schedule` was not used because `check_and_run_overdue()` is currently dead code (never called from anywhere).

### False positives verified and documented (7 of 10 top-10 items)

| # | Audit claim | Empirical reality |
|---|-------------|-------------------|
| 1 | `cognitive/_core.py:228` decay inverted | Formula is mathematically correct (Ebbinghaus). Applying the proposed fix would have broken the cognitive core for every user (stability 3.0 would produce decay 3.0, 9x faster). |
| 2 | `cognitive/_ingest.py:72` `_refine_memory()` undefined | The function is defined at `_ingest.py:378`, 70+ lines of full logic. |
| 3 | `runtime_power.py:68` invalid model string `claude-opus-4-6[1m]` | This is the official Claude Opus 4.6 1M-context model ID, confirmed in production use across 4 source files. |
| 4 | Timestamps TEXT/REAL mixed | Real inconsistency in the schema but the code handles types correctly in every verified query (50+ call sites). Proposed mass migration would have been a major refactor with no proven bug. |
| 5 | Missing FK CASCADE on 6 tables | Deliberate absence to preserve history. `protocol_tasks` has 300 of 301 rows with no active session, `workflow_runs` has 34 of 34 — applying CASCADE would have deleted all of them at the next session TTL sweep. |
| 6 | LIKE queries without indexes on 10K+ rows | Real row counts are 4 (reminders), 119 (followups), 3 (sessions). Adding indexes + FTS would be pure overhead. |
| 8 | `json.loads` without try/except across 14 plugins | AST-based analysis with `ast.NodeVisitor` tracking the try-stack confirms **zero** unguarded `json.loads` in the 14 plugins. The audit used a grep pattern that missed function-level `try/except` blocks. |

Full analysis captured as NEXO learnings #188, #189, #190, #191, #192, #193, #194.

### Partial deferrals

- **Item 7 (PRAGMAs)**: only `wal_autocheckpoint` was bumped. Switching `auto_vacuum` from `NONE` to `INCREMENTAL` was deferred because the production DB currently has `freelist_count=0` (no fragmentation to reclaim) and changing it requires a blocking `VACUUM` rebuild.

- **Item 9 (diary_archive)**: left as is. The table is empty in production because no diaries have crossed the 180d threshold yet. All 3 MCP tools (`nexo_diary_archive_search`, `nexo_diary_archive_read`, `nexo_diary_archive_stats`) are fully wired up via `src/plugins/episodic_memory.py` and 7 SELECTs in `src/db/_episodic.py`. The audit claim of "write-only circuit" is incorrect.

### Discoveries outside the audit scope (not fixed in this PR)

Captured as learnings for future work:

1. **#186** — `nexo update` should restart active processes after a version bump, otherwise long-running MCP servers and LaunchAgents keep using stale in-memory code.
2. **#190** — Francisco's `NEXO_HOME` is `~/claude`, not the hardcoded default `~/.nexo`. A stale DB from April at `~/.nexo/data/nexo.db` (475 KB, schema v21) should be cleaned up.
3. **#194** — `maintenance_schedule` has 8 task rows but `check_and_run_overdue()` is never invoked. The table is effectively dead code. Each cron runs its own script directly via LaunchAgent.
4. **Mirror `~/claude/`** — contains a full code copy that `auto_update.py` does NOT sync. `bin/nexo-brain.js` syncs it during install, but `git pull` does not touch it. Script changes in `src/scripts/*` may not reach user runtimes via `nexo update` alone.

## Test plan

- [x] `tests/test_migrations.py` passes (10 tests)
- [x] `tests/test_item_read_tokens_cleanup.py` new suite (4 tests): purge removes only expired, throttle blocks repeat calls, issue triggers cleanup, cleanup failure does not block issuance
- [x] Full suite minus doctor/deep-sleep: `430 passed in 29.71s`
- [x] Import verification: `python -c "import server"` OK from isolated worktree
- [x] Schema unchanged: no new migrations, no `db/__init__.py` exports added (respects learning #162 about partial mirror breakage)
- [ ] CI checks on GitHub Actions (awaiting run)

## Audit artefacts

All in `/Users/franciscoc/Desktop/`:
- `NEXO-AUDIT-2026-04-11.txt` — raw audit
- `NEXO-AUDIT-2026-04-11-roadmap.txt` — phased roadmap
- `NEXO-AUDIT-2026-04-11-progress.md` — live tracking file with every decision, command and test run
