### PR TITLE
chore(maintenance): remove dead check_and_run_overdue dispatcher (Learning #194)

### DIFF
--- a/src/maintenance.py
+++ b/src/maintenance.py
@@ -1,62 +1,53 @@
-"""Opportunistic maintenance — run overdue tasks on MCP startup."""
+"""Placeholder module for historical `maintenance` runner.
 
-import time
-from datetime import datetime, timezone
-from db import get_db
+HISTORICAL CONTEXT (NEXO-AUDIT-2026-04-11 finding, Learning #194)
+==================================================================
 
+This module previously exposed `check_and_run_overdue()` and a private
+`_run_task()` dispatcher that walked the `maintenance_schedule` table and
+executed cognitive decay, synthesis, self audit, weight learning, somatic
+decay, somatic projection, drive decay and graph maintenance as needed.
 
-def check_and_run_overdue():
-    conn = get_db()
-    rows = conn.execute("SELECT task_name, interval_hours, last_run_at FROM maintenance_schedule").fetchall()
-    ran = []
-    for row in rows:
-        task = row["task_name"]
-        interval = row["interval_hours"]
-        last_run = row["last_run_at"]
-        if last_run:
-            try:
-                last_dt = datetime.strptime(last_run, "%Y-%m-%dT%H:%M:%S")
-                hours_since = (datetime.now(timezone.utc).replace(tzinfo=None) - last_dt).total_seconds() / 3600
-                if hours_since < interval:
-                    continue
-            except (ValueError, TypeError):
-                pass
-        start = time.time()
-        try:
-            _run_task(task)
-            duration_ms = int((time.time() - start) * 1000)
-            conn.execute(
-                "UPDATE maintenance_schedule SET last_run_at = ?, last_duration_ms = ?, "
-                "run_count = run_count + 1 WHERE task_name = ?",
-                (datetime.now(timezone.utc).replace(tzinfo=None).strftime("%Y-%m-%dT%H:%M:%S"), duration_ms, task))
-            conn.commit()
-            ran.append({"task": task, "duration_ms": duration_ms})
-        except Exception as e:
-            ran.append({"task": task, "error": str(e)})
-    return ran
+None of that code was ever called from anywhere. A repository-wide grep
+for `check_and_run_overdue`, `from maintenance`, `import maintenance` and
+`maintenance.check` produced zero hits during the 2026-04-11 audit. Each
+of those tasks actually runs from its own LaunchAgent via its own script
+in `src/scripts/` (e.g. `nexo-cognitive-decay.py`, `nexo-daily-self-audit
+.py`, `nexo-evolution-run.py`), not through this dispatcher. The
+`maintenance_schedule` table in SQLite is still populated by migrations
+(see `db/_schema.py::_m9_maintenance_schedule` and the drive_decay
+registration) but is effectively dead data: nothing reads it.
 
+Why the dispatcher was removed
+------------------------------
+The dead dispatcher was actively misleading: developers reading the code
+could reasonably conclude that adding a row to `maintenance_schedule`
+would cause the named task to run. It would not. That false contract
+was the root of a near-miss during the Item 9 fix of the 2026-04-11
+audit, where the first plan was to register a new `read_token_cleanup`
+task via this mechanism before discovering that the mechanism is never
+invoked. See `src/db/_reminders.py::_purge_expired_read_tokens_if_due`
+for the opportunistic-cleanup pattern that replaced that initial plan.
 
-def _run_task(task_name: str):
-    import cognitive
-    if task_name == "cognitive_decay":
-        cognitive.apply_decay()
-        cognitive.promote_stm_to_ltm()
-        cognitive.gc_stm()
-    elif task_name == "somatic_decay":
-        cognitive.somatic_nightly_decay()
-    elif task_name == "somatic_projection":
-        cognitive.somatic_project_events()
-    elif task_name == "weight_learning":
-        try:
-            import sys, os
-            sys.path.insert(0, os.path.join(os.path.dirname(__file__), "plugins"))
-            from adaptive_mode import learn_weights, prune_adaptive_log
-            learn_weights()
-            prune_adaptive_log()
-        except Exception:
-            pass
-    elif task_name == "drive_decay":
-        from db import decay_drive_signals
-        decay_drive_signals()
-    elif task_name == "graph_maintenance":
-        pass  # Future: orphan cleanup, consolidation
+What to do if you need scheduled maintenance
+--------------------------------------------
+Do NOT reintroduce a dispatcher in this module. Pick one of:
+
+  * Add your work to an existing LaunchAgent script under
+    `src/scripts/` that already runs on the cadence you need.
+  * Register a new personal script via `nexo_personal_script_create` and
+    let the schedule/LaunchAgent system handle it.
+  * Run the cleanup opportunistically inside the hot path, throttled
+    by wall-clock (see `_purge_expired_read_tokens_if_due`).
+
+What happens to the `maintenance_schedule` table
+-------------------------------------------------
+The table is intentionally left in place. Removing it would require a
+destructive migration for every installed user with no benefit — the
+rows do no harm, cost a few KB each, and their removal is deferred to a
+future cleanup pass when migration numbering is renegotiated.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/tests/test_maintenance_dead_code.py
+++ b/tests/test_maintenance_dead_code.py
@@ -1,0 +1,47 @@
+"""Regression test for the maintenance.py dead-code removal.
+
+Records the invariant that src/maintenance.py must NOT re-export the old
+`check_and_run_overdue` / `_run_task` dispatcher that was removed in the
+NEXO-AUDIT-2026-04-11 cleanup (Learning #194). If a future change adds
+those names back, this test fails loudly so whoever is doing it has to
+either rename or confirm the intent.
+
+Why a test and not just a comment? During the audit we confirmed that
+the dispatcher had been dead code from the moment it was written, and
+that the existence of the false contract almost caused a regression.
+A test is the only way to keep that lesson compiled.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+
+def test_maintenance_module_does_not_re_export_dead_dispatcher():
+    mod = importlib.import_module("maintenance")
+
+    # The module is now a placeholder. It must not carry over the removed
+    # dispatcher surface. If you are here because you want to add one of
+    # these names back, STOP and read the docstring of src/maintenance.py
+    # first — the correct answer is almost certainly to attach your work
+    # to an existing LaunchAgent script, not to revive this dispatcher.
+    forbidden = [
+        "check_and_run_overdue",
+        "_run_task",
+    ]
+    for name in forbidden:
+        assert not hasattr(mod, name), (
+            f"maintenance.{name} must not be re-exported. "
+            "See NEXO-AUDIT-2026-04-11 Learning #194 and the docstring of "
+            "src/maintenance.py for the rationale."
+        )
+
+
+def test_maintenance_module_has_empty_public_surface():
+    mod = importlib.import_module("maintenance")
+
+    # The module is a placeholder with no public API.
+    assert getattr(mod, "__all__", None) == [], (
+        "maintenance.__all__ must stay empty — the module is a historical "
+        "placeholder. See src/maintenance.py docstring."
+    )


### PR DESCRIPTION
## Summary

`src/maintenance.py` exposed `check_and_run_overdue()` and a private `_run_task()` dispatcher that walked `maintenance_schedule` to run a list of cognitive / self-audit / evolution tasks. **Nobody ever called it.** Every task already runs via its own LaunchAgent script.

During the Fase 1 audit Item 9 fix, the first plan was to register a new maintenance task through this dead dispatcher — the trap almost closed before discovering the mechanism was hollow. See Learning #194.

## What this PR changes

- `src/maintenance.py` is now a placeholder module with a long docstring explaining what was removed, why, and what to do instead (LaunchAgent script, `nexo_personal_script_create`, or opportunistic in-band cleanup throttled by wall-clock).
- `__all__` is explicitly empty.
- `maintenance_schedule` table is **left alone** — removing it would need a destructive migration for every installed user with zero benefit.
- New regression test `tests/test_maintenance_dead_code.py` with two assertions that fail loudly if a future refactor reintroduces the dead surface.

## Why a test and not just a comment

The dispatcher was dead code from the moment it was written. A comment did not prevent it from living for months and almost causing a regression. A failing test is the only way to keep the lesson compiled.

## Runtime impact

**Zero.** Grep confirmed no call site existed, so removing the functions cannot break anything. The placeholder keeps `import maintenance` working in case anything ever reaches for the module.

## Test plan

- [x] `tests/test_maintenance_dead_code.py`: 2 passed
- [x] `tests/test_migrations.py + test_item_read_tokens_cleanup.py + test_backup_rotation.py`: 22 passed
- [x] Full suite minus doctor/deep-sleep: **438 passed in 30.56s**
- [ ] CI checks