### PR TITLE
feat(cognitive): integrate somatic markers into search reranking (audit-fase3 item 2)

### DIFF
--- a/src/cognitive/_search.py
+++ b/src/cognitive/_search.py
@@ -278,6 +278,82 @@ def _result_confidence(score: float) -> str:
 # (structural) worlds.
 # ============================================================================
 
+def _somatic_boost_results(results: list[dict], max_boost: float = 0.10) -> list[dict]:
+    """Boost search results that touch high-risk somatic targets.
+
+    Closes Fase 3 item 2 of NEXO-AUDIT-2026-04-11. The somatic_markers table
+    is populated by guard hits, error_repetition events, and learning_add
+    side effects (see _memory.py:somatic_*). Until this function existed,
+    that risk signal was never used to influence retrieval — a memory
+    touching a known-painful area got no extra surfacing.
+
+    Now any retrieved memory whose `domain` matches an area-type marker
+    with risk_score > 0.1 receives a positive boost proportional to the
+    risk_score. The intent is positive (not penalizing): a high-risk area
+    is exactly the context where the agent benefits from extra reminders.
+
+    Boost formula: min(max_boost, 0.10 * risk_score)
+    - risk_score 0.2 -> +0.020
+    - risk_score 0.5 -> +0.050
+    - risk_score 1.0 -> +0.100 (capped)
+
+    Result rows that received a boost carry `somatic_boost` (the actual
+    boost) and `somatic_risk` (the source risk_score) so dashboards and
+    downstream rerankers can identify them.
+
+    The boost gate matches `_kg_boost_results`: only results already at
+    score >= 0.45 receive the boost, so noise from very weak matches is
+    not amplified.
+    """
+    if not results:
+        return results
+
+    try:
+        db = _get_db()
+    except Exception:
+        return results
+
+    # Collect distinct domains across the result set so we can do a single
+    # batched query against somatic_markers instead of one per result.
+    domains = {(r.get("domain") or "").strip() for r in results if (r.get("domain") or "").strip()}
+    if not domains:
+        return results
+
+    try:
+        placeholders = ",".join(["?"] * len(domains))
+        rows = db.execute(
+            f"SELECT target, risk_score FROM somatic_markers "
+            f"WHERE target_type = 'area' AND risk_score > 0.1 "
+            f"AND target IN ({placeholders})",
+            list(domains),
+        ).fetchall()
+    except Exception:
+        return results
+
+    if not rows:
+        return results
+
+    risk_by_domain = {row["target"]: float(row["risk_score"] or 0.0) for row in rows}
+
+    for r in results:
+        domain = (r.get("domain") or "").strip()
+        if not domain:
+            continue
+        risk = risk_by_domain.get(domain, 0.0)
+        if risk <= 0.1:
+            continue
+        if r.get("score", 0) < 0.45:  # Same relevance gate as KG and temporal
+            continue
+        boost = min(max_boost, 0.10 * risk)
+        if boost <= 0:
+            continue
+        r["score"] = min(0.95, r["score"] + boost)
+        r["somatic_boost"] = round(boost, 4)
+        r["somatic_risk"] = round(risk, 4)
+
+    return results
+
+
 def _kg_boost_results(results: list[dict], max_boost: float = 0.08) -> list[dict]:
     """Boost search results based on Knowledge Graph connectivity.
 
@@ -966,6 +1042,11 @@ def search(
 
     # Knowledge Graph structural boost: connected memories rank higher
     results = _kg_boost_results(results)
+
+    # Fase 3 item 2: somatic risk boost — memories whose domain matches a
+    # high-risk area marker get a small positive lift so the agent surfaces
+    # warnings about painful areas more aggressively.
+    results = _somatic_boost_results(results)
 
     # Sort by score descending, take top-20 for reranking
     results.sort(key=lambda x: x.get("score", 0), reverse=True)

--- a/tests/test_cognitive.py
+++ b/tests/test_cognitive.py
@@ -579,3 +579,136 @@ def test_dream_weight_rejects_garbage_input(monkeypatch):
     )
     # Garbage falls back to 0 -> dreams excluded.
     assert all(r["source_type"] != "dream_insight" for r in results)
+
+
+# ── Fase 3 item 2: somatic markers in retrieval reranking ────────────────
+
+
+def test_somatic_boost_results_no_op_when_no_markers(monkeypatch):
+    import importlib
+    _search = importlib.import_module("cognitive._search")
+
+    class _SCursor:
+        def fetchall(self):
+            return []
+
+    class _SDB:
+        def execute(self, sql, params=()):
+            return _SCursor()
+
+    monkeypatch.setattr(_search, "_get_db", lambda: _SDB())
+    results = [
+        {"store": "ltm", "id": 1, "domain": "ecommerce", "score": 0.7, "source_type": "learning", "source_id": "L1"},
+    ]
+    boosted = _search._somatic_boost_results(results)
+    assert "somatic_boost" not in boosted[0]
+    assert boosted[0]["score"] == 0.7
+
+
+def test_somatic_boost_results_lifts_high_risk_domain(monkeypatch):
+    import importlib
+    _search = importlib.import_module("cognitive._search")
+
+    class _SCursor:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def fetchall(self):
+            return self._rows
+
+    class _SDB:
+        def execute(self, sql, params=()):
+            if "FROM somatic_markers" in sql:
+                return _SCursor([
+                    {"target": "ecommerce", "risk_score": 0.6},
+                    {"target": "wazion", "risk_score": 0.05},
+                ])
+            return _SCursor([])
+
+    monkeypatch.setattr(_search, "_get_db", lambda: _SDB())
+
+    results = [
+        {"store": "ltm", "id": 1, "domain": "ecommerce", "score": 0.70, "source_type": "learning", "source_id": "L1"},
+        {"store": "ltm", "id": 2, "domain": "wazion", "score": 0.65, "source_type": "learning", "source_id": "L2"},
+        {"store": "ltm", "id": 3, "domain": "nexo", "score": 0.80, "source_type": "learning", "source_id": "L3"},
+    ]
+    boosted = _search._somatic_boost_results(results)
+
+    by_id = {r["id"]: r for r in boosted}
+    assert by_id[1]["score"] == pytest.approx(0.76, abs=1e-4)
+    assert by_id[1]["somatic_boost"] == pytest.approx(0.06, abs=1e-4)
+    assert by_id[1]["somatic_risk"] == pytest.approx(0.6, abs=1e-4)
+    assert by_id[2]["score"] == 0.65
+    assert "somatic_boost" not in by_id[2]
+    assert by_id[3]["score"] == 0.80
+    assert "somatic_boost" not in by_id[3]
+
+
+def test_somatic_boost_results_skips_low_relevance_results(monkeypatch):
+    """The 0.45 relevance gate must prevent boosting noisy weak matches."""
+    import importlib
+    _search = importlib.import_module("cognitive._search")
+
+    class _SCursor:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def fetchall(self):
+            return self._rows
+
+    class _SDB:
+        def execute(self, sql, params=()):
+            if "FROM somatic_markers" in sql:
+                return _SCursor([{"target": "ecommerce", "risk_score": 0.9}])
+            return _SCursor([])
+
+    monkeypatch.setattr(_search, "_get_db", lambda: _SDB())
+
+    results = [
+        {"store": "ltm", "id": 1, "domain": "ecommerce", "score": 0.40, "source_type": "learning", "source_id": "L1"},
+    ]
+    boosted = _search._somatic_boost_results(results)
+    assert boosted[0]["score"] == 0.40
+    assert "somatic_boost" not in boosted[0]
+
+
+def test_somatic_boost_results_caps_at_max_boost(monkeypatch):
+    import importlib
+    _search = importlib.import_module("cognitive._search")
+
+    class _SCursor:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def fetchall(self):
+            return self._rows
+
+    class _SDB:
+        def execute(self, sql, params=()):
+            if "FROM somatic_markers" in sql:
+                return _SCursor([{"target": "ecommerce", "risk_score": 1.5}])
+            return _SCursor([])
+
+    monkeypatch.setattr(_search, "_get_db", lambda: _SDB())
+
+    results = [
+        {"store": "ltm", "id": 1, "domain": "ecommerce", "score": 0.70, "source_type": "learning", "source_id": "L1"},
+    ]
+    boosted = _search._somatic_boost_results(results)
+    assert boosted[0]["somatic_boost"] == pytest.approx(0.10, abs=1e-4)
+    assert boosted[0]["score"] == pytest.approx(0.80, abs=1e-4)
+
+
+def test_somatic_boost_results_handles_db_error_gracefully(monkeypatch):
+    import importlib
+    _search = importlib.import_module("cognitive._search")
+
+    def _raises():
+        raise RuntimeError("db unavailable")
+
+    monkeypatch.setattr(_search, "_get_db", _raises)
+    results = [
+        {"store": "ltm", "id": 1, "domain": "ecommerce", "score": 0.7},
+    ]
+    boosted = _search._somatic_boost_results(results)
+    assert boosted == results


### PR DESCRIPTION
Closes Fase 3 item 2. Adds `_somatic_boost_results()` to wire `somatic_markers` into the search rerank pipeline. High-risk area domains (risk_score > 0.1) get a positive lift (max 0.10) so the agent surfaces warnings about painful areas more aggressively. Same 0.45 relevance gate as KG boost. 5 new tests, 23/23 in test_cognitive total.