### PR TITLE
fix(auto_update): rotate old backup directories to cap disk usage

### DIFF
--- a/src/auto_update.py
+++ b/src/auto_update.py
@@ -355,6 +355,52 @@ def _sync_crons():
         _log(f"Cron sync warning: {e}")
 
 
+AUTO_UPDATE_BACKUP_KEEP = 10
+"""Maximum number of auto-update backups to keep per prefix.
+
+Both `pre-autoupdate-*/` (DB snapshots) and `runtime-tree-*/` (code mirrors)
+were accumulating indefinitely, growing to tens of GB on long-running
+installs. Rotating to the N most recent keeps a meaningful rollback window
+without unbounded disk use."""
+
+
+def _rotate_auto_update_backups(prefix: str, keep: int = AUTO_UPDATE_BACKUP_KEEP) -> int:
+    """Delete old auto-update backup directories matching a prefix, keeping `keep` most recent.
+
+    Silent on failures — cleanup must never interrupt the auto-update flow.
+    Returns number of entries removed (0 on failure or nothing to prune).
+    """
+    if keep <= 0:
+        return 0
+    base = NEXO_HOME / "backups"
+    if not base.is_dir():
+        return 0
+    try:
+        candidates = [p for p in base.iterdir() if p.is_dir() and p.name.startswith(prefix)]
+    except Exception as e:
+        _log(f"Backup rotation scan warning ({prefix}): {e}")
+        return 0
+    if len(candidates) <= keep:
+        return 0
+    # Newest first by modification time, then delete everything beyond `keep`
+    try:
+        candidates.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    except Exception as e:
+        _log(f"Backup rotation sort warning ({prefix}): {e}")
+        return 0
+    removed = 0
+    import shutil as _shutil
+    for old in candidates[keep:]:
+        try:
+            _shutil.rmtree(str(old))
+            removed += 1
+        except Exception as e:
+            _log(f"Backup rotation remove warning ({old.name}): {e}")
+    if removed:
+        _log(f"Rotated {removed} old {prefix}* backup(s), kept {keep} most recent")
+    return removed
+
+
 def _backup_dbs() -> str | None:
     """Snapshot all .db files before migration. Returns backup dir or None."""
     import sqlite3
@@ -388,6 +434,14 @@ def _backup_dbs() -> str | None:
                         conn.close()
                     except Exception:
                         pass
+    # Opportunistic rotation: keep only the N most recent pre-autoupdate dirs.
+    # Failures here must never bubble up — the caller depends on the backup
+    # path string for rollback and should not see spurious exceptions from
+    # housekeeping of older entries.
+    try:
+        _rotate_auto_update_backups("pre-autoupdate-")
+    except Exception as e:
+        _log(f"Backup rotation warning (pre-autoupdate): {e}")
     return str(backup_dir)
 
 
@@ -1315,6 +1369,13 @@ def _backup_runtime_tree(dest: Path = NEXO_HOME) -> str:
     if (dest / "bin").is_dir():
         import shutil
         shutil.copytree(str(dest / "bin"), str(backup_dir / "bin"), dirs_exist_ok=True)
+    # Opportunistic rotation: runtime-tree snapshots were accumulating forever
+    # because nothing ever pruned them. Keep only the N most recent; failures
+    # must never block the runtime-tree caller's rollback flow.
+    try:
+        _rotate_auto_update_backups("runtime-tree-")
+    except Exception as e:
+        _log(f"Backup rotation warning (runtime-tree): {e}")
     return str(backup_dir)
 
 

--- a/src/plugins/backup.py
+++ b/src/plugins/backup.py
@@ -100,13 +100,24 @@ def handle_backup_restore(filename: str) -> str:
 
 
 def _cleanup_old():
-    """Remove backups older than RETENTION_DAYS."""
+    """Remove backups older than RETENTION_DAYS.
+
+    Covers both the hourly `nexo-YYYY-MM-DD-HHMM.db` snapshots and the
+    `nexo-pre-restore-*.db` safety snapshots created by handle_backup_restore.
+    Failures are swallowed — housekeeping must never interrupt the caller.
+    """
     if not os.path.isdir(BACKUP_DIR):
         return
     cutoff = time.time() - (RETENTION_DAYS * 86400)
+    # glob `nexo-*.db` matches both the hourly pattern and pre-restore
+    # snapshots, so a single loop prunes both with a single pass.
     for f in glob.glob(os.path.join(BACKUP_DIR, "nexo-*.db")):
-        if os.path.getmtime(f) < cutoff:
-            os.remove(f)
+        try:
+            if os.path.getmtime(f) < cutoff:
+                os.remove(f)
+        except OSError:
+            # Permission / concurrent removal — skip silently.
+            pass
 
 
 TOOLS = [

--- a/tests/test_backup_rotation.py
+++ b/tests/test_backup_rotation.py
@@ -1,0 +1,136 @@
+"""Tests for auto-update backup rotation.
+
+Covers NEXO-AUDIT-2026-04-11 post-fase1 finding: both `pre-autoupdate-*/`
+and `runtime-tree-*/` backup directories were accumulating forever under
+`$NEXO_HOME/backups/` with no rotation. The fix keeps the N most recent
+entries per prefix and silently swallows housekeeping failures so the
+auto-update flow can never be interrupted by cleanup problems.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def isolated_nexo_home(tmp_path, monkeypatch):
+    """Point NEXO_HOME at an empty temp directory for the duration of the test.
+
+    The auto_update module reads NEXO_HOME at import time, so we re-import
+    the module under the patched environment."""
+    backups_dir = tmp_path / "backups"
+    backups_dir.mkdir()
+
+    monkeypatch.setenv("NEXO_HOME", str(tmp_path))
+
+    import auto_update
+    mod = importlib.reload(auto_update)
+    return mod, backups_dir
+
+
+def _make_backup_dir(base: Path, name: str, mtime_offset: int = 0) -> Path:
+    d = base / name
+    d.mkdir()
+    (d / "marker").write_text("ok")
+    if mtime_offset:
+        t = time.time() + mtime_offset
+        os.utime(str(d), (t, t))
+    return d
+
+
+def test_rotate_keeps_newest_n_pre_autoupdate(isolated_nexo_home):
+    auto_update, backups_dir = isolated_nexo_home
+
+    # Create 15 pre-autoupdate dirs with increasing (more recent) mtimes
+    created = []
+    for i in range(15):
+        # Offset ranges from -1400 to 0 seconds so index 14 is the newest
+        d = _make_backup_dir(backups_dir, f"pre-autoupdate-{i:02d}", mtime_offset=-1400 + i * 100)
+        created.append(d)
+
+    removed = auto_update._rotate_auto_update_backups("pre-autoupdate-", keep=10)
+    assert removed == 5
+
+    remaining = sorted(
+        p.name for p in backups_dir.iterdir()
+        if p.is_dir() and p.name.startswith("pre-autoupdate-")
+    )
+    # Oldest 5 (00..04) should be gone, newest 10 (05..14) should remain
+    assert remaining == [f"pre-autoupdate-{i:02d}" for i in range(5, 15)]
+
+
+def test_rotate_keeps_newest_n_runtime_tree(isolated_nexo_home):
+    auto_update, backups_dir = isolated_nexo_home
+
+    for i in range(12):
+        _make_backup_dir(backups_dir, f"runtime-tree-{i:02d}", mtime_offset=-1200 + i * 100)
+
+    removed = auto_update._rotate_auto_update_backups("runtime-tree-", keep=10)
+    assert removed == 2
+
+    remaining = sorted(
+        p.name for p in backups_dir.iterdir() if p.name.startswith("runtime-tree-")
+    )
+    assert remaining == [f"runtime-tree-{i:02d}" for i in range(2, 12)]
+
+
+def test_rotate_noop_when_fewer_than_keep(isolated_nexo_home):
+    auto_update, backups_dir = isolated_nexo_home
+
+    for i in range(3):
+        _make_backup_dir(backups_dir, f"pre-autoupdate-{i:02d}")
+
+    removed = auto_update._rotate_auto_update_backups("pre-autoupdate-", keep=10)
+    assert removed == 0
+
+    remaining = sorted(p.name for p in backups_dir.iterdir())
+    assert len(remaining) == 3
+
+
+def test_rotate_only_touches_matching_prefix(isolated_nexo_home):
+    auto_update, backups_dir = isolated_nexo_home
+
+    # Mix prefixes: 12 pre-autoupdate + 5 runtime-tree + 3 other
+    for i in range(12):
+        _make_backup_dir(backups_dir, f"pre-autoupdate-{i:02d}", mtime_offset=-1200 + i * 100)
+    for i in range(5):
+        _make_backup_dir(backups_dir, f"runtime-tree-{i:02d}")
+    for i in range(3):
+        _make_backup_dir(backups_dir, f"something-else-{i:02d}")
+
+    removed = auto_update._rotate_auto_update_backups("pre-autoupdate-", keep=10)
+    assert removed == 2
+
+    # runtime-tree-* and something-else-* must be untouched
+    assert sum(1 for p in backups_dir.iterdir() if p.name.startswith("runtime-tree-")) == 5
+    assert sum(1 for p in backups_dir.iterdir() if p.name.startswith("something-else-")) == 3
+
+
+def test_rotate_is_silent_when_base_missing(isolated_nexo_home, tmp_path):
+    auto_update, backups_dir = isolated_nexo_home
+
+    # Wipe backups dir entirely and verify no exception surfaces
+    import shutil
+    shutil.rmtree(str(backups_dir))
+    assert not backups_dir.exists()
+
+    removed = auto_update._rotate_auto_update_backups("pre-autoupdate-", keep=10)
+    assert removed == 0
+
+
+def test_rotate_zero_keep_is_noop(isolated_nexo_home):
+    """Safety: keep<=0 should not wipe all backups — it's a defensive no-op
+    so a buggy caller can never nuke the entire backup history."""
+    auto_update, backups_dir = isolated_nexo_home
+
+    for i in range(5):
+        _make_backup_dir(backups_dir, f"pre-autoupdate-{i:02d}")
+
+    removed = auto_update._rotate_auto_update_backups("pre-autoupdate-", keep=0)
+    assert removed == 0
+    assert len(list(backups_dir.iterdir())) == 5


### PR DESCRIPTION
## Summary

Post-Fase 1 finding (not in the original audit): both `pre-autoupdate-*/` and `runtime-tree-*/` backup directories under `$NEXO_HOME/backups/` were accumulating forever. On a production check-in today that directory had **329 entries and ~10 GB** of old backups with no rotation.

## What this PR changes

- New helper `_rotate_auto_update_backups(prefix, keep=10)` in `src/auto_update.py`.
- Called opportunistically at the end of `_backup_dbs()` and `_backup_runtime_tree()` so every successful backup leaves at most `AUTO_UPDATE_BACKUP_KEEP=10` entries per prefix.
- Both the helper and the call sites are wrapped in `try/except` — cleanup failures never surface to the caller or invalidate the auto-update rollback path.
- Safety knob: `keep<=0` is a defensive no-op so a buggy caller can never wipe the entire history.
- Sort is by `mtime` desc, so the newest N survive regardless of directory name.

Also tightens `plugins/backup.py::_cleanup_old`:
- Wraps per-file `os.remove` in `OSError` handling so permission / concurrent-removal issues do not escape housekeeping.
- Docstring clarifies the glob already covers the hourly `nexo-YYYY-MM-DD-HHMM.db` line **and** `nexo-pre-restore-*.db` safety snapshots.

## New tests

`tests/test_backup_rotation.py` (6 tests):
1. keeps newest N of `pre-autoupdate-*`
2. keeps newest N of `runtime-tree-*`
3. no-op when fewer than keep exist
4. only touches matching prefix (sibling directories untouched)
5. silent when base dir missing
6. `keep<=0` is a defensive no-op (never wipes entire history)

## Test plan

- [x] `pytest tests/test_backup_rotation.py`: 6 passed
- [x] `pytest tests/test_migrations.py tests/test_item_read_tokens_cleanup.py`: 14 passed
- [x] Full suite minus doctor/deep-sleep: **436 passed in 31.34s**
- [x] Diff: no behavioural change to backup **creation** paths — only opportunistic post-creation cleanup added
- [ ] CI checks on GitHub Actions

## Impact on users

Any user that has been running NEXO for more than ~1 month recovers tens of GB at the next `nexo update`. On Francisco's machine the first post-merge run will reclaim roughly 9 GB from `~/claude/backups/`.