### PR TITLE
fix(evolution): apply user-approved proposals on next cycle (audit-fase2 item 1)

### DIFF
--- a/src/db/_schema.py
+++ b/src/db/_schema.py
@@ -886,6 +886,24 @@ def _m37_cortex_goal_profile_trace(conn):
     conn.execute("CREATE INDEX IF NOT EXISTS idx_cortex_evaluations_goal_profile ON cortex_evaluations(goal_profile_id)")
 
 
+def _m38_evolution_log_proposal_payload(conn):
+    """Persist the full proposal dict (with `changes` array) so user-approved
+    proposals can be applied by a later cycle.
+
+    Before m38, evolution_log only stored the proposal `action` string. When a
+    user marked a proposal as `accepted` via nexo_evolution_approve, the next
+    cycle had no way to re-execute it because the `changes` operations were
+    discarded after the original cycle. Adding `proposal_payload` (TEXT/JSON)
+    closes that loop and lets _apply_accepted_proposals() in the runner pick
+    up accepted rows and run them through execute_auto_proposal().
+
+    Idempotent and append-only: ALTER TABLE ADD COLUMN is non-destructive in
+    SQLite. Pre-m38 rows keep proposal_payload NULL and are skipped by the
+    apply step (which requires a non-null payload).
+    """
+    _migrate_add_column(conn, "evolution_log", "proposal_payload", "TEXT DEFAULT NULL")
+
+
 MIGRATIONS = [
     (1, "learnings_columns", _m1_learnings_columns),
     (2, "followups_reasoning", _m2_followups_reasoning),
@@ -924,6 +942,7 @@ MIGRATIONS = [
     (35, "cortex_evaluation_outcome_link", _m35_cortex_evaluation_outcome_link),
     (36, "goal_profiles", _m36_goal_profiles),
     (37, "cortex_goal_profile_trace", _m37_cortex_goal_profile_trace),
+    (38, "evolution_log_proposal_payload", _m38_evolution_log_proposal_payload),
 ]
 
 

--- a/src/scripts/nexo-evolution-run.py
+++ b/src/scripts/nexo-evolution-run.py
@@ -1231,6 +1231,136 @@ def _create_failure_followup(conn: sqlite3.Connection, cycle_num: int, log_id: i
         log(f"  WARN: Failed to create failure followup: {e}")
 
 
+# ── Apply user-approved proposals from prior cycles ─────────────────────
+def _apply_accepted_proposals(
+    conn: sqlite3.Connection,
+    cycle_num: int,
+    max_to_apply: int,
+    evolution_mode: str,
+) -> dict:
+    """Apply evolution_log rows that the user marked as `accepted`.
+
+    Reads up to `max_to_apply` rows where `status = 'accepted'` and
+    `proposal_payload IS NOT NULL`, deserializes the original proposal dict,
+    and runs each one through `execute_auto_proposal()` (same path as live
+    AUTO proposals: snapshot, apply, validate, rollback on failure).
+
+    Updates each row's status to one of: 'applied', 'rolled_back', 'blocked',
+    'skipped'. Failed rows get an `NF-EVO-L<id>` followup so they remain
+    visible after the cycle. The cycle continues even if individual rows
+    fail — one bad proposal does not block the queue.
+
+    Pre-m38 rows have NULL proposal_payload and are intentionally skipped:
+    we cannot reconstruct their `changes` array.
+
+    Returns: dict with attempted/applied/rolled_back/blocked/skipped/failed counts.
+    """
+    rows = conn.execute(
+        "SELECT id, dimension, proposal, reasoning, proposal_payload "
+        "FROM evolution_log WHERE status = 'accepted' AND proposal_payload IS NOT NULL "
+        "ORDER BY id ASC LIMIT ?",
+        (max(1, int(max_to_apply)),),
+    ).fetchall()
+
+    stats = {
+        "attempted": 0,
+        "applied": 0,
+        "rolled_back": 0,
+        "blocked": 0,
+        "skipped": 0,
+        "failed": 0,
+    }
+
+    for row in rows:
+        log_id = row["id"]
+        raw_payload = row["proposal_payload"]
+        try:
+            payload = json.loads(raw_payload)
+        except Exception as e:
+            log(f"  ACCEPTED #{log_id} skipped: invalid payload ({e})")
+            conn.execute(
+                "UPDATE evolution_log SET status = ?, test_result = ? WHERE id = ?",
+                ("skipped", f"Invalid proposal_payload JSON: {e}", log_id),
+            )
+            stats["skipped"] += 1
+            continue
+
+        if not isinstance(payload, dict) or not payload.get("changes"):
+            log(f"  ACCEPTED #{log_id} skipped: payload missing changes array")
+            conn.execute(
+                "UPDATE evolution_log SET status = ?, test_result = ? WHERE id = ?",
+                ("skipped", "Payload missing or empty changes array", log_id),
+            )
+            stats["skipped"] += 1
+            continue
+
+        action = (payload.get("action") or row["proposal"] or "")[:80]
+        log(f"  ACCEPTED #{log_id} applying: {action}")
+        stats["attempted"] += 1
+
+        try:
+            result = execute_auto_proposal(payload, cycle_num, conn, mode=evolution_mode)
+        except Exception as e:
+            log(f"    FAILED execute_auto_proposal: {e}")
+            conn.execute(
+                "UPDATE evolution_log SET status = ?, test_result = ? WHERE id = ?",
+                ("blocked", f"execute_auto_proposal raised: {e}", log_id),
+            )
+            stats["failed"] += 1
+            try:
+                _create_failure_followup(
+                    conn, cycle_num, log_id, payload, {"status": "failed", "reason": str(e)}
+                )
+            except Exception:
+                pass
+            continue
+
+        status = str(result.get("status") or "failed")
+        update_sets = ["status = ?"]
+        update_vals: list[object] = [status]
+        if "test_result" in result:
+            update_sets.append("test_result = ?")
+            update_vals.append(str(result.get("test_result", ""))[:2000])
+        if result.get("snapshot_ref"):
+            update_sets.append("snapshot_ref = ?")
+            update_vals.append(result["snapshot_ref"])
+        if result.get("files_changed"):
+            update_sets.append("files_changed = ?")
+            update_vals.append(json.dumps(result["files_changed"]))
+        update_vals.append(log_id)
+        conn.execute(
+            f"UPDATE evolution_log SET {', '.join(update_sets)} WHERE id = ?",
+            update_vals,
+        )
+
+        if status == "applied":
+            stats["applied"] += 1
+            log(f"    APPLIED")
+        elif status == "rolled_back":
+            stats["rolled_back"] += 1
+            log(f"    ROLLED BACK: {str(result.get('test_result', ''))[:100]}")
+            try:
+                _create_failure_followup(conn, cycle_num, log_id, payload, result)
+            except Exception:
+                pass
+        elif status == "blocked":
+            stats["blocked"] += 1
+            log(f"    BLOCKED: {str(result.get('reason') or result.get('test_result', ''))[:100]}")
+            try:
+                _create_failure_followup(conn, cycle_num, log_id, payload, result)
+            except Exception:
+                pass
+        elif status == "skipped":
+            stats["skipped"] += 1
+            log(f"    SKIPPED: {result.get('reason', '')}")
+        else:
+            stats["failed"] += 1
+            log(f"    UNKNOWN STATUS: {status}")
+
+    conn.commit()
+    return stats
+
+
 # ── Main run ─────────────────────────────────────────────────────────────
 def run():
     log("=" * 60)
@@ -1272,6 +1402,40 @@ def run():
         set_consecutive_failures(failures + 1)
         sys.exit(1)
     log("Restore test PASSED")
+
+    # Apply user-approved proposals from prior cycles BEFORE generating new ones.
+    # nexo_evolution_approve marks proposals as 'accepted' but until m38 there
+    # was no consumer for that status. This step closes the loop so the user's
+    # explicit approvals actually run on the next cycle, with the same sandbox
+    # / snapshot / rollback safety as live AUTO proposals.
+    log("Checking for user-approved proposals to apply...")
+    cycle_num_for_apply = objective.get("total_evolutions", 0) + 1
+    evolution_mode_for_apply = _normalize_mode(objective.get("evolution_mode", "auto"))
+    max_to_apply = max_auto_changes(objective.get("total_evolutions", 0))
+    apply_conn = sqlite3.connect(str(NEXO_DB), timeout=10)
+    apply_conn.row_factory = sqlite3.Row
+    apply_conn.execute("PRAGMA busy_timeout=5000")
+    try:
+        apply_stats = _apply_accepted_proposals(
+            apply_conn,
+            cycle_num_for_apply,
+            max_to_apply,
+            evolution_mode_for_apply,
+        )
+        if apply_stats["attempted"]:
+            log(
+                f"  Applied {apply_stats['applied']}/{apply_stats['attempted']} accepted proposals "
+                f"({apply_stats['rolled_back']} rolled back, "
+                f"{apply_stats['blocked']} blocked, "
+                f"{apply_stats['skipped']} skipped, "
+                f"{apply_stats['failed']} failed)"
+            )
+        else:
+            log("  No user-approved proposals pending")
+    except Exception as e:
+        log(f"  WARN: apply_accepted_proposals raised: {e}")
+    finally:
+        apply_conn.close()
 
     # Gather data
     log("Gathering week data from nexo.db...")
@@ -1348,8 +1512,9 @@ def run():
             log(f"  QUEUED [{scope}]: {action[:80]}")
             conn.execute(
                 "INSERT INTO evolution_log (cycle_number, dimension, proposal, classification, "
-                "reasoning, status) VALUES (?, ?, ?, ?, ?, ?)",
-                (cycle_num, dimension, action, classification, reasoning, "pending_review")
+                "reasoning, status, proposal_payload) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (cycle_num, dimension, action, classification, reasoning, "pending_review",
+                 json.dumps(p, ensure_ascii=False))
             )
             followup_items.append({
                 "dimension": dimension,
@@ -1369,12 +1534,13 @@ def run():
 
             cur = conn.execute(
                 "INSERT INTO evolution_log (cycle_number, dimension, proposal, classification, "
-                "reasoning, status, files_changed, snapshot_ref, test_result) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "reasoning, status, files_changed, snapshot_ref, test_result, proposal_payload) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (cycle_num, dimension, action, "auto", reasoning, status,
                  json.dumps(result.get("files_changed", [])),
                  result.get("snapshot_ref", ""),
-                 result.get("test_result", ""))
+                 result.get("test_result", ""),
+                 json.dumps(p, ensure_ascii=False))
             )
             log_id = cur.lastrowid
 
@@ -1401,8 +1567,9 @@ def run():
 
             conn.execute(
                 "INSERT INTO evolution_log (cycle_number, dimension, proposal, classification, "
-                "reasoning, status) VALUES (?, ?, ?, ?, ?, ?)",
-                (cycle_num, dimension, action, classification, reasoning, "proposed")
+                "reasoning, status, proposal_payload) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (cycle_num, dimension, action, classification, reasoning, "proposed",
+                 json.dumps(p, ensure_ascii=False))
             )
             if evolution_mode in {"review", "managed"}:
                 followup_items.append({

--- a/tests/test_evolution.py
+++ b/tests/test_evolution.py
@@ -75,7 +75,8 @@ def evolution_env(tmp_path, monkeypatch):
         "id INTEGER PRIMARY KEY AUTOINCREMENT, created_at TEXT DEFAULT (datetime('now')), "
         "cycle_number INTEGER NOT NULL, dimension TEXT NOT NULL, proposal TEXT NOT NULL, "
         "classification TEXT NOT NULL DEFAULT 'auto', status TEXT DEFAULT 'pending', "
-        "files_changed TEXT, snapshot_ref TEXT, test_result TEXT, impact INTEGER DEFAULT 0, reasoning TEXT NOT NULL)"
+        "files_changed TEXT, snapshot_ref TEXT, test_result TEXT, impact INTEGER DEFAULT 0, "
+        "reasoning TEXT NOT NULL, proposal_payload TEXT DEFAULT NULL)"
     )
     conn.execute(
         "CREATE TABLE evolution_metrics ("
@@ -646,3 +647,310 @@ class TestPublicContributionExecution:
         assert marks == ["peer_reviewed:1"]
         assert saved
         assert saved[-1]["history"][0]["mode"] == "public_core_review"
+
+
+class TestApplyAcceptedProposals:
+    """Fase 2 item 1: user-approved proposals must actually be applied.
+
+    Before m38 + _apply_accepted_proposals, calling nexo_evolution_approve
+    just flipped status to 'accepted' and the row was never consumed.
+    These tests pin the closed loop: the runner reads accepted rows that
+    have a proposal_payload and runs them through execute_auto_proposal.
+    """
+
+    def _seed_accepted(
+        self,
+        env: Path,
+        *,
+        action: str,
+        changes: list[dict],
+        cycle_number: int = 1,
+        dimension: str = "reliability",
+        reasoning: str = "user approved",
+        payload_override: object = None,
+    ) -> int:
+        conn = sqlite3.connect(str(env / "data" / "nexo.db"))
+        try:
+            payload = (
+                payload_override
+                if payload_override is not None
+                else json.dumps({
+                    "classification": "propose",
+                    "dimension": dimension,
+                    "action": action,
+                    "reasoning": reasoning,
+                    "scope": "local",
+                    "changes": changes,
+                })
+            )
+            cur = conn.execute(
+                "INSERT INTO evolution_log (cycle_number, dimension, proposal, classification, "
+                "reasoning, status, proposal_payload) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (cycle_number, dimension, action, "propose", reasoning, "accepted", payload),
+            )
+            conn.commit()
+            return int(cur.lastrowid)
+        finally:
+            conn.close()
+
+    def test_apply_accepted_runs_user_approved_proposal_and_marks_applied(
+        self, evolution_env, monkeypatch
+    ):
+        target = evolution_env / "scripts" / "approved_patch.py"
+        target.write_text("print('before')\n")
+
+        _, runner = _load_runner_module(monkeypatch, evolution_env)
+        runner.dry_run_restore_test = lambda: True
+
+        log_id = self._seed_accepted(
+            evolution_env,
+            action="Apply user-approved patch",
+            changes=[
+                {
+                    "file": str(target),
+                    "operation": "replace",
+                    "search": "print('before')\n",
+                    "content": "print('after')\n",
+                }
+            ],
+        )
+
+        conn = sqlite3.connect(str(evolution_env / "data" / "nexo.db"))
+        conn.row_factory = sqlite3.Row
+        try:
+            stats = runner._apply_accepted_proposals(
+                conn, cycle_num=2, max_to_apply=3, evolution_mode="managed"
+            )
+            row = conn.execute(
+                "SELECT status, files_changed, test_result FROM evolution_log WHERE id = ?",
+                (log_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+
+        assert stats["attempted"] == 1
+        assert stats["applied"] == 1
+        assert stats["rolled_back"] == 0
+        assert stats["blocked"] == 0
+        assert stats["skipped"] == 0
+        assert stats["failed"] == 0
+        assert row["status"] == "applied"
+        assert str(target) in (row["files_changed"] or "")
+        assert target.read_text() == "print('after')\n"
+
+    def test_apply_accepted_skips_rows_without_payload(self, evolution_env, monkeypatch):
+        _, runner = _load_runner_module(monkeypatch, evolution_env)
+
+        # Pre-m38 row: payload is NULL. Must NOT be touched.
+        conn = sqlite3.connect(str(evolution_env / "data" / "nexo.db"))
+        cur = conn.execute(
+            "INSERT INTO evolution_log (cycle_number, dimension, proposal, classification, "
+            "reasoning, status, proposal_payload) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (1, "reliability", "Pre-m38 legacy row", "propose", "legacy", "accepted", None),
+        )
+        legacy_id = cur.lastrowid
+        conn.commit()
+        conn.close()
+
+        conn = sqlite3.connect(str(evolution_env / "data" / "nexo.db"))
+        conn.row_factory = sqlite3.Row
+        try:
+            stats = runner._apply_accepted_proposals(
+                conn, cycle_num=2, max_to_apply=3, evolution_mode="managed"
+            )
+            row = conn.execute(
+                "SELECT status FROM evolution_log WHERE id = ?", (legacy_id,)
+            ).fetchone()
+        finally:
+            conn.close()
+
+        assert stats["attempted"] == 0
+        assert stats["applied"] == 0
+        assert row["status"] == "accepted"  # legacy row untouched
+
+    def test_apply_accepted_marks_skipped_when_payload_invalid_json(
+        self, evolution_env, monkeypatch
+    ):
+        _, runner = _load_runner_module(monkeypatch, evolution_env)
+
+        log_id = self._seed_accepted(
+            evolution_env,
+            action="Bad payload row",
+            changes=[],
+            payload_override="not-json{{",
+        )
+
+        conn = sqlite3.connect(str(evolution_env / "data" / "nexo.db"))
+        conn.row_factory = sqlite3.Row
+        try:
+            stats = runner._apply_accepted_proposals(
+                conn, cycle_num=2, max_to_apply=3, evolution_mode="managed"
+            )
+            row = conn.execute(
+                "SELECT status, test_result FROM evolution_log WHERE id = ?", (log_id,)
+            ).fetchone()
+        finally:
+            conn.close()
+
+        assert stats["skipped"] == 1
+        assert stats["applied"] == 0
+        assert row["status"] == "skipped"
+        assert "Invalid proposal_payload JSON" in (row["test_result"] or "")
+
+    def test_apply_accepted_marks_skipped_when_changes_array_missing(
+        self, evolution_env, monkeypatch
+    ):
+        _, runner = _load_runner_module(monkeypatch, evolution_env)
+
+        log_id = self._seed_accepted(
+            evolution_env,
+            action="No changes row",
+            changes=[],  # empty list, payload object will end up with []
+        )
+
+        conn = sqlite3.connect(str(evolution_env / "data" / "nexo.db"))
+        conn.row_factory = sqlite3.Row
+        try:
+            stats = runner._apply_accepted_proposals(
+                conn, cycle_num=2, max_to_apply=3, evolution_mode="managed"
+            )
+            row = conn.execute(
+                "SELECT status, test_result FROM evolution_log WHERE id = ?", (log_id,)
+            ).fetchone()
+        finally:
+            conn.close()
+
+        assert stats["skipped"] == 1
+        assert row["status"] == "skipped"
+        assert "missing or empty changes" in (row["test_result"] or "")
+
+    def test_apply_accepted_rolls_back_failed_proposal_and_creates_followup(
+        self, evolution_env, monkeypatch
+    ):
+        target = evolution_env / "scripts" / "rollback_target.py"
+        target.write_text("print('original')\n")
+
+        _, runner = _load_runner_module(monkeypatch, evolution_env)
+        runner.dry_run_restore_test = lambda: True
+
+        log_id = self._seed_accepted(
+            evolution_env,
+            action="Patch that will fail validation",
+            changes=[
+                {
+                    "file": str(target),
+                    "operation": "replace",
+                    "search": "missing-marker-not-in-file",
+                    "content": "print('would-not-apply')\n",
+                }
+            ],
+        )
+
+        conn = sqlite3.connect(str(evolution_env / "data" / "nexo.db"))
+        conn.row_factory = sqlite3.Row
+        try:
+            stats = runner._apply_accepted_proposals(
+                conn, cycle_num=2, max_to_apply=3, evolution_mode="managed"
+            )
+            row = conn.execute(
+                "SELECT status, test_result FROM evolution_log WHERE id = ?",
+                (log_id,),
+            ).fetchone()
+            followup = conn.execute(
+                "SELECT id, description FROM followups ORDER BY created_at DESC LIMIT 1"
+            ).fetchone()
+        finally:
+            conn.close()
+
+        # apply_change returns BLOCKED for missing search text — execute_auto_proposal
+        # raises and rolls back, so the row ends up rolled_back (no actual writes).
+        assert stats["attempted"] == 1
+        assert stats["applied"] == 0
+        assert row["status"] in ("rolled_back", "blocked")
+        assert followup is not None
+        assert followup["id"].startswith("NF-EVO-L")
+        assert target.read_text() == "print('original')\n"
+
+    def test_apply_accepted_respects_max_to_apply_cap(
+        self, evolution_env, monkeypatch
+    ):
+        targets = []
+        for i in range(5):
+            t = evolution_env / "scripts" / f"capped_{i}.py"
+            t.write_text(f"print('original_{i}')\n")
+            targets.append(t)
+
+        _, runner = _load_runner_module(monkeypatch, evolution_env)
+        runner.dry_run_restore_test = lambda: True
+
+        for i, t in enumerate(targets):
+            self._seed_accepted(
+                evolution_env,
+                action=f"Patch {i}",
+                changes=[
+                    {
+                        "file": str(t),
+                        "operation": "replace",
+                        "search": f"print('original_{i}')\n",
+                        "content": f"print('patched_{i}')\n",
+                    }
+                ],
+            )
+
+        conn = sqlite3.connect(str(evolution_env / "data" / "nexo.db"))
+        conn.row_factory = sqlite3.Row
+        try:
+            stats = runner._apply_accepted_proposals(
+                conn, cycle_num=2, max_to_apply=2, evolution_mode="managed"
+            )
+            applied_rows = conn.execute(
+                "SELECT id FROM evolution_log WHERE status = 'applied' ORDER BY id ASC"
+            ).fetchall()
+            still_accepted = conn.execute(
+                "SELECT COUNT(*) FROM evolution_log WHERE status = 'accepted'"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+
+        assert stats["attempted"] == 2
+        assert stats["applied"] == 2
+        assert len(applied_rows) == 2
+        assert still_accepted == 3  # 5 seeded - 2 applied = 3 left for future cycles
+
+    def test_m38_migration_is_idempotent_and_adds_proposal_payload(self):
+        """The m38 migration must be safe to re-run on a real schema."""
+        from db._schema import _m38_evolution_log_proposal_payload
+
+        # Build a minimal evolution_log table without proposal_payload, like
+        # any pre-m38 install would have.
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.execute(
+            "CREATE TABLE evolution_log ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, cycle_number INTEGER NOT NULL, "
+            "dimension TEXT NOT NULL, proposal TEXT NOT NULL, "
+            "classification TEXT NOT NULL DEFAULT 'auto', status TEXT DEFAULT 'pending', "
+            "files_changed TEXT, snapshot_ref TEXT, test_result TEXT, "
+            "impact INTEGER DEFAULT 0, reasoning TEXT NOT NULL)"
+        )
+        conn.execute(
+            "INSERT INTO evolution_log (cycle_number, dimension, proposal, reasoning) "
+            "VALUES (?, ?, ?, ?)",
+            (1, "safety", "pre-m38 row", "legacy"),
+        )
+        conn.commit()
+
+        # Run twice — must not raise.
+        _m38_evolution_log_proposal_payload(conn)
+        _m38_evolution_log_proposal_payload(conn)
+
+        cols = {row["name"] for row in conn.execute("PRAGMA table_info(evolution_log)")}
+        assert "proposal_payload" in cols
+
+        # Pre-existing row preserved with NULL payload.
+        row = conn.execute(
+            "SELECT proposal, proposal_payload FROM evolution_log WHERE id = 1"
+        ).fetchone()
+        assert row["proposal"] == "pre-m38 row"
+        assert row["proposal_payload"] is None
+        conn.close()


### PR DESCRIPTION
## Summary

Close the user-approval loop in the weekly Evolution cycle. Closes Fase 2 item 1 of NEXO-AUDIT-2026-04-11.

Before this change, `nexo_evolution_approve(log_id)` only flipped `evolution_log.status` to `'accepted'`. Nothing in `nexo-evolution-run.py` ever read those rows, so every user approval was effectively dead code. The `proposal` column was also a flat string (the action description), with no way to recover the `changes` array once the cycle finished.

Now the runner reads `accepted` rows at the start of each cycle and runs them through the existing `execute_auto_proposal()` path, with snapshot/apply/validate/rollback semantics intact.

## What changed

**Migration `m38_evolution_log_proposal_payload`** — adds `proposal_payload TEXT DEFAULT NULL` to `evolution_log`. Idempotent (`ALTER TABLE ADD COLUMN`), append-only, non-destructive. Pre-m38 rows keep `proposal_payload = NULL` and are intentionally skipped by the apply step.

**`nexo-evolution-run.py` INSERTs** — three insertion points now persist `json.dumps(p, ensure_ascii=False)` into `proposal_payload`:
- Review-mode queue (`status=pending_review`)
- Propose path for review/managed (`status=proposed`)
- Auto path (`status=applied/rolled_back/blocked`) — included for trace symmetry even though auto rows execute synchronously

**`_apply_accepted_proposals(conn, cycle_num, max_to_apply, evolution_mode)`** — new function:
- `SELECT ... FROM evolution_log WHERE status='accepted' AND proposal_payload IS NOT NULL ORDER BY id ASC LIMIT ?`
- Deserializes payload, validates `changes` array, calls `execute_auto_proposal()`
- Updates row to `applied` / `rolled_back` / `blocked` / `skipped` with `test_result`, `snapshot_ref`, `files_changed`
- Failed/rolled-back/blocked rows get an `NF-EVO-L<id>` followup so they remain visible
- Returns `{attempted, applied, rolled_back, blocked, skipped, failed}` stats
- One bad row never blocks the queue

**`run()` wiring** — the new step runs right after the dry-run restore test, before the LLM is invoked. User approvals from prior cycles always take precedence over freshly generated proposals. Wrapped in its own `sqlite3` connection with `row_factory` set so the helper can use named columns.

**Test fixture** — `tests/test_evolution.py::evolution_env` extends `CREATE TABLE evolution_log` with `proposal_payload TEXT DEFAULT NULL` so existing tests still exercise the modified INSERTs.

## Empirical verification before the fix

Per Phase 1 audit discipline (every audit item must be verified empirically before touching code):

- `grep "accepted"` in `nexo-evolution-run.py`: only one match, line 1009, an unrelated comment about file extension validators. Zero callers consume `status='accepted'`.
- `grep "evolution_log"` queries: only filtered by `cycle_number` or `id`, never by `status='accepted'`.
- `db/_evolution.py:update_evolution_log_status()` exists, but the runner never calls it for the `accepted -> applied` transition.
- All four evolution modes (`auto`, `review`, `managed`, `public_core`) and their `safe_zones` / `immutable_files` lists are unchanged. Existing rollback, snapshot, and circuit-breaker semantics are preserved.
- Guard learning #50 (`No marcar capacidades de NEXO como gaps sin verificar tools y tests`) was triggered by `nexo_guard_check` and forced this verification before declaring the gap real.

## Tests added (`TestApplyAcceptedProposals`)

| Test | Verifies |
|---|---|
| `test_apply_accepted_runs_user_approved_proposal_and_marks_applied` | Happy path: real `replace` change, file rewritten, status=`applied`, `files_changed` populated |
| `test_apply_accepted_skips_rows_without_payload` | Pre-m38 legacy row with `NULL` payload is left untouched (still `accepted`) |
| `test_apply_accepted_marks_skipped_when_payload_invalid_json` | Garbage JSON marks the row `skipped` with clear `test_result` |
| `test_apply_accepted_marks_skipped_when_changes_array_missing` | Payload without populated `changes` list marks row `skipped` |
| `test_apply_accepted_rolls_back_failed_proposal_and_creates_followup` | `search` not found triggers `RuntimeError`, status ends `rolled_back`/`blocked`, `NF-EVO-L*` followup created, original file content preserved |
| `test_apply_accepted_respects_max_to_apply_cap` | 5 seeded rows with cap of 2 means exactly 2 applied, 3 left for the next cycle |
| `test_m38_migration_is_idempotent_and_adds_proposal_payload` | Migration runs twice on a pre-m38 schema, adds the column, preserves pre-existing rows with `NULL` payload |

## Test plan

- [x] `pytest tests/test_evolution.py -v` — 21/21 passing (7 new tests included)
- [x] `pytest tests/test_migrations.py tests/test_protocol.py -v` — 33/33 passing (no regression in adjacent surfaces)
- [x] `python -c "import server"` — clean import
- [ ] CI: 4 status checks (verify-claude-plugin, verify-clawhub-skill, verify-client-parity, verify-openclaw-plugin)

## Risk

**Low-medium.** The new column and helper are additive. Pre-m38 rows are explicitly skipped (by `proposal_payload IS NOT NULL`) so any installation upgrading mid-week sees zero behavior change for legacy rows. Failures are caught at three levels:

1. Per-row try/except in `_apply_accepted_proposals` → row marked skipped/blocked
2. Whole-step try/except in `run()` → cycle continues with new proposals even if apply step crashes
3. `execute_auto_proposal()` already does snapshot + rollback on validation failure

The cap (`max_auto_changes(total_evolutions)` = 1, 2, or 3 per cycle) limits blast radius even if many approvals pile up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
