### PR TITLE
feat(state-watchers): auto-create followups when watchers fire (audit-fase3 item 5)

### DIFF
--- a/src/state_watchers_runtime.py
+++ b/src/state_watchers_runtime.py
@@ -320,19 +320,153 @@ def _persist_result(result: dict) -> None:
         conn.close()
 
 
+def _open_watcher_followup(result: dict) -> dict:
+    """Open or refresh a NF-WATCHER-{id} followup when a watcher fires.
+
+    Closes Fase 3 item 5 of NEXO-AUDIT-2026-04-11. Until this helper, state
+    watchers only updated their own row in `state_watchers` and wrote a
+    summary file. A watcher could go critical and stay critical for days
+    without ever surfacing to the user.
+
+    Idempotent: uses INSERT OR REPLACE on a deterministic id derived from
+    the watcher_id, so consecutive runs that hit the same problem refresh
+    the followup in place rather than duplicating it. The followup is
+    automatically resolved next time the watcher reports healthy (the cron
+    that wires `run_state_watchers` will hit the resolve path).
+
+    Returns: {action: 'opened'|'refreshed'|'skipped'|'failed', followup_id, reason}
+    """
+    health = (result.get("health") or "").strip().lower()
+    watcher_id = (result.get("watcher_id") or "").strip()
+    if not watcher_id:
+        return {"action": "skipped", "reason": "missing watcher_id"}
+    if health not in {"degraded", "critical"}:
+        return {"action": "skipped", "reason": f"health={health}"}
+
+    followup_id = f"NF-WATCHER-{watcher_id}"
+    severity_map = {"degraded": "warn", "critical": "error"}
+    severity = severity_map.get(health, "warn")
+    priority_map = {"degraded": "high", "critical": "critical"}
+    priority = priority_map.get(health, "high")
+    title = (result.get("title") or watcher_id).strip()
+    summary = (result.get("summary") or "").strip() or "(no summary)"
+    target = (result.get("target") or "").strip()
+    watcher_type = (result.get("watcher_type") or "").strip()
+
+    description_lines = [
+        f"State watcher {watcher_id} reports {health.upper()} ({severity}).",
+        f"Title: {title}",
+        f"Type: {watcher_type}" + (f" / Target: {target}" if target else ""),
+        "",
+        f"Summary: {summary}",
+    ]
+    evidence = result.get("evidence") or []
+    if isinstance(evidence, list) and evidence:
+        description_lines.append("")
+        description_lines.append("Evidence:")
+        for ev in evidence[:5]:
+            description_lines.append(f"  - {str(ev)[:200]}")
+    description_lines.append("")
+    description_lines.append(
+        "Investigate the watcher target and either fix the underlying drift "
+        "or update the watcher's threshold. The followup will auto-resolve "
+        "next time the watcher reports healthy."
+    )
+    description = "\n".join(description_lines)
+    verification = (
+        f"sqlite3 ~/claude/data/nexo.db \"SELECT last_health, last_result "
+        f"FROM state_watchers WHERE watcher_id = '{watcher_id}'\""
+    )
+
+    db_path = _db_path()
+    if not db_path.is_file():
+        return {"action": "failed", "followup_id": followup_id, "reason": "db not found"}
+
+    now_epoch = datetime.now().timestamp()
+    conn = sqlite3.connect(str(db_path))
+    try:
+        existing = conn.execute(
+            "SELECT id, status FROM followups WHERE id = ?", (followup_id,)
+        ).fetchone()
+        was_pending = bool(existing) and (existing[1] == "PENDING")
+        try:
+            conn.execute(
+                "INSERT OR REPLACE INTO followups (id, description, date, status, "
+                "verification, created_at, updated_at, priority) "
+                "VALUES (?, ?, NULL, 'PENDING', ?, ?, ?, ?)",
+                (followup_id, description, verification, now_epoch, now_epoch, priority),
+            )
+            conn.commit()
+        except sqlite3.OperationalError:
+            return {"action": "failed", "followup_id": followup_id, "reason": "followups table missing"}
+    finally:
+        conn.close()
+
+    return {
+        "action": "refreshed" if was_pending else "opened",
+        "followup_id": followup_id,
+        "severity": severity,
+    }
+
+
+def _resolve_watcher_followup(watcher_id: str) -> dict:
+    """Auto-resolve a NF-WATCHER-{id} followup when the watcher recovers.
+
+    Idempotent: a no-op when the followup does not exist or is already
+    resolved. Called from run_state_watchers when a watcher reports healthy
+    after previously being degraded/critical.
+    """
+    if not watcher_id:
+        return {"action": "skipped", "reason": "missing watcher_id"}
+    db_path = _db_path()
+    if not db_path.is_file():
+        return {"action": "skipped", "reason": "db not found"}
+    followup_id = f"NF-WATCHER-{watcher_id}"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        existing = conn.execute(
+            "SELECT id, status FROM followups WHERE id = ?", (followup_id,)
+        ).fetchone()
+        if not existing:
+            return {"action": "skipped", "reason": "no followup"}
+        if existing[1] != "PENDING":
+            return {"action": "skipped", "reason": f"already {existing[1]}"}
+        conn.execute(
+            "UPDATE followups SET status = 'COMPLETED', updated_at = ? "
+            "WHERE id = ? AND status = 'PENDING'",
+            (datetime.now().timestamp(), followup_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return {"action": "resolved", "followup_id": followup_id}
+
+
 def run_state_watchers(*, persist: bool = True, status: str = "active") -> dict:
     watchers = _list_watchers(status=status)
     results = [evaluate_state_watcher(watcher) for watcher in watchers]
     counts = {"healthy": 0, "degraded": 0, "critical": 0, "unknown": 0}
+    followup_actions: list[dict] = []
     for result in results:
         counts[result["health"]] = counts.get(result["health"], 0) + 1
         if persist:
             _persist_result(result)
+            # Surface degraded/critical as a followup, auto-resolve when healthy.
+            try:
+                if result["health"] in {"degraded", "critical"}:
+                    action = _open_watcher_followup(result)
+                else:
+                    action = _resolve_watcher_followup(result.get("watcher_id", ""))
+                if action.get("action") not in {"skipped", None}:
+                    followup_actions.append(action)
+            except Exception:
+                pass  # Best-effort surfacing
     summary = {
         "generated_at": _now_iso(),
         "watcher_count": len(results),
         "counts": counts,
         "watchers": results,
+        "followup_actions": followup_actions,
     }
     if persist:
         summary_file = _summary_file()

--- a/tests/test_state_watchers.py
+++ b/tests/test_state_watchers.py
@@ -43,6 +43,20 @@ def watcher_env(tmp_path, monkeypatch):
         )"""
     )
     conn.execute(
+        """CREATE TABLE IF NOT EXISTS followups (
+            id TEXT PRIMARY KEY,
+            description TEXT NOT NULL,
+            date TEXT,
+            status TEXT NOT NULL DEFAULT 'PENDING',
+            verification TEXT DEFAULT '',
+            recurrence TEXT,
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL,
+            reasoning TEXT,
+            priority TEXT DEFAULT 'medium'
+        )"""
+    )
+    conn.execute(
         """CREATE TABLE IF NOT EXISTS cron_runs (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             cron_id TEXT NOT NULL,
@@ -112,3 +126,172 @@ def test_api_health_watcher_marks_bad_status_critical(watcher_env, monkeypatch):
     summary = runtime.run_state_watchers()
     assert summary["counts"]["critical"] == 1
     assert summary["watchers"][0]["watcher_type"] == "api_health"
+
+
+# ── Fase 3 item 5: state watchers auto-create followups ──────────────────
+
+
+def _read_followup(followup_id: str) -> tuple | None:
+    """Read a followup row through whichever connection the runtime uses.
+
+    The conftest `isolated_db` autouse fixture redirects writes through
+    NEXO_TEST_DB. We use the same path here so we read what the runtime
+    just wrote.
+    """
+    db_path = os.environ.get("NEXO_TEST_DB") or os.environ.get("NEXO_DB")
+    assert db_path, "no test db env var configured"
+    conn = sqlite3.connect(db_path)
+    try:
+        return conn.execute(
+            "SELECT id, status, priority, description FROM followups WHERE id = ?",
+            (followup_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+
+
+def _count_watcher_followups() -> int:
+    db_path = os.environ.get("NEXO_TEST_DB") or os.environ.get("NEXO_DB")
+    conn = sqlite3.connect(db_path)
+    try:
+        return conn.execute(
+            "SELECT COUNT(*) FROM followups WHERE id LIKE 'NF-WATCHER-%'"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+
+def test_critical_watcher_opens_followup_with_correct_priority(watcher_env, monkeypatch):
+    home, db, runtime = watcher_env
+
+    class _Resp:
+        status = 500
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(runtime.request, "urlopen", lambda req, timeout=0: _Resp())
+    db.create_state_watcher("api_health", "Production API", target="https://example.com/health")
+
+    summary = runtime.run_state_watchers()
+    assert summary["counts"]["critical"] == 1
+
+    actions = summary.get("followup_actions", [])
+    assert len(actions) == 1
+    assert actions[0]["action"] == "opened"
+    assert actions[0]["severity"] == "error"
+    assert actions[0]["followup_id"].startswith("NF-WATCHER-")
+
+    row = _read_followup(actions[0]["followup_id"])
+    assert row is not None
+    assert row[1] == "PENDING"
+    assert row[2] == "critical"
+    assert "CRITICAL" in row[3]
+    assert "Production API" in row[3]
+
+
+def test_degraded_watcher_opens_high_priority_followup(watcher_env):
+    home, db, runtime = watcher_env
+    repo = Path(home) / "repo"
+    repo.mkdir()
+    os.system(f"git -C {repo} init -q")
+    (repo / "README.md").write_text("dirty\n")
+
+    db.create_state_watcher("repo_drift", "Repo", target=str(repo))
+    summary = runtime.run_state_watchers()
+
+    assert summary["counts"]["degraded"] == 1
+    actions = summary.get("followup_actions", [])
+    assert len(actions) == 1
+    assert actions[0]["action"] == "opened"
+    assert actions[0]["severity"] == "warn"
+
+    row = _read_followup(actions[0]["followup_id"])
+    assert row is not None
+    assert row[2] == "high"
+    assert "DEGRADED" in row[3]
+
+
+def test_followup_idempotent_across_runs(watcher_env, monkeypatch):
+    _home, db, runtime = watcher_env
+
+    class _Resp:
+        status = 500
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(runtime.request, "urlopen", lambda req, timeout=0: _Resp())
+    db.create_state_watcher("api_health", "API", target="https://example.com/health")
+
+    runtime.run_state_watchers()
+    second_summary = runtime.run_state_watchers()
+
+    actions = second_summary.get("followup_actions", [])
+    assert len(actions) == 1
+    assert actions[0]["action"] == "refreshed"
+    assert _count_watcher_followups() == 1  # idempotent: still exactly 1 row
+
+
+def test_healthy_watcher_does_not_create_followup(watcher_env):
+    _home, db, runtime = watcher_env
+    db.create_state_watcher(
+        "expiry",
+        "SSL cert with plenty of margin",
+        config={
+            "due_at": (datetime.now(timezone.utc) + timedelta(days=180)).strftime("%Y-%m-%d"),
+            "warn_days": 14,
+            "critical_days": 5,
+        },
+    )
+
+    summary = runtime.run_state_watchers()
+    assert summary["counts"]["healthy"] == 1
+    assert summary.get("followup_actions") == []
+    assert _count_watcher_followups() == 0
+
+
+def test_recovered_watcher_auto_resolves_followup(watcher_env, monkeypatch):
+    _home, db, runtime = watcher_env
+
+    state = {"status": 500}
+
+    class _Resp:
+        @property
+        def status(self):
+            return state["status"]
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(runtime.request, "urlopen", lambda req, timeout=0: _Resp())
+    db.create_state_watcher("api_health", "API", target="https://example.com/health")
+
+    runtime.run_state_watchers()
+    assert _count_watcher_followups() == 1
+
+    state["status"] = 200
+
+    second_summary = runtime.run_state_watchers()
+    assert second_summary["counts"]["healthy"] == 1
+    actions = second_summary.get("followup_actions", [])
+    assert any(a["action"] == "resolved" for a in actions)
+
+    db_path = os.environ.get("NEXO_TEST_DB") or os.environ.get("NEXO_DB")
+    conn = sqlite3.connect(db_path)
+    try:
+        after = conn.execute(
+            "SELECT status FROM followups WHERE id LIKE 'NF-WATCHER-%'"
+        ).fetchone()
+    finally:
+        conn.close()
+    assert after[0] == "COMPLETED"


### PR DESCRIPTION
## Summary

State watchers already evaluated repo drift, cron drift, api health, environment drift, and certificate expiry on a daily cron, but **no followup was ever created when a watcher reported degraded or critical**. A watcher could go critical and stay critical for days without ever surfacing to the user. Closes Fase 3 item 5 of NEXO-AUDIT-2026-04-11.

## What changed

- **`_open_watcher_followup(result)`** — new helper that creates a deterministic `NF-WATCHER-{watcher_id}` followup with priority `high`/`critical` based on health. Idempotent via `INSERT OR REPLACE`.
- **`_resolve_watcher_followup(watcher_id)`** — new helper that auto-resolves the followup when the watcher recovers to healthy.
- **`run_state_watchers()`** — wires both helpers per result, adds `followup_actions` to the summary dict.

## Tests added (5 new in tests/test_state_watchers.py)

| Test | Verifies |
|---|---|
| critical_watcher_opens_followup_with_correct_priority | api 500 → priority=critical, severity=error |
| degraded_watcher_opens_high_priority_followup | dirty git repo → priority=high |
| followup_idempotent_across_runs | second run → 'refreshed', count stays 1 |
| healthy_watcher_does_not_create_followup | SSL cert with margin → no followup |
| recovered_watcher_auto_resolves_followup | api 500→200 → followup COMPLETED |

## Empirical verification before the fix

- `grep "create_followup\|open.*followup" src/state_watchers_runtime.py` → **0 matches**
- `_persist_result` only updated `state_watchers.last_health`
- `run_state_watchers` wrote summary file but never touched `followups`

## Test plan

- [x] `pytest tests/test_state_watchers.py -v` — 8/8 passing (5 new + 3 existing)
- [x] `python -c "import server"` — clean import
- [ ] CI: 4 status checks

## Risk

Low. Two new best-effort helpers wrapped in try/except. Idempotent followup id prevents accumulation. No source files mutated, only writes to `followups` table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)