### PR TITLE
feat(skills): auto-promote outcome patterns to skill drafts (audit-fase2 item 2)

### DIFF
--- a/src/scripts/nexo-outcome-checker.py
+++ b/src/scripts/nexo-outcome-checker.py
@@ -74,6 +74,35 @@ def main() -> int:
             f"deadline={result.get('deadline')})"
         )
 
+    # Phase 2 item 2: after closing outcomes, attempt to promote any
+    # outcome pattern that just crossed the suggested-skill threshold to a
+    # real draft skill. The helper is idempotent and capped at
+    # max_promotions per run, so this is safe to call on every cycle.
+    promotion_summary: dict = {"promoted": [], "skipped": [], "errors": [], "scanned": 0}
+    try:
+        from skills_runtime import auto_promote_outcome_patterns_to_skills
+        promotion_summary = auto_promote_outcome_patterns_to_skills(
+            min_success_rate=0.8,
+            max_promotions=3,
+        )
+        if promotion_summary.get("promoted"):
+            log(
+                f"Auto-promoted {len(promotion_summary['promoted'])} outcome pattern(s) "
+                f"to skill draft(s) (scanned={promotion_summary.get('scanned', 0)})"
+            )
+            for entry in promotion_summary["promoted"]:
+                log(
+                    f"  -> {entry.get('pattern_key')} -> skill {entry.get('skill_id')} "
+                    f"(success_rate={entry.get('success_rate')}, created={entry.get('created')})"
+                )
+        elif promotion_summary.get("scanned"):
+            log(
+                f"Outcome pattern auto-promote: scanned {promotion_summary['scanned']}, "
+                f"none qualified (skipped={len(promotion_summary['skipped'])})"
+            )
+    except Exception as e:
+        log(f"WARN: outcome pattern auto-promote raised: {e}")
+
     summary = {
         "checked_at": datetime.now().isoformat(timespec="seconds"),
         "checked": checked,
@@ -82,6 +111,7 @@ def main() -> int:
         "pending": pending,
         "errors": errors,
         "ids": checked_ids,
+        "auto_promoted_patterns": promotion_summary,
     }
     SUMMARY_FILE.parent.mkdir(parents=True, exist_ok=True)
     SUMMARY_FILE.write_text(json.dumps(summary, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")

--- a/src/skills_runtime.py
+++ b/src/skills_runtime.py
@@ -620,6 +620,120 @@ def materialize_outcome_pattern_skill(pattern_key: str) -> dict:
     }
 
 
+def auto_promote_outcome_patterns_to_skills(
+    *,
+    min_success_rate: float = 0.8,
+    max_promotions: int = 3,
+) -> dict:
+    """Promote mature outcome patterns to draft skills without manual approval.
+
+    Closes Fase 2 item 2 of NEXO-AUDIT-2026-04-11. Until this function ran
+    automatically, every outcome pattern that crossed the suggested-skill
+    threshold sat in the candidates table waiting for an explicit
+    nexo_skill_seed_from_outcome_pattern call. The materialization helper
+    already existed (see materialize_outcome_pattern_skill above), but no
+    process invoked it on a schedule.
+
+    This wrapper:
+      - Lists current outcome pattern candidates (top 20).
+      - Filters to reinforce_strategy candidates that the analyzer already
+        flagged as suggested_skill_candidate=True (resolved >= 4) AND whose
+        success_rate is at or above min_success_rate (default 0.8).
+      - Calls materialize_outcome_pattern_skill() per qualifying candidate,
+        capped at max_promotions per invocation so a sudden flood does not
+        materialize dozens of skills in one cycle.
+      - materialize_outcome_pattern_skill() is itself idempotent: if the
+        target skill id already exists it returns created=False without
+        re-creating, so this function is safe to run repeatedly.
+
+    Returns a stats dict:
+        {
+          "promoted": [list of {pattern_key, skill_id, created}],
+          "skipped": [list of {pattern_key, reason}],
+          "errors":  [list of {pattern_key, error}],
+          "scanned": int,  # number of candidates inspected
+        }
+
+    Best-effort: never raises. A single failing pattern logs an error entry
+    but lets the loop continue, so one bad row never blocks the queue.
+    """
+    _ensure_ready()
+    sync_skill_directories()
+
+    promoted: list[dict] = []
+    skipped: list[dict] = []
+    errors: list[dict] = []
+
+    try:
+        candidates = list_outcome_pattern_candidates(limit=20)
+    except Exception as e:
+        return {
+            "promoted": [],
+            "skipped": [],
+            "errors": [{"pattern_key": "*", "error": f"list_outcome_pattern_candidates raised: {e}"}],
+            "scanned": 0,
+        }
+
+    scanned = 0
+    promote_budget = max(0, int(max_promotions))
+    for candidate in candidates:
+        scanned += 1
+        pattern_key = (candidate.get("pattern_key") or "").strip()
+        if not pattern_key:
+            skipped.append({"pattern_key": "", "reason": "missing pattern_key"})
+            continue
+        if candidate.get("candidate_type") != "reinforce_strategy":
+            skipped.append({"pattern_key": pattern_key, "reason": "not reinforce_strategy"})
+            continue
+        if not candidate.get("suggested_skill_candidate"):
+            skipped.append({"pattern_key": pattern_key, "reason": "below suggested_skill_candidate threshold"})
+            continue
+        success_rate = float(candidate.get("success_rate") or 0.0)
+        if success_rate < float(min_success_rate):
+            skipped.append({
+                "pattern_key": pattern_key,
+                "reason": f"success_rate {success_rate:.3f} < {min_success_rate:.3f}",
+            })
+            continue
+        if promote_budget <= 0:
+            skipped.append({"pattern_key": pattern_key, "reason": "promotion budget exhausted"})
+            continue
+
+        try:
+            result = materialize_outcome_pattern_skill(pattern_key)
+        except Exception as e:
+            errors.append({"pattern_key": pattern_key, "error": str(e)})
+            continue
+
+        if not result.get("ok"):
+            errors.append({
+                "pattern_key": pattern_key,
+                "error": result.get("error", "materialize_outcome_pattern_skill failed"),
+            })
+            continue
+
+        skill = result.get("skill") or {}
+        promoted.append({
+            "pattern_key": pattern_key,
+            "skill_id": skill.get("id") or skill.get("skill_id"),
+            "created": bool(result.get("created")),
+            "success_rate": success_rate,
+            "resolved_outcomes": int(candidate.get("resolved_outcomes") or 0),
+        })
+        # Only newly-created skills consume the budget. Idempotent re-use of
+        # an existing skill costs nothing because it didn't materialize a new
+        # one — letting other candidates through.
+        if result.get("created"):
+            promote_budget -= 1
+
+    return {
+        "promoted": promoted,
+        "skipped": skipped,
+        "errors": errors,
+        "scanned": scanned,
+    }
+
+
 def auto_promote_skill_evolution(approved_by: str = "system:auto") -> dict:
     """Convert mature guide skills into executable drafts without manual approval."""
     _ensure_ready()

--- a/tests/test_skills_v2.py
+++ b/tests/test_skills_v2.py
@@ -628,3 +628,119 @@ class TestSkillsCli:
         auto_payload = json.loads(auto.stdout)
         assert auto_payload["auto_applied"] is True
         assert auto_payload["level"] == "published"
+
+
+class TestAutoPromoteOutcomePatternsToSkills:
+    """Fase 2 item 2: outcome patterns must be auto-promoted to skill drafts.
+
+    Before this helper existed, every outcome pattern that crossed the
+    suggested-skill threshold sat in the candidates table waiting for an
+    explicit nexo_skill_seed_from_outcome_pattern call. The materializer
+    already existed but no scheduled process invoked it. These tests pin
+    that the new wrapper:
+      - Promotes qualifying patterns automatically.
+      - Skips low-success-rate or non-reinforce candidates.
+      - Respects the per-cycle promotion budget.
+      - Is idempotent across consecutive runs.
+    """
+
+    def test_promotes_qualifying_pattern_to_skill_draft(self, skills_env):
+        db, skills_runtime, _, _ = _reload_skill_stack()
+        db.init_db()
+
+        _seed_outcome_pattern(db, selected_choice="staged_validation", count=4)
+
+        result = skills_runtime.auto_promote_outcome_patterns_to_skills(
+            min_success_rate=0.8, max_promotions=3
+        )
+
+        assert result["scanned"] >= 1
+        assert len(result["promoted"]) == 1
+        promoted = result["promoted"][0]
+        assert promoted["created"] is True
+        assert promoted["skill_id"]
+        assert promoted["success_rate"] == 1.0  # all seeded outcomes succeeded
+        assert promoted["resolved_outcomes"] >= 4
+        assert result["errors"] == []
+
+        skill = db.get_skill(promoted["skill_id"])
+        assert skill is not None
+        assert skill["level"] == "draft"
+        assert skill["mode"] == "guide"
+        assert skill["source_kind"] == "personal"
+
+    def test_idempotent_across_runs_does_not_recreate_existing_skill(self, skills_env):
+        db, skills_runtime, _, _ = _reload_skill_stack()
+        db.init_db()
+
+        _seed_outcome_pattern(db, selected_choice="staged_validation", count=4)
+
+        first = skills_runtime.auto_promote_outcome_patterns_to_skills(
+            min_success_rate=0.8, max_promotions=3
+        )
+        second = skills_runtime.auto_promote_outcome_patterns_to_skills(
+            min_success_rate=0.8, max_promotions=3
+        )
+
+        assert len(first["promoted"]) == 1
+        assert first["promoted"][0]["created"] is True
+
+        # Second run should report the same skill but as not-created (the
+        # underlying materializer already returned existing).
+        assert len(second["promoted"]) == 1
+        assert second["promoted"][0]["created"] is False
+        assert second["promoted"][0]["skill_id"] == first["promoted"][0]["skill_id"]
+
+    def test_skips_pattern_below_min_success_rate(self, skills_env):
+        db, skills_runtime, _, _ = _reload_skill_stack()
+        db.init_db()
+
+        # Mostly-failing pattern: 1 success out of 5 → success rate 0.2
+        _seed_outcome_pattern(db, selected_choice="failing_pattern", count=4, success=False)
+        _seed_outcome_pattern(db, selected_choice="failing_pattern", count=1, success=True)
+
+        result = skills_runtime.auto_promote_outcome_patterns_to_skills(
+            min_success_rate=0.8, max_promotions=3
+        )
+
+        # The candidate becomes an avoid_strategy (or below threshold), so
+        # auto_promote must skip it — never materialize a skill from a bad
+        # pattern.
+        assert result["promoted"] == []
+        assert any(
+            "failing_pattern" in (s.get("pattern_key") or "")
+            or "not reinforce_strategy" in s.get("reason", "")
+            or "success_rate" in s.get("reason", "")
+            for s in result["skipped"]
+        )
+
+    def test_respects_max_promotions_budget(self, skills_env):
+        db, skills_runtime, _, _ = _reload_skill_stack()
+        db.init_db()
+
+        _seed_outcome_pattern(db, selected_choice="strategy_a", count=4, area="ops")
+        _seed_outcome_pattern(db, selected_choice="strategy_b", count=4, area="qa")
+        _seed_outcome_pattern(db, selected_choice="strategy_c", count=4, area="release")
+
+        result = skills_runtime.auto_promote_outcome_patterns_to_skills(
+            min_success_rate=0.8, max_promotions=2
+        )
+
+        promoted_count = sum(1 for entry in result["promoted"] if entry["created"])
+        assert promoted_count == 2
+        # The third qualifying candidate must show up in skipped with the
+        # budget-exhausted reason — not as an error.
+        assert any("promotion budget exhausted" in s.get("reason", "") for s in result["skipped"])
+
+    def test_returns_clean_result_when_no_candidates(self, skills_env):
+        db, skills_runtime, _, _ = _reload_skill_stack()
+        db.init_db()
+
+        result = skills_runtime.auto_promote_outcome_patterns_to_skills(
+            min_success_rate=0.8, max_promotions=3
+        )
+
+        assert result["promoted"] == []
+        assert result["skipped"] == []
+        assert result["errors"] == []
+        assert result["scanned"] == 0


### PR DESCRIPTION
## Summary

Auto-promote mature outcome patterns to draft skills. Closes Fase 2 item 2 of NEXO-AUDIT-2026-04-11.

Outcome patterns that crossed the suggested-skill threshold sat in the candidates table waiting for an explicit `nexo_skill_seed_from_outcome_pattern` call. The materializer (`materialize_outcome_pattern_skill`) already existed, but no scheduled process invoked it. Users had to remember to seed each pattern by hand. This change closes the loop: every time the daily outcome-checker runs, it scans the candidate list and promotes any qualifying pattern to a draft skill automatically.

## What changed

**`src/skills_runtime.py:auto_promote_outcome_patterns_to_skills(min_success_rate=0.8, max_promotions=3)`** — new helper:

- Scans up to 20 outcome pattern candidates via `list_outcome_pattern_candidates`.
- Filters to `reinforce_strategy` patterns with `suggested_skill_candidate=True` (the analyzer's existing flag for `resolved >= 4`) AND `success_rate >= min_success_rate`.
- Calls `materialize_outcome_pattern_skill` per qualifying candidate, capped at `max_promotions` per cycle so a sudden flood does not materialize dozens of skills in one run.
- Idempotent: only newly-created skills consume the budget. Re-running on an already-materialized pattern returns `created=False` without touching it.
- Best-effort: never raises. A failing candidate logs into `errors[]` and the loop continues to the next.
- Returns `{promoted, skipped, errors, scanned}` stats.

**`src/scripts/nexo-outcome-checker.py`** — wired to call the new helper after evaluating pending outcomes. The promotion summary is logged and persisted into the existing `outcome-checker-summary.json` under `auto_promoted_patterns` so morning briefings and dashboards can pick it up without an extra DB query. Wrapped in its own try/except so a failing promote step never breaks outcome checking.

## Empirical verification before the fix

Per Phase 1 audit discipline (verify before touching code):

- `materialize_outcome_pattern_skill` exists at `skills_runtime.py:583` with full snapshot/idempotency semantics.
- `list_outcome_pattern_candidates` and `capture_outcome_pattern` exist in `db/_outcomes.py` with the analyzer logic and constants (`OUTCOME_PATTERN_MIN_RESOLVED=3`, `OUTCOME_PATTERN_MIN_SUCCESS_RATE=0.75`).
- `nexo_outcome_pattern_candidates` and `nexo_skill_seed_from_outcome_pattern` are exposed as MCP tools.
- `grep "materialize_outcome_pattern_skill"` in `scripts/`: only the manual MCP plugin handler. **No cron, no nightly job, no scheduled invocation.**
- `nexo-outcome-checker.py` runs every day on the manifest schedule but did not call the materializer.

## Tests added (`TestAutoPromoteOutcomePatternsToSkills`, 5 tests)

| Test | Verifies |
|---|---|
| `test_promotes_qualifying_pattern_to_skill_draft` | Seed a strong pattern (4 successful outcomes), assert exactly one skill created with expected level/mode/source_kind |
| `test_idempotent_across_runs_does_not_recreate_existing_skill` | Two consecutive runs return the same skill_id but second has `created=False` |
| `test_skips_pattern_below_min_success_rate` | 1 success of 5 outcomes becomes `avoid_strategy`, must NOT be promoted |
| `test_respects_max_promotions_budget` | 3 qualifying candidates with cap 2 → exactly 2 created, third lands in skipped with budget-exhausted reason |
| `test_returns_clean_result_when_no_candidates` | Empty environment yields `promoted=skipped=errors=[]`, `scanned=0` |

## Test plan

- [x] `pytest tests/test_skills_v2.py::TestAutoPromoteOutcomePatternsToSkills -v` — 5/5 passing
- [x] `pytest tests/test_skills_v2.py tests/test_outcomes.py -v` — 26/26 passing (no regression)
- [x] `python -c "import server"` — clean import
- [ ] CI: 4 status checks

## Risk

Low. The new function only calls existing helpers (`list_outcome_pattern_candidates`, `materialize_outcome_pattern_skill`) which already have idempotency and snapshot semantics. The cap (`max_promotions=3` per cycle) bounds blast radius. Three layers of try/except ensure a failing helper degrades gracefully. Skill drafts created by this path land in level=`draft`, mode=`guide`, source_kind=`personal` — they need explicit promotion to take effect as executable code, so even a wrongly-promoted pattern is a no-op until a human approves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
