### PR TITLE
feat(cognitive-decay): surface correction fatigue as visible followup (audit-fase3 item 4)

### DIFF
--- a/src/scripts/nexo-cognitive-decay.py
+++ b/src/scripts/nexo-cognitive-decay.py
@@ -19,6 +19,71 @@ import cognitive
 STATE_FILE = NEXO_HOME / "operations" / ".catchup-state.json"
 
 
+CORRECTION_FATIGUE_FOLLOWUP_ID = "NF-CORRECTION-FATIGUE"
+
+
+def _open_correction_fatigue_followup(fatigued: list) -> str:
+    """Surface fatigued memories as a single high-priority followup.
+
+    Closes Fase 3 item 4 of NEXO-AUDIT-2026-04-11. check_correction_fatigue
+    already auto-decays the strength of memories corrected 3+ times in a
+    week and tags them under_review, but the under_review tag is never
+    read elsewhere — the user could lose hours debugging a wrong memory
+    before noticing it had been silently decayed. This helper writes a
+    single deterministic followup so the operator sees the list at the
+    next morning briefing.
+
+    Idempotent across daily runs via the fixed id NF-CORRECTION-FATIGUE
+    (INSERT OR REPLACE). Best-effort: never raises.
+    """
+    import sqlite3 as _sqlite3
+    if not fatigued:
+        return "no_signal"
+
+    db_path = (
+        os.environ.get("NEXO_TEST_DB")
+        or os.environ.get("NEXO_DB")
+        or str(NEXO_HOME / "data" / "nexo.db")
+    )
+    if not Path(db_path).exists():
+        return "skipped_no_db"
+
+    lines = [
+        f"NEXO detected {len(fatigued)} memory/memories corrected 3+ times in the last 7 days.",
+        "These have been auto-decayed to strength <= 0.2 and tagged under_review.",
+        "Verify each one and either delete it, refine its content, or accept the decay.",
+        "",
+    ]
+    for f in fatigued[:10]:
+        lines.append(
+            f"- LTM #{f.get('memory_id')} ({f.get('corrections_7d')}x corrections, "
+            f"strength={f.get('strength')}): {(f.get('content') or '')[:160]}"
+        )
+    if len(fatigued) > 10:
+        lines.append(f"... and {len(fatigued) - 10} more")
+    description = "\n".join(lines)
+    verification = (
+        "sqlite3 ~/claude/data/cognitive.db \"SELECT id, content, strength, tags "
+        "FROM ltm_memories WHERE tags LIKE '%under_review%' ORDER BY strength ASC LIMIT 50\""
+    )
+    now_epoch = datetime.now().timestamp()
+
+    conn = _sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "INSERT OR REPLACE INTO followups (id, description, date, status, "
+            "verification, created_at, updated_at, priority) "
+            "VALUES (?, ?, NULL, 'PENDING', ?, ?, ?, 'high')",
+            (CORRECTION_FATIGUE_FOLLOWUP_ID, description, verification, now_epoch, now_epoch),
+        )
+        conn.commit()
+    except Exception as e:
+        return f"failed: {e}"
+    finally:
+        conn.close()
+    return "opened_or_refreshed"
+
+
 def update_catchup_state():
     """Register successful run so catch-up script knows we ran."""
     try:
@@ -88,12 +153,22 @@ def main():
         print(f"[{ts}] Consolidation error: {e}")
 
     # 5. Correction fatigue — mark memories corrected 3+ times as unreliable
+    # Closes Fase 3 item 4 of NEXO-AUDIT-2026-04-11. check_correction_fatigue
+    # already auto-decays strength to 0.2 and tags the memory as
+    # 'under_review', but the under_review tag is never read elsewhere in the
+    # codebase. The user could lose hours debugging a wrong memory before
+    # noticing it had been silently decayed. Surface as a daily followup so
+    # the operator sees fatigued memories at the next morning briefing.
     try:
         fatigued = cognitive.check_correction_fatigue()
         if fatigued:
             print(f"[{ts}] CORRECTION FATIGUE: {len(fatigued)} memories corrected 3+ times in 7d:")
             for f in fatigued:
                 print(f"[{ts}]   LTM #{f['memory_id']} ({f['corrections_7d']}x): {f['content'][:80]}...")
+            try:
+                _open_correction_fatigue_followup(fatigued)
+            except Exception as fe:
+                print(f"[{ts}] Correction fatigue followup error: {fe}")
         else:
             print(f"[{ts}] No correction fatigue detected.")
     except Exception as e:

--- a/tests/test_correction_fatigue_followup.py
+++ b/tests/test_correction_fatigue_followup.py
@@ -1,0 +1,170 @@
+"""Tests for the correction fatigue followup surfacing — Fase 3 item 4.
+
+The check_correction_fatigue helper itself already auto-decays affected
+memories. This file pins the new follow-up surfacing in
+nexo-cognitive-decay.py so the operator sees fatigued memories at the
+next morning briefing instead of having to read the cron log.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "src" / "scripts" / "nexo-cognitive-decay.py"
+
+
+def _load_module(monkeypatch, home: Path):
+    monkeypatch.setenv("NEXO_HOME", str(home))
+    monkeypatch.setenv("NEXO_CODE", str(REPO_ROOT / "src"))
+    sys.modules.pop("nexo_cognitive_decay_test", None)
+    spec = importlib.util.spec_from_file_location("nexo_cognitive_decay_test", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _seed_followups_table(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS followups (
+            id TEXT PRIMARY KEY,
+            description TEXT NOT NULL,
+            date TEXT,
+            status TEXT NOT NULL DEFAULT 'PENDING',
+            verification TEXT DEFAULT '',
+            recurrence TEXT,
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL,
+            reasoning TEXT,
+            priority TEXT DEFAULT 'medium'
+        )"""
+    )
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture
+def fatigue_env(tmp_path, monkeypatch, isolated_db):
+    home = tmp_path / "nexo"
+    (home / "data").mkdir(parents=True, exist_ok=True)
+    db_path = Path(isolated_db["nexo_db"])
+    _seed_followups_table(db_path)
+    return home, db_path
+
+
+def test_no_fatigued_memories_returns_no_signal(fatigue_env, monkeypatch):
+    home, _ = fatigue_env
+    mod = _load_module(monkeypatch, home)
+    result = mod._open_correction_fatigue_followup([])
+    assert result == "no_signal"
+
+
+def test_fatigued_memories_create_followup_with_high_priority(fatigue_env, monkeypatch):
+    home, db_path = fatigue_env
+    mod = _load_module(monkeypatch, home)
+
+    fatigued = [
+        {
+            "memory_id": 101,
+            "corrections_7d": 4,
+            "types": "explicit,implicit,explicit,implicit",
+            "content": "El servidor de Recambios BMW se llama mundiserver",
+            "strength": 0.2,
+            "source_type": "session",
+            "domain": "ecommerce",
+        },
+        {
+            "memory_id": 202,
+            "corrections_7d": 3,
+            "types": "explicit",
+            "content": "WAzion soporta sesiones múltiples por número",
+            "strength": 0.2,
+            "source_type": "session",
+            "domain": "wazion",
+        },
+    ]
+
+    result = mod._open_correction_fatigue_followup(fatigued)
+    assert result == "opened_or_refreshed"
+
+    conn = sqlite3.connect(str(db_path))
+    row = conn.execute(
+        "SELECT id, status, priority, description FROM followups WHERE id = ?",
+        (mod.CORRECTION_FATIGUE_FOLLOWUP_ID,),
+    ).fetchone()
+    conn.close()
+
+    assert row is not None
+    assert row[0] == "NF-CORRECTION-FATIGUE"
+    assert row[1] == "PENDING"
+    assert row[2] == "high"
+    assert "2 memory" in row[3] or "2 memories" in row[3]
+    assert "LTM #101" in row[3]
+    assert "LTM #202" in row[3]
+    assert "under_review" in row[3]
+
+
+def test_idempotent_across_runs(fatigue_env, monkeypatch):
+    home, db_path = fatigue_env
+    mod = _load_module(monkeypatch, home)
+
+    fatigued = [
+        {
+            "memory_id": 101,
+            "corrections_7d": 3,
+            "types": "explicit",
+            "content": "Test memory",
+            "strength": 0.2,
+            "source_type": "session",
+            "domain": "test",
+        }
+    ]
+
+    mod._open_correction_fatigue_followup(fatigued)
+    mod._open_correction_fatigue_followup(fatigued)
+
+    conn = sqlite3.connect(str(db_path))
+    rows = conn.execute(
+        "SELECT id FROM followups WHERE id = ?",
+        (mod.CORRECTION_FATIGUE_FOLLOWUP_ID,),
+    ).fetchall()
+    conn.close()
+    assert len(rows) == 1
+
+
+def test_truncates_long_lists_to_10_with_remainder(fatigue_env, monkeypatch):
+    home, db_path = fatigue_env
+    mod = _load_module(monkeypatch, home)
+
+    fatigued = [
+        {
+            "memory_id": i,
+            "corrections_7d": 3,
+            "types": "explicit",
+            "content": f"Memory #{i}",
+            "strength": 0.2,
+            "source_type": "session",
+            "domain": "test",
+        }
+        for i in range(15)
+    ]
+
+    mod._open_correction_fatigue_followup(fatigued)
+
+    conn = sqlite3.connect(str(db_path))
+    row = conn.execute(
+        "SELECT description FROM followups WHERE id = ?",
+        (mod.CORRECTION_FATIGUE_FOLLOWUP_ID,),
+    ).fetchone()
+    conn.close()
+    assert row is not None
+    assert "and 5 more" in row[0]


### PR DESCRIPTION
Closes Fase 3 item 4. Adds NF-CORRECTION-FATIGUE deterministic followup so fatigued memories surface in morning briefing instead of being buried in cron log. 4 tests new. Pattern matches Fase 2 items 4 and 6.