### PR TITLE
fix(heartbeat): surface open protocol debt (audit-fase2 item 7)

### DIFF
--- a/src/tools_sessions.py
+++ b/src/tools_sessions.py
@@ -584,6 +584,35 @@ def handle_heartbeat(sid: str, task: str, context_hint: str = '') -> str:
         except Exception:
             pass  # Best-effort reminder only
 
+    # Protocol debt surfacing: if this session has open debts, warn so the
+    # agent can resolve them with nexo_protocol_debt_resolve before claiming
+    # any task complete. Mirrors task_open / task_close behavior so that
+    # protocol debt is visible at every protocol touchpoint, not only at
+    # task boundaries.
+    try:
+        from db import list_protocol_debts
+        session_debts = list_protocol_debts(status="open", session_id=sid, limit=5)
+        if session_debts:
+            error_count = sum(1 for d in session_debts if d.get("severity") == "error")
+            icon = "⛔" if error_count else "⚠"
+            parts.append("")
+            parts.append(
+                f"{icon} PROTOCOL DEBT: {len(session_debts)} open debt(s) in this session"
+                + (f" ({error_count} error)" if error_count else "")
+                + "."
+            )
+            for debt in session_debts[:3]:
+                evidence = (debt.get("evidence") or "").strip().replace("\n", " ")
+                parts.append(
+                    f"  [{debt.get('id')}] {debt.get('debt_type', '?')}"
+                    f" ({debt.get('severity', '?')}): {evidence[:100]}"
+                )
+            parts.append(
+                "  Resolve with nexo_protocol_debt_resolve before claiming task complete."
+            )
+    except Exception:
+        pass  # Best-effort surfacing, never block heartbeat
+
     return "\n".join(parts)
 
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -617,3 +617,68 @@ def test_task_open_previews_anticipatory_warnings_without_firing_trigger():
     assert payload["preventive_followup"]["id"].startswith("NF-PROTOCOL-")
     assert get_followup(payload["preventive_followup"]["id"]) is not None
     assert any(trigger["id"] == trigger_id for trigger in triggers)
+
+
+def test_heartbeat_surfaces_open_protocol_debt():
+    """heartbeat must warn when the current session has open protocol debt.
+
+    Mirrors task_open / task_close behavior so the agent sees protocol debt
+    at every protocol touchpoint, not only at task boundaries. Without this
+    surfacing, an agent could log many heartbeats without ever noticing
+    debts opened by self-audit, task_close, or guard checks.
+    """
+    from db import create_protocol_debt
+    from tools_sessions import handle_heartbeat
+
+    sid = _register_session("nexo-1011-2011")
+    create_protocol_debt(
+        sid,
+        "claimed_done_without_evidence",
+        severity="error",
+        evidence="Closed task without close_evidence payload",
+    )
+    create_protocol_debt(
+        sid,
+        "missing_followup_payload",
+        severity="warn",
+        evidence="duplicate followup id",
+    )
+
+    output = handle_heartbeat(sid=sid, task="continue work", context_hint="checking session state")
+
+    assert "PROTOCOL DEBT" in output
+    assert "2 open debt(s)" in output
+    assert "1 error" in output
+    assert "claimed_done_without_evidence" in output
+    assert "missing_followup_payload" in output
+    assert "nexo_protocol_debt_resolve" in output
+
+
+def test_heartbeat_silent_when_no_protocol_debt():
+    """heartbeat must NOT spam the protocol debt warning when the session is clean."""
+    from tools_sessions import handle_heartbeat
+
+    sid = _register_session("nexo-1012-2012")
+    output = handle_heartbeat(sid=sid, task="clean work", context_hint="all good")
+
+    assert "PROTOCOL DEBT" not in output
+
+
+def test_heartbeat_only_surfaces_current_session_debt():
+    """heartbeat must scope debt surfacing to the current session, not bleed across sessions."""
+    from db import create_protocol_debt
+    from tools_sessions import handle_heartbeat
+
+    other_sid = _register_session("nexo-1013-2013")
+    create_protocol_debt(
+        other_sid,
+        "claimed_done_without_evidence",
+        severity="error",
+        evidence="other session debt",
+    )
+
+    current_sid = _register_session("nexo-1014-2014")
+    output = handle_heartbeat(sid=current_sid, task="my work", context_hint="my context")
+
+    assert "PROTOCOL DEBT" not in output
+    assert "other session debt" not in output


### PR DESCRIPTION
## Summary

Surface open `protocol_debt` rows for the active session in every `nexo_heartbeat` call. Closes Fase 2 item 7 of NEXO-AUDIT-2026-04-11.

`task_open` and `task_close` already returned `open_debts`, but `handle_heartbeat` did not. That left a window where an agent could rack up dozens of heartbeats during a long session without ever being told that protocol debt was piling up (debts opened by self-audit, guard checks, or task_close discipline). Now every heartbeat checks once and prints a single block when relevant.

## What changed

`src/tools_sessions.py:handle_heartbeat()` — adds a best-effort try/except block immediately after the LEARNING REMINDER:

- Calls `list_protocol_debts(status="open", session_id=sid, limit=5)`
- Skips silently when nothing is open (no spam on clean sessions)
- Stop icon when any debt is severity `error`, warn icon otherwise
- Shows up to 3 debts with id, type, severity and 100-char evidence
- Always points to `nexo_protocol_debt_resolve` as the next action
- Wrapped in try/except so a DB hiccup never blocks heartbeat

`tests/test_protocol.py` — adds 3 regression tests:

1. `test_heartbeat_surfaces_open_protocol_debt` — error+warn debts produce the warning, count, severity tally, debt types and resolver tip.
2. `test_heartbeat_silent_when_no_protocol_debt` — clean session emits no PROTOCOL DEBT line.
3. `test_heartbeat_only_surfaces_current_session_debt` — debts opened by another session do not bleed across.

## Empirical verification before the fix

Per Phase 1 audit discipline (every audit item must be verified empirically before touching code, see learnings #188-#194):

- `grep` on `src/tools_sessions.py`: zero pre-existing references to `protocol_debt` or `list_protocol_debts`
- `grep` on `tests/`: zero existing heartbeat-debt regressions
- `nexo-daily-self-audit.py` creates `codex_session_missing_heartbeat` debts post-mortem but does no in-session surfacing
- Guard learning #50 (`No marcar capacidades de NEXO como gaps sin verificar tools y tests`) was triggered by `nexo_guard_check` and forced the verification before declaring the gap real

## Test plan

- [x] `pytest tests/test_protocol.py -v` — 23/23 passing (3 new tests included)
- [x] `pytest tests/test_self_audit.py tests/test_hook_guardrails.py -v` — 25/25 passing (no regression in adjacent surfaces)
- [x] `python -c "import server"` — clean import
- [ ] CI: 4 status checks must pass before merge

## Risk

Low. Single best-effort block, single new DB query (LIMIT 5), zero schema change, zero migration, zero new dependency. The try/except mirrors the existing pattern used by drive detection, diary draft, learning reminder and guard reminder in the same function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
