### PR TITLE
feat(deep-sleep): code_change action stages findings into evolution_log (audit-fase2 item 5)

### DIFF
--- a/src/scripts/deep-sleep/apply_findings.py
+++ b/src/scripts/deep-sleep/apply_findings.py
@@ -2005,11 +2005,136 @@ def apply_action(action: dict, run_id: str) -> dict:
         # These are included in the briefing file, not applied separately
         log_entry["status"] = "included_in_briefing"
 
+    elif action_type == "code_change":
+        # Closes Fase 2 item 5: deep sleep can now hand a concrete code
+        # change to the evolution apply pipeline. We do NOT touch any source
+        # file directly here — that would bypass the sandbox/snapshot/rollback
+        # safety net that lives in nexo-evolution-run.py:execute_auto_proposal.
+        # Instead we persist the proposal to evolution_log with status=accepted
+        # and a proposal_payload, so the next evolution cycle picks it up via
+        # _apply_accepted_proposals (added in Fase 2 item 1, m38).
+        result = apply_code_change_action(content, dedupe_key)
+        log_entry["status"] = "applied" if result.get("success") else "error"
+        log_entry["details"] = result
+
     else:
         log_entry["status"] = "unknown_type"
         log_entry["details"] = {"error": f"Unknown action_type: {action_type}"}
 
     return log_entry
+
+
+def apply_code_change_action(content: dict, dedupe_key: str) -> dict:
+    """Stage a code_change finding into evolution_log for the next cycle.
+
+    Required content keys:
+        dimension:  evolution dimension (reliability/safety/etc)
+        action:     short human-readable description of what to do
+        reasoning:  why deep sleep proposed this change
+        changes:    list of {file, operation, search?, content} entries
+                    matching nexo-evolution-run.py:apply_change semantics
+
+    Optional:
+        scope: 'local' | 'public' (default 'local')
+        classification: 'propose' | 'auto' (default 'propose')
+
+    Idempotent: if a row with the same dedupe_key already exists in
+    evolution_log (matched against proposal_payload extras.dedupe_key), the
+    function returns success without inserting a duplicate.
+
+    Returns: {success: bool, evolution_log_id: int|None, reason: str|None,
+              skipped_duplicate: bool}
+    """
+    if not isinstance(content, dict):
+        return {"success": False, "reason": "content must be a dict"}
+
+    dimension = (content.get("dimension") or "").strip()
+    action_text = (content.get("action") or content.get("title") or "").strip()
+    reasoning = (content.get("reasoning") or content.get("why") or "").strip()
+    changes = content.get("changes") or []
+    scope = (content.get("scope") or "local").strip() or "local"
+    classification = (content.get("classification") or "propose").strip() or "propose"
+
+    if not dimension:
+        return {"success": False, "reason": "missing dimension"}
+    if not action_text:
+        return {"success": False, "reason": "missing action"}
+    if not isinstance(changes, list) or not changes:
+        return {"success": False, "reason": "missing or empty changes array"}
+    for idx, change in enumerate(changes):
+        if not isinstance(change, dict):
+            return {"success": False, "reason": f"changes[{idx}] is not a dict"}
+        if not change.get("file"):
+            return {"success": False, "reason": f"changes[{idx}] missing file"}
+        if not change.get("operation"):
+            return {"success": False, "reason": f"changes[{idx}] missing operation"}
+
+    payload = {
+        "classification": classification,
+        "dimension": dimension,
+        "action": action_text,
+        "reasoning": reasoning,
+        "scope": scope,
+        "changes": changes,
+        "extras": {
+            "source": "deep_sleep",
+            "dedupe_key": dedupe_key,
+        },
+    }
+    payload_json = json.dumps(payload, ensure_ascii=False)
+
+    try:
+        conn = sqlite3.connect(str(NEXO_DB), timeout=10)
+    except Exception as e:
+        return {"success": False, "reason": f"cannot open nexo.db: {e}"}
+
+    try:
+        # Idempotency: skip if any prior row already staged this dedupe_key.
+        existing = conn.execute(
+            "SELECT id FROM evolution_log "
+            "WHERE proposal_payload IS NOT NULL "
+            "  AND proposal_payload LIKE ? "
+            "ORDER BY id DESC LIMIT 1",
+            (f'%"dedupe_key": "{dedupe_key}"%',),
+        ).fetchone()
+        if existing:
+            return {
+                "success": True,
+                "skipped_duplicate": True,
+                "evolution_log_id": int(existing[0]),
+                "reason": "already staged in evolution_log",
+            }
+
+        cur = conn.execute(
+            "INSERT INTO evolution_log "
+            "(cycle_number, dimension, proposal, classification, reasoning, status, proposal_payload) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                0,  # cycle_number 0 = staged from outside the regular cycle
+                dimension,
+                action_text,
+                classification,
+                reasoning or "deep sleep proposed code change",
+                "accepted",
+                payload_json,
+            ),
+        )
+        try:
+            conn.commit()
+        except Exception:
+            pass
+        return {
+            "success": True,
+            "skipped_duplicate": False,
+            "evolution_log_id": int(cur.lastrowid),
+        }
+    except Exception as e:
+        return {"success": False, "reason": f"insert failed: {e}"}
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
 
 
 def main():

--- a/tests/test_deep_sleep_apply.py
+++ b/tests/test_deep_sleep_apply.py
@@ -484,3 +484,188 @@ def test_write_morning_briefing_includes_top_impact_and_queue_changes(monkeypatc
     assert "Why:" in briefing
     assert "## Impact Queue Changes" in briefing
     assert "+12.5 -> 64.0" in briefing
+
+
+# ── Fase 2 item 5: code_change action stages into evolution_log ──────────
+
+
+def _seed_evolution_log_table(db_path: Path) -> None:
+    """Create a minimal post-m38 evolution_log schema for the apply tests."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS evolution_log ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "created_at TEXT DEFAULT (datetime('now')), "
+        "cycle_number INTEGER NOT NULL, "
+        "dimension TEXT NOT NULL, "
+        "proposal TEXT NOT NULL, "
+        "classification TEXT NOT NULL DEFAULT 'auto', "
+        "status TEXT DEFAULT 'pending', "
+        "files_changed TEXT, snapshot_ref TEXT, test_result TEXT, "
+        "impact INTEGER DEFAULT 0, reasoning TEXT NOT NULL, "
+        "proposal_payload TEXT DEFAULT NULL)"
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_apply_code_change_action_stages_into_evolution_log(monkeypatch, tmp_path):
+    apply_mod = _load_apply_module(monkeypatch, tmp_path)
+    db_path = Path(os.environ["NEXO_DB"])
+    _seed_evolution_log_table(db_path)
+
+    content = {
+        "dimension": "reliability",
+        "action": "Add retry to flaky API call",
+        "reasoning": "deep sleep saw 5 retried failures in 2 days",
+        "scope": "local",
+        "changes": [
+            {
+                "file": "/tmp/repo/src/api.py",
+                "operation": "replace",
+                "search": "return call()",
+                "content": "return call_with_retry(call, max_retries=3)",
+            }
+        ],
+    }
+    result = apply_mod.apply_code_change_action(content, dedupe_key="ds-2026-04-11-api-retry")
+
+    assert result["success"] is True
+    assert result.get("skipped_duplicate") is False
+    assert result["evolution_log_id"]
+
+    conn = sqlite3.connect(str(db_path))
+    row = conn.execute(
+        "SELECT dimension, proposal, classification, status, proposal_payload "
+        "FROM evolution_log WHERE id = ?",
+        (result["evolution_log_id"],),
+    ).fetchone()
+    conn.close()
+
+    assert row is not None
+    assert row[0] == "reliability"
+    assert row[1] == "Add retry to flaky API call"
+    assert row[2] == "propose"
+    assert row[3] == "accepted"
+    payload = json.loads(row[4])
+    assert payload["changes"][0]["file"] == "/tmp/repo/src/api.py"
+    assert payload["extras"]["source"] == "deep_sleep"
+    assert payload["extras"]["dedupe_key"] == "ds-2026-04-11-api-retry"
+
+
+def test_apply_code_change_action_is_idempotent_by_dedupe_key(monkeypatch, tmp_path):
+    apply_mod = _load_apply_module(monkeypatch, tmp_path)
+    db_path = Path(os.environ["NEXO_DB"])
+    _seed_evolution_log_table(db_path)
+
+    content = {
+        "dimension": "safety",
+        "action": "Quote shell args",
+        "reasoning": "shell injection hardening",
+        "changes": [
+            {
+                "file": "/tmp/repo/src/run.sh",
+                "operation": "replace",
+                "search": "rm -rf $TARGET",
+                "content": 'rm -rf "$TARGET"',
+            }
+        ],
+    }
+    first = apply_mod.apply_code_change_action(content, dedupe_key="ds-quote-shell")
+    second = apply_mod.apply_code_change_action(content, dedupe_key="ds-quote-shell")
+
+    assert first["success"] is True
+    assert first["skipped_duplicate"] is False
+    assert second["success"] is True
+    assert second["skipped_duplicate"] is True
+    assert second["evolution_log_id"] == first["evolution_log_id"]
+
+    conn = sqlite3.connect(str(db_path))
+    count = conn.execute("SELECT COUNT(*) FROM evolution_log").fetchone()[0]
+    conn.close()
+    assert count == 1
+
+
+def test_apply_code_change_action_validates_required_fields(monkeypatch, tmp_path):
+    apply_mod = _load_apply_module(monkeypatch, tmp_path)
+    _seed_evolution_log_table(Path(os.environ["NEXO_DB"]))
+
+    bad1 = apply_mod.apply_code_change_action(
+        {"action": "do x", "changes": [{"file": "x", "operation": "replace"}]}, "k1"
+    )
+    assert bad1["success"] is False
+    assert "dimension" in bad1["reason"]
+
+    bad2 = apply_mod.apply_code_change_action(
+        {"dimension": "reliability", "action": "do x"}, "k2"
+    )
+    assert bad2["success"] is False
+    assert "changes" in bad2["reason"]
+
+    bad3 = apply_mod.apply_code_change_action(
+        {"dimension": "reliability", "action": "do x", "changes": []}, "k3"
+    )
+    assert bad3["success"] is False
+
+    bad4 = apply_mod.apply_code_change_action(
+        {"dimension": "reliability", "action": "do x", "changes": [{"file": "x"}]}, "k4"
+    )
+    assert bad4["success"] is False
+    assert "operation" in bad4["reason"]
+
+
+def test_apply_action_dispatches_code_change(monkeypatch, tmp_path):
+    apply_mod = _load_apply_module(monkeypatch, tmp_path)
+    _seed_evolution_log_table(Path(os.environ["NEXO_DB"]))
+
+    action = {
+        "action_type": "code_change",
+        "action_class": "auto_apply",
+        "dedupe_key": "ds-dispatch-test",
+        "content": {
+            "dimension": "reliability",
+            "action": "Wire dispatch",
+            "reasoning": "regression test",
+            "changes": [
+                {
+                    "file": "/tmp/repo/foo.py",
+                    "operation": "replace",
+                    "search": "old",
+                    "content": "new",
+                }
+            ],
+        },
+    }
+    log_entry = apply_mod.apply_action(action, run_id="ds-test")
+
+    assert log_entry["status"] == "applied"
+    assert log_entry["action_type"] == "code_change"
+    assert log_entry["details"]["success"] is True
+    assert log_entry["details"]["evolution_log_id"]
+
+
+def test_apply_action_skips_code_change_when_action_class_not_auto_apply(monkeypatch, tmp_path):
+    apply_mod = _load_apply_module(monkeypatch, tmp_path)
+    _seed_evolution_log_table(Path(os.environ["NEXO_DB"]))
+
+    action = {
+        "action_type": "code_change",
+        "action_class": "draft_for_morning",
+        "dedupe_key": "ds-deferred",
+        "content": {
+            "dimension": "reliability",
+            "action": "Wire dispatch",
+            "changes": [
+                {"file": "x", "operation": "replace", "search": "a", "content": "b"}
+            ],
+        },
+    }
+    log_entry = apply_mod.apply_action(action, run_id="ds-test")
+
+    assert log_entry["status"] == "deferred_to_morning"
+    db_path = Path(os.environ["NEXO_DB"])
+    conn = sqlite3.connect(str(db_path))
+    count = conn.execute("SELECT COUNT(*) FROM evolution_log").fetchone()[0]
+    conn.close()
+    assert count == 0


### PR DESCRIPTION
## Summary

Let Deep Sleep stage concrete code findings into the evolution apply queue. Closes Fase 2 item 5 of NEXO-AUDIT-2026-04-11.

Deep Sleep already converted findings into learnings, followups, skill drafts, and morning briefing items. The audit listed item 5 as "deep sleep should produce code changes, not just followups". The minimal change to close that loop **without** duplicating the snapshot/apply/validate/rollback machinery in `nexo-evolution-run.py` is to let Deep Sleep stage code findings into `evolution_log` with `status='accepted'` and a `proposal_payload`. Fase 2 item 1 (PR #101) already added the consumer (`_apply_accepted_proposals`) that picks those rows up on the next evolution cycle and runs them through `execute_auto_proposal`.

Net result: Deep Sleep -> evolution_log (this PR) -> next cycle applies (PR #101). End-to-end self-improvement loop is closed.

## What changed

**`src/scripts/deep-sleep/apply_findings.py`**

- **New action_type** `code_change` in `apply_action()`. When `action_class == 'auto_apply'` it dispatches to `apply_code_change_action`. Other action_classes (`draft_for_morning`, etc.) keep the existing `deferred_to_morning` behavior so a low-confidence draft never lands in `evolution_log`.

- **New helper** `apply_code_change_action(content, dedupe_key)`:
  - Validates required keys: `dimension`, `action`, `changes` (non-empty list).
  - Validates each change has `file` + `operation`.
  - Builds the `proposal_payload` that `_apply_accepted_proposals` already expects: `classification, dimension, action, reasoning, scope, changes` + an `extras` block tagging `source=deep_sleep` and the `dedupe_key`.
  - Inserts into `evolution_log` with `cycle_number=0` (= staged from outside a regular cycle), `status='accepted'`, `classification='propose'`.
  - **Idempotent**: looks up `evolution_log` rows whose `proposal_payload` contains the same `dedupe_key` and short-circuits with `skipped_duplicate=True`.
  - **Never touches a source file directly.** The actual edit happens in the next evolution cycle, going through `execute_auto_proposal` which has snapshot, validate, and rollback.

## Tests added (5 new in `tests/test_deep_sleep_apply.py`)

| Test | Verifies |
|---|---|
| `test_apply_code_change_action_stages_into_evolution_log` | Happy path: row inserted with correct dimension/proposal/classification/status, payload contains changes + extras (source, dedupe_key) |
| `test_apply_code_change_action_is_idempotent_by_dedupe_key` | Same content + same dedupe_key called twice → second returns `skipped_duplicate=True` with same id, `COUNT(*)=1` |
| `test_apply_code_change_action_validates_required_fields` | Missing dimension / changes / empty changes / change missing operation → all `success=False` with clear `reason` |
| `test_apply_action_dispatches_code_change` | Full `apply_action()` dispatch routes auto_apply code_change to the helper, status=`applied` |
| `test_apply_action_skips_code_change_when_action_class_not_auto_apply` | `draft_for_morning` class results in `deferred_to_morning`, evolution_log remains empty |

## Empirical verification before the fix

Per Phase 1 audit discipline:

- `apply_findings.py:apply_action()` at line 1951 already had a clean dispatch table for `action_type`. Adding `code_change` is a one-elif insertion plus the helper.
- `evolution_log` post-m38 schema (PR #101) supports `proposal_payload`.
- `_apply_accepted_proposals` in `nexo-evolution-run.py` reads exactly the shape we are persisting (`status='accepted' AND proposal_payload IS NOT NULL`).
- This is the **fourth** Fase 2 item that turned out to be a tiny wiring change on top of existing infrastructure rather than a green-field implementation.

## Test plan

- [x] `pytest tests/test_deep_sleep_apply.py -v` — 11/11 passing (5 new + 6 existing)
- [ ] CI: 4 status checks

## Risk

Low. No source files are touched directly — the new path only writes to `evolution_log`. The existing safety net in `execute_auto_proposal` (snapshot + validate + rollback) still applies when the next cycle picks up the staged row. Idempotency by `dedupe_key` prevents duplicate rows from re-running deep sleep. Three layers of defense: required-field validation, dedupe lookup, fallback try/except around the insert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
