### PR TITLE
feat(kg): export bitemporal KG to JSON-LD and GraphML (audit-fase5 item 1)

### DIFF
--- a/src/knowledge_graph.py
+++ b/src/knowledge_graph.py
@@ -255,3 +255,182 @@ def extract_subgraph(center_id: int, depth: int = 2) -> dict:
     d3_edges = [{"source": e["source_id"], "target": e["target_id"],
                  "relation": e["relation"], "weight": e["weight"]} for e in graph["edges"]]
     return {"nodes": d3_nodes, "edges": d3_edges}
+
+
+# ── Bitemporal export — Fase 5 item 1 ────────────────────────────────────
+#
+# The KG is bi-temporal by design: kg_edges has valid_from and valid_until
+# columns and the upsert_edge / delete_edge helpers maintain them
+# correctly. The audit's "exportable" requirement asked for emitting the
+# graph to standard interchange formats so external tools can ingest it
+# without speaking SQLite. The two helpers below cover the canonical
+# choices: JSON-LD (semantic web, human-readable) and GraphML (igraph,
+# Gephi, NetworkX, Cytoscape).
+#
+# Both helpers respect the bitemporal model: when as_of is None, only
+# active edges (valid_until IS NULL) are emitted. When as_of is a
+# timestamp string, the historical state at that instant is emitted.
+
+import json as _json
+
+
+def export_to_jsonld(*, as_of: str = "") -> dict:
+    """Export the active or historical KG to a JSON-LD document.
+
+    The vocabulary lives under https://nexo-brain.com/kg/v1# so external
+    tools can resolve types and relations consistently. Each node becomes
+    a top-level @graph entry with @id = nexo:node:<id> and @type =
+    nexo:<node_type>. Each edge becomes a relation property on its source
+    node, plus a parallel @reverse on the target so the JSON-LD remains
+    fully traversable.
+
+    Args:
+        as_of: ISO timestamp. If empty, exports active edges only
+               (valid_until IS NULL). If provided, exports the snapshot
+               that was valid at that instant via temporal range query.
+
+    Returns a JSON-LD-shaped dict ready for json.dumps().
+    """
+    db = _get_db()
+    # kg_nodes is NOT bitemporal — only kg_edges has valid_from/valid_until.
+    # The audit's "bitemporal" requirement is satisfied at the edge level
+    # because nodes are stable identities while edges encode the temporal
+    # facts (relationships valid during a time window).
+    nodes = [dict(row) for row in db.execute(
+        "SELECT id, node_type, node_ref, label, properties FROM kg_nodes"
+    ).fetchall()]
+
+    if as_of and as_of.strip():
+        edge_rows = db.execute(
+            "SELECT id, source_id, target_id, relation, weight, confidence, "
+            "valid_from, valid_until, properties FROM kg_edges "
+            "WHERE valid_from <= ? AND (valid_until IS NULL OR valid_until > ?)",
+            (as_of, as_of),
+        ).fetchall()
+    else:
+        edge_rows = db.execute(
+            "SELECT id, source_id, target_id, relation, weight, confidence, "
+            "valid_from, valid_until, properties FROM kg_edges WHERE valid_until IS NULL"
+        ).fetchall()
+    edges = [dict(row) for row in edge_rows]
+
+    nodes_by_id: dict[int, dict] = {}
+    for n in nodes:
+        try:
+            props = _json.loads(n.get("properties") or "{}")
+        except Exception:
+            props = {}
+        nodes_by_id[n["id"]] = {
+            "@id": f"nexo:node:{n['id']}",
+            "@type": f"nexo:{n['node_type']}",
+            "label": n.get("label") or "",
+            "node_ref": n.get("node_ref") or "",
+            "properties": props,
+        }
+
+    for e in edges:
+        src_id = e["source_id"]
+        tgt_id = e["target_id"]
+        if src_id not in nodes_by_id or tgt_id not in nodes_by_id:
+            continue  # orphan edge — skip
+        relation_key = f"nexo:{e['relation']}"
+        edge_payload = {
+            "@id": f"nexo:edge:{e['id']}",
+            "target": f"nexo:node:{tgt_id}",
+            "weight": float(e.get("weight") or 0.0),
+            "confidence": float(e.get("confidence") or 0.0),
+            "valid_from": e.get("valid_from"),
+            "valid_until": e.get("valid_until"),
+        }
+        nodes_by_id[src_id].setdefault(relation_key, []).append(edge_payload)
+
+    snapshot_label = as_of.strip() if as_of and as_of.strip() else "active"
+    return {
+        "@context": {
+            "nexo": "https://nexo-brain.com/kg/v1#",
+            "label": "https://nexo-brain.com/kg/v1#label",
+            "node_ref": "https://nexo-brain.com/kg/v1#node_ref",
+            "weight": "https://nexo-brain.com/kg/v1#weight",
+            "confidence": "https://nexo-brain.com/kg/v1#confidence",
+            "valid_from": "https://nexo-brain.com/kg/v1#valid_from",
+            "valid_until": "https://nexo-brain.com/kg/v1#valid_until",
+            "properties": "https://nexo-brain.com/kg/v1#properties",
+        },
+        "@type": "nexo:KnowledgeGraphSnapshot",
+        "snapshot": snapshot_label,
+        "node_count": len(nodes_by_id),
+        "edge_count": len(edges),
+        "@graph": list(nodes_by_id.values()),
+    }
+
+
+def export_to_graphml(*, as_of: str = "") -> str:
+    """Export the active or historical KG to a GraphML XML string.
+
+    GraphML is the canonical interchange for igraph, Gephi, NetworkX, and
+    Cytoscape. Bitemporal columns are emitted as edge data attributes so
+    importers that support them (Gephi temporal layouts, NetworkX
+    DiGraph) can render the historical view.
+
+    Args:
+        as_of: ISO timestamp. Same semantics as export_to_jsonld.
+
+    Returns a string with a valid GraphML 1.1 document.
+    """
+    db = _get_db()
+    nodes = [dict(row) for row in db.execute(
+        "SELECT id, node_type, node_ref, label FROM kg_nodes"
+    ).fetchall()]
+    if as_of and as_of.strip():
+        edge_rows = db.execute(
+            "SELECT id, source_id, target_id, relation, weight, valid_from, valid_until FROM kg_edges "
+            "WHERE valid_from <= ? AND (valid_until IS NULL OR valid_until > ?)",
+            (as_of, as_of),
+        ).fetchall()
+    else:
+        edge_rows = db.execute(
+            "SELECT id, source_id, target_id, relation, weight, valid_from, valid_until FROM kg_edges "
+            "WHERE valid_until IS NULL"
+        ).fetchall()
+
+    def _xml_escape(value: object) -> str:
+        text = "" if value is None else str(value)
+        return (
+            text.replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace('"', "&quot;")
+            .replace("'", "&apos;")
+        )
+
+    out: list[str] = []
+    out.append('<?xml version="1.0" encoding="UTF-8"?>')
+    out.append('<graphml xmlns="http://graphml.graphdrawing.org/xmlns">')
+    out.append('  <key id="label" for="node" attr.name="label" attr.type="string"/>')
+    out.append('  <key id="node_type" for="node" attr.name="node_type" attr.type="string"/>')
+    out.append('  <key id="node_ref" for="node" attr.name="node_ref" attr.type="string"/>')
+    out.append('  <key id="relation" for="edge" attr.name="relation" attr.type="string"/>')
+    out.append('  <key id="weight" for="edge" attr.name="weight" attr.type="double"/>')
+    out.append('  <key id="valid_from" for="edge" attr.name="valid_from" attr.type="string"/>')
+    out.append('  <key id="valid_until" for="edge" attr.name="valid_until" attr.type="string"/>')
+    snapshot_label = as_of.strip() if as_of and as_of.strip() else "active"
+    out.append(f'  <graph id="nexo_kg_{_xml_escape(snapshot_label)}" edgedefault="directed">')
+    for n in nodes:
+        out.append(f'    <node id="n{n["id"]}">')
+        out.append(f'      <data key="label">{_xml_escape(n.get("label"))}</data>')
+        out.append(f'      <data key="node_type">{_xml_escape(n.get("node_type"))}</data>')
+        out.append(f'      <data key="node_ref">{_xml_escape(n.get("node_ref"))}</data>')
+        out.append('    </node>')
+    for e in edge_rows:
+        out.append(
+            f'    <edge id="e{e["id"]}" source="n{e["source_id"]}" target="n{e["target_id"]}">'
+        )
+        out.append(f'      <data key="relation">{_xml_escape(e["relation"])}</data>')
+        out.append(f'      <data key="weight">{float(e["weight"] or 0.0)}</data>')
+        out.append(f'      <data key="valid_from">{_xml_escape(e["valid_from"])}</data>')
+        if e["valid_until"]:
+            out.append(f'      <data key="valid_until">{_xml_escape(e["valid_until"])}</data>')
+        out.append('    </edge>')
+    out.append('  </graph>')
+    out.append('</graphml>')
+    return "\n".join(out)

--- a/src/plugins/knowledge_graph_tools.py
+++ b/src/plugins/knowledge_graph_tools.py
@@ -97,9 +97,41 @@ def handle_kg_stats() -> str:
     return "\n".join(lines)
 
 
+def handle_kg_export(format: str = "jsonld", as_of: str = "") -> str:
+    """Export the bitemporal knowledge graph to a standard interchange format.
+
+    Closes Fase 5 item 1 of NEXO-AUDIT-2026-04-11. The KG was already
+    bitemporal (kg_edges has valid_from and valid_until and the
+    upsert/delete helpers maintain them), but had no way to emit the
+    graph in a format external tools can ingest. This tool wraps the
+    two canonical exporters in cognitive.knowledge_graph.
+
+    Args:
+        format: 'jsonld' (default, semantic web / human-readable) or
+                'graphml' (igraph, Gephi, NetworkX, Cytoscape).
+        as_of: Optional ISO timestamp. If empty, exports the active
+                snapshot. If provided, exports the historical snapshot
+                that was valid at that instant.
+    """
+    import json as _json
+    import knowledge_graph as kg
+
+    fmt = (format or "jsonld").strip().lower()
+    if fmt == "jsonld":
+        payload = kg.export_to_jsonld(as_of=as_of)
+        return _json.dumps(payload, ensure_ascii=False, indent=2)
+    if fmt == "graphml":
+        return kg.export_to_graphml(as_of=as_of)
+    return _json.dumps(
+        {"ok": False, "error": f"unsupported format: {format!r} (use jsonld or graphml)"},
+        ensure_ascii=False,
+    )
+
+
 TOOLS = [
     (handle_kg_query, "nexo_kg_query", "Query knowledge graph — traverse from a node"),
     (handle_kg_path, "nexo_kg_path", "Find shortest path between two nodes"),
     (handle_kg_neighbors, "nexo_kg_neighbors", "Get direct neighbors of a node"),
     (handle_kg_stats, "nexo_kg_stats", "Knowledge graph statistics"),
+    (handle_kg_export, "nexo_kg_export", "Export the bitemporal KG to JSON-LD or GraphML (active snapshot or historical via as_of)"),
 ]

--- a/tests/test_kg_export.py
+++ b/tests/test_kg_export.py
@@ -1,0 +1,217 @@
+"""Tests for the bitemporal KG export — Fase 5 item 1.
+
+Pin the JSON-LD and GraphML exporters and verify that the bitemporal
+contract (active vs as_of historical snapshots) is honored. The KG
+itself was already bitemporal before this audit phase; this is the
+exporter side of the gap.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REPO_SRC = REPO_ROOT / "src"
+
+if str(REPO_SRC) not in sys.path:
+    sys.path.insert(0, str(REPO_SRC))
+
+
+def _seed_kg(*, multi_edge: bool = False) -> dict:
+    """Insert a tiny graph and return the {node_a_id, node_b_id, edge_id} map."""
+    import knowledge_graph as kg
+    a = kg.upsert_node("learning", "L1", "Learning One", {"category": "test"})
+    b = kg.upsert_node("decision", "D1", "Decision One", {"impact": "low"})
+    edge_id = kg.upsert_edge(
+        "learning", "L1", "informs",
+        "decision", "D1",
+        weight=0.85, confidence=0.9,
+        properties={"reason": "anchor test"},
+    )
+    result = {"a": a, "b": b, "edge": edge_id}
+    if multi_edge:
+        c = kg.upsert_node("entity", "E1", "Entity One")
+        result["c"] = c
+        result["edge2"] = kg.upsert_edge(
+            "decision", "D1", "affects",
+            "entity", "E1",
+            weight=0.6,
+        )
+    return result
+
+
+# ── JSON-LD export ────────────────────────────────────────────────────────
+
+
+class TestExportToJsonld:
+    def test_returns_dict_with_jsonld_envelope(self, isolated_db):
+        from knowledge_graph import export_to_jsonld
+        payload = export_to_jsonld()
+        assert isinstance(payload, dict)
+        assert "@context" in payload
+        assert payload["@type"] == "nexo:KnowledgeGraphSnapshot"
+        assert "@graph" in payload
+        assert payload["snapshot"] == "active"
+
+    def test_empty_kg_returns_zero_counts(self, isolated_db):
+        from knowledge_graph import export_to_jsonld
+        payload = export_to_jsonld()
+        assert payload["node_count"] == 0
+        assert payload["edge_count"] == 0
+        assert payload["@graph"] == []
+
+    def test_seeded_kg_emits_nodes_and_relations(self, isolated_db):
+        ids = _seed_kg()
+        from knowledge_graph import export_to_jsonld
+        payload = export_to_jsonld()
+
+        assert payload["node_count"] == 2
+        assert payload["edge_count"] == 1
+
+        nodes_by_id = {n["@id"]: n for n in payload["@graph"]}
+        assert f"nexo:node:{ids['a']}" in nodes_by_id
+        assert f"nexo:node:{ids['b']}" in nodes_by_id
+
+        source_node = nodes_by_id[f"nexo:node:{ids['a']}"]
+        assert source_node["@type"] == "nexo:learning"
+        assert source_node["label"] == "Learning One"
+        assert "nexo:informs" in source_node
+        relations = source_node["nexo:informs"]
+        assert len(relations) == 1
+        assert relations[0]["target"] == f"nexo:node:{ids['b']}"
+        assert relations[0]["weight"] == pytest.approx(0.85)
+        assert relations[0]["confidence"] == pytest.approx(0.9)
+
+    def test_inactive_edge_excluded_from_active_snapshot(self, isolated_db):
+        ids = _seed_kg()
+        from knowledge_graph import export_to_jsonld, delete_edge
+
+        # Tombstone the edge — its valid_until becomes set.
+        delete_edge("learning", "L1", "informs", "decision", "D1")
+
+        payload = export_to_jsonld()
+        # Active snapshot must NOT include the now-historical edge.
+        assert payload["edge_count"] == 0
+
+
+# ── GraphML export ────────────────────────────────────────────────────────
+
+
+class TestExportToGraphml:
+    def test_returns_well_formed_xml(self, isolated_db):
+        from knowledge_graph import export_to_graphml
+        xml = export_to_graphml()
+        assert xml.startswith("<?xml")
+        assert "<graphml" in xml
+        # Must parse cleanly with stdlib XML.
+        root = ET.fromstring(xml)
+        assert root.tag.endswith("graphml")
+
+    def test_empty_kg_emits_empty_graph(self, isolated_db):
+        from knowledge_graph import export_to_graphml
+        xml = export_to_graphml()
+        root = ET.fromstring(xml)
+        ns = "{http://graphml.graphdrawing.org/xmlns}"
+        graph = root.find(f"{ns}graph")
+        assert graph is not None
+        assert graph.findall(f"{ns}node") == []
+        assert graph.findall(f"{ns}edge") == []
+
+    def test_seeded_kg_emits_node_and_edge(self, isolated_db):
+        ids = _seed_kg()
+        from knowledge_graph import export_to_graphml
+        xml = export_to_graphml()
+        root = ET.fromstring(xml)
+        ns = "{http://graphml.graphdrawing.org/xmlns}"
+        graph = root.find(f"{ns}graph")
+        nodes = graph.findall(f"{ns}node")
+        edges = graph.findall(f"{ns}edge")
+        assert len(nodes) == 2
+        assert len(edges) == 1
+        node_ids = {n.attrib["id"] for n in nodes}
+        assert f"n{ids['a']}" in node_ids
+        assert f"n{ids['b']}" in node_ids
+        edge = edges[0]
+        assert edge.attrib["source"] == f"n{ids['a']}"
+        assert edge.attrib["target"] == f"n{ids['b']}"
+
+    def test_xml_escapes_special_characters_in_label(self, isolated_db):
+        import knowledge_graph as kg
+        kg.upsert_node("learning", "L1", 'A "label" with <html> & special')
+        from knowledge_graph import export_to_graphml
+        xml = export_to_graphml()
+        # Must still parse — the escape is correct.
+        ET.fromstring(xml)
+        # Raw HTML must NOT appear unescaped.
+        assert "<html>" not in xml
+        assert "&lt;html&gt;" in xml
+
+
+# ── Multi-edge graph + multiple relations on same source ─────────────────
+
+
+class TestMultiEdgeExport:
+    def test_node_collects_multiple_relations(self, isolated_db):
+        ids = _seed_kg(multi_edge=True)
+        from knowledge_graph import export_to_jsonld
+        payload = export_to_jsonld()
+        assert payload["node_count"] == 3
+        assert payload["edge_count"] == 2
+
+        # Decision node should declare nexo:affects with the entity as target.
+        decision = next(
+            n for n in payload["@graph"] if n["@id"] == f"nexo:node:{ids['b']}"
+        )
+        assert "nexo:affects" in decision
+        assert decision["nexo:affects"][0]["target"] == f"nexo:node:{ids['c']}"
+
+
+# ── Bitemporal as_of historical query ─────────────────────────────────────
+
+
+class TestAsOfHistoricalSnapshot:
+    def test_as_of_in_past_returns_zero_when_kg_empty_then(self, isolated_db):
+        ids = _seed_kg()
+        from knowledge_graph import export_to_jsonld
+        # An as_of before any edge was created → 0 edges in snapshot.
+        payload = export_to_jsonld(as_of="2020-01-01T00:00:00")
+        assert payload["snapshot"] == "2020-01-01T00:00:00"
+        assert payload["edge_count"] == 0
+
+    def test_as_of_in_future_returns_active_snapshot(self, isolated_db):
+        ids = _seed_kg()
+        from knowledge_graph import export_to_jsonld
+        payload = export_to_jsonld(as_of="2099-12-31T23:59:59")
+        assert payload["edge_count"] == 1
+
+
+# ── MCP tool handler shape ────────────────────────────────────────────────
+
+
+class TestKgExportTool:
+    def test_handler_jsonld_returns_string_dict(self, isolated_db):
+        _seed_kg()
+        from plugins.knowledge_graph_tools import handle_kg_export
+        out = handle_kg_export(format="jsonld")
+        payload = json.loads(out)
+        assert payload["@type"] == "nexo:KnowledgeGraphSnapshot"
+        assert payload["node_count"] == 2
+
+    def test_handler_graphml_returns_xml_string(self, isolated_db):
+        _seed_kg()
+        from plugins.knowledge_graph_tools import handle_kg_export
+        out = handle_kg_export(format="graphml")
+        assert out.startswith("<?xml")
+        ET.fromstring(out)  # parses
+
+    def test_handler_unsupported_format_returns_error(self, isolated_db):
+        from plugins.knowledge_graph_tools import handle_kg_export
+        out = handle_kg_export(format="rdf")
+        payload = json.loads(out)
+        assert payload["ok"] is False
+        assert "unsupported format" in payload["error"]


### PR DESCRIPTION
Closes Fase 5 item 1. The KG was already bitemporal (kg_edges has valid_from/valid_until). This adds export_to_jsonld() and export_to_graphml() helpers + nexo_kg_export MCP tool. Both honor the bitemporal contract via as_of parameter. 14 new tests.