### PR TITLE
feat(skills): Voyager-style co-activation detector (audit-fase5 item 5)

### DIFF
--- a/src/plugins/skills.py
+++ b/src/plugins/skills.py
@@ -20,6 +20,7 @@ from skills_runtime import (
     apply_skill,
     approve_skill_execution,
     compose_skills,
+    detect_skill_coactivation_candidates,
     get_featured_skill_summaries,
     list_evolution_candidates,
     materialize_outcome_pattern_skill,
@@ -210,6 +211,35 @@ def handle_skill_evolution_candidates() -> str:
     return json.dumps(list_evolution_candidates(), ensure_ascii=False)
 
 
+def handle_skill_compose_candidates(
+    min_co_occurrence: int = 3,
+    min_success_rate: float = 0.6,
+    limit: int = 20,
+) -> str:
+    """List Voyager-style composition candidates from skill_usage co-activation.
+
+    Closes Fase 5 item 5. Detects pairs of skills that fire together
+    in the same session repeatedly and could become a single composite.
+    Returns the candidates sorted by co-occurrence count, with a
+    suggested deterministic skill_id (SK-COMPOSE-<a>+<b>) that
+    nexo_skill_compose can take as input.
+
+    Args:
+        min_co_occurrence: minimum sessions where both skills fired (default 3).
+        min_success_rate: minimum joint success rate (default 0.6).
+        limit: max candidates to return (default 20).
+    """
+    return json.dumps(
+        detect_skill_coactivation_candidates(
+            min_co_occurrence=int(min_co_occurrence),
+            min_success_rate=float(min_success_rate),
+            limit=int(limit),
+        ),
+        ensure_ascii=False,
+        indent=2,
+    )
+
+
 def handle_skill_seed_from_outcome_pattern(pattern_key: str) -> str:
     return json.dumps(materialize_outcome_pattern_skill(pattern_key), ensure_ascii=False)
 
@@ -306,4 +336,6 @@ TOOLS = [
      "Retire a skill cleanly so it leaves the active lifecycle."),
     (handle_skill_compose, "nexo_skill_compose",
      "Compose multiple existing skills into one higher-level reusable skill."),
+    (handle_skill_compose_candidates, "nexo_skill_compose_candidates",
+     "Voyager-style detection: list skill pairs that fired together in 3+ sessions with 60%+ joint success and could become a single composite (closes Fase 5 item 5)."),
 ]

--- a/src/skills_runtime.py
+++ b/src/skills_runtime.py
@@ -734,6 +734,123 @@ def auto_promote_outcome_patterns_to_skills(
     }
 
 
+def detect_skill_coactivation_candidates(
+    *,
+    min_co_occurrence: int = 3,
+    min_success_rate: float = 0.6,
+    limit: int = 20,
+) -> list[dict]:
+    """Detect pairs of skills that fire together and could be composed.
+
+    Closes Fase 5 item 5 of NEXO-AUDIT-2026-04-11. NEXO already has
+    compose_skills (manual composer), auto_promote_outcome_patterns_to_skills
+    (Fase 2 item 2), and auto_promote_skill_evolution (guide → executable
+    draft). What it lacked is the Voyager-style observation pass: when
+    the same two skills are used inside the same session multiple times,
+    a composite skill probably wants to exist.
+
+    This function reads skill_usage rows, groups by session_id to get
+    the set of skills per session, builds a co-occurrence count over
+    all unordered pairs, and returns candidates whose count is at or
+    above min_co_occurrence and whose joint success rate is at or
+    above min_success_rate.
+
+    Args:
+        min_co_occurrence: minimum number of sessions both skills must
+            have co-occurred in. Default 3 — same threshold the
+            outcome_pattern detector uses.
+        min_success_rate: minimum joint success rate (success rows /
+            total rows for the pair). Default 0.6.
+        limit: max candidates to return. Default 20.
+
+    Returns a list (newest co-occurrence first):
+        [
+          {
+            "skill_a": str, "skill_b": str,
+            "co_occurrence": int,
+            "joint_success_rate": float,
+            "sessions": [session_id, ...],
+            "suggested_skill_id": str,   # canonical id for the composite
+          },
+          ...
+        ]
+
+    Pure DB read, never raises. Empty list when skill_usage table is
+    missing or no candidates qualify.
+    """
+    _ensure_ready()
+    try:
+        from db import get_db
+        conn = get_db()
+        # Sanity check the table exists.
+        conn.execute("SELECT 1 FROM skill_usage LIMIT 1").fetchone()
+    except Exception:
+        return []
+
+    try:
+        rows = conn.execute(
+            "SELECT skill_id, session_id, success FROM skill_usage "
+            "WHERE session_id IS NOT NULL AND session_id != '' "
+            "ORDER BY created_at DESC LIMIT 5000"
+        ).fetchall()
+    except Exception:
+        return []
+
+    by_session: dict[str, list[tuple[str, int]]] = {}
+    for row in rows:
+        sid = (row["session_id"] or "").strip() if hasattr(row, "keys") else (row[1] or "").strip()
+        if not sid:
+            continue
+        skill_id = row["skill_id"] if hasattr(row, "keys") else row[0]
+        success = row["success"] if hasattr(row, "keys") else row[2]
+        by_session.setdefault(sid, []).append((skill_id, int(success or 0)))
+
+    pair_stats: dict[tuple[str, str], dict] = {}
+    for sid, usages in by_session.items():
+        # Distinct skills with their best (any) success in this session.
+        seen_in_session: dict[str, int] = {}
+        for skill_id, success in usages:
+            seen_in_session[skill_id] = max(seen_in_session.get(skill_id, 0), success)
+        skills_in_session = sorted(seen_in_session.keys())
+        if len(skills_in_session) < 2:
+            continue
+        for i in range(len(skills_in_session)):
+            for j in range(i + 1, len(skills_in_session)):
+                pair = (skills_in_session[i], skills_in_session[j])
+                stats = pair_stats.setdefault(
+                    pair,
+                    {"co_occurrence": 0, "joint_success": 0, "sessions": []},
+                )
+                stats["co_occurrence"] += 1
+                # Joint success: both skills succeeded in this session.
+                if seen_in_session[pair[0]] and seen_in_session[pair[1]]:
+                    stats["joint_success"] += 1
+                stats["sessions"].append(sid)
+
+    candidates: list[dict] = []
+    for (skill_a, skill_b), stats in pair_stats.items():
+        co = stats["co_occurrence"]
+        if co < int(min_co_occurrence):
+            continue
+        rate = stats["joint_success"] / co if co > 0 else 0.0
+        if rate < float(min_success_rate):
+            continue
+        # Deterministic suggested id derived from the pair so re-running
+        # the detector points at the same composite skill.
+        suggested_id = "SK-COMPOSE-" + "+".join(sorted([skill_a, skill_b]))
+        candidates.append({
+            "skill_a": skill_a,
+            "skill_b": skill_b,
+            "co_occurrence": co,
+            "joint_success_rate": round(rate, 3),
+            "sessions": stats["sessions"][:5],
+            "suggested_skill_id": suggested_id,
+        })
+
+    candidates.sort(key=lambda c: (-c["co_occurrence"], -c["joint_success_rate"]))
+    return candidates[: max(1, int(limit))]
+
+
 def auto_promote_skill_evolution(approved_by: str = "system:auto") -> dict:
     """Convert mature guide skills into executable drafts without manual approval."""
     _ensure_ready()

--- a/tests/test_skill_coactivation.py
+++ b/tests/test_skill_coactivation.py
@@ -1,0 +1,177 @@
+"""Tests for the Voyager-style skill co-activation detector — Fase 5 item 5."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REPO_SRC = REPO_ROOT / "src"
+
+if str(REPO_SRC) not in sys.path:
+    sys.path.insert(0, str(REPO_SRC))
+
+
+_skills_seeded: set[str] = set()
+
+
+def _ensure_skill_exists(skill_id: str):
+    """Insert a stub skill row so the FK on skill_usage holds."""
+    if skill_id in _skills_seeded:
+        return
+    from db import get_db
+    conn = get_db()
+    conn.execute(
+        "INSERT OR IGNORE INTO skills (id, name, description, level, content) "
+        "VALUES (?, ?, '', 'draft', '')",
+        (skill_id, f"Test skill {skill_id}"),
+    )
+    try:
+        conn.commit()
+    except Exception:
+        pass
+    _skills_seeded.add(skill_id)
+
+
+def _seed_skill_usage(skill_id: str, session_id: str, success: bool = True):
+    _ensure_skill_exists(skill_id)
+    from db import get_db
+    conn = get_db()
+    conn.execute(
+        "INSERT INTO skill_usage (skill_id, session_id, success, context, created_at) "
+        "VALUES (?, ?, ?, ?, datetime('now'))",
+        (skill_id, session_id, 1 if success else 0, "test seed"),
+    )
+    try:
+        conn.commit()
+    except Exception:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _reset_seeded_skills():
+    """Reset the cache between tests so each isolated_db starts clean."""
+    _skills_seeded.clear()
+    yield
+    _skills_seeded.clear()
+
+
+# ── Empty / sparse cases ─────────────────────────────────────────────────
+
+
+class TestEmptyCases:
+    def test_empty_skill_usage_returns_empty_list(self, isolated_db):
+        from skills_runtime import detect_skill_coactivation_candidates
+        assert detect_skill_coactivation_candidates() == []
+
+    def test_single_skill_per_session_no_pairs(self, isolated_db):
+        _seed_skill_usage("SK-A", "sid-1")
+        _seed_skill_usage("SK-A", "sid-2")
+        from skills_runtime import detect_skill_coactivation_candidates
+        result = detect_skill_coactivation_candidates(min_co_occurrence=1)
+        assert result == []
+
+    def test_pair_below_min_co_occurrence_excluded(self, isolated_db):
+        _seed_skill_usage("SK-A", "sid-1")
+        _seed_skill_usage("SK-B", "sid-1")
+        _seed_skill_usage("SK-A", "sid-2")
+        _seed_skill_usage("SK-B", "sid-2")
+        from skills_runtime import detect_skill_coactivation_candidates
+        result = detect_skill_coactivation_candidates(min_co_occurrence=3)
+        assert result == []
+
+
+# ── Co-occurrence detection ──────────────────────────────────────────────
+
+
+class TestCoOccurrenceDetection:
+    def test_strong_pair_returns_one_candidate(self, isolated_db):
+        for sid in ("sid-1", "sid-2", "sid-3"):
+            _seed_skill_usage("SK-A", sid, success=True)
+            _seed_skill_usage("SK-B", sid, success=True)
+        from skills_runtime import detect_skill_coactivation_candidates
+        result = detect_skill_coactivation_candidates(min_co_occurrence=3)
+        assert len(result) == 1
+        candidate = result[0]
+        assert {candidate["skill_a"], candidate["skill_b"]} == {"SK-A", "SK-B"}
+        assert candidate["co_occurrence"] == 3
+        assert candidate["joint_success_rate"] == 1.0
+        assert candidate["suggested_skill_id"] == "SK-COMPOSE-SK-A+SK-B"
+        assert "sid-1" in candidate["sessions"]
+
+    def test_pair_below_success_rate_excluded(self, isolated_db):
+        _seed_skill_usage("SK-A", "sid-1", success=True)
+        _seed_skill_usage("SK-B", "sid-1", success=True)
+        for sid in ("sid-2", "sid-3", "sid-4"):
+            _seed_skill_usage("SK-A", sid, success=True)
+            _seed_skill_usage("SK-B", sid, success=False)
+        from skills_runtime import detect_skill_coactivation_candidates
+        result = detect_skill_coactivation_candidates(
+            min_co_occurrence=3, min_success_rate=0.6
+        )
+        assert result == []
+
+    def test_multiple_pairs_sorted_by_co_occurrence_desc(self, isolated_db):
+        for i in range(5):
+            sid = f"ab-{i}"
+            _seed_skill_usage("SK-A", sid)
+            _seed_skill_usage("SK-B", sid)
+        for i in range(3):
+            sid = f"cd-{i}"
+            _seed_skill_usage("SK-C", sid)
+            _seed_skill_usage("SK-D", sid)
+
+        from skills_runtime import detect_skill_coactivation_candidates
+        result = detect_skill_coactivation_candidates(min_co_occurrence=3)
+        assert len(result) == 2
+        assert result[0]["co_occurrence"] == 5
+        assert result[1]["co_occurrence"] == 3
+
+    def test_three_skills_in_one_session_yields_three_pairs(self, isolated_db):
+        for i in range(3):
+            sid = f"abc-{i}"
+            _seed_skill_usage("SK-A", sid)
+            _seed_skill_usage("SK-B", sid)
+            _seed_skill_usage("SK-C", sid)
+
+        from skills_runtime import detect_skill_coactivation_candidates
+        result = detect_skill_coactivation_candidates(min_co_occurrence=3)
+        assert len(result) == 3
+
+    def test_suggested_skill_id_is_deterministic_and_sorted(self, isolated_db):
+        for i in range(3):
+            sid = f"order-{i}"
+            _seed_skill_usage("SK-Z", sid)
+            _seed_skill_usage("SK-A", sid)
+
+        from skills_runtime import detect_skill_coactivation_candidates
+        result = detect_skill_coactivation_candidates(min_co_occurrence=3)
+        assert len(result) == 1
+        assert result[0]["suggested_skill_id"] == "SK-COMPOSE-SK-A+SK-Z"
+
+
+# ── MCP tool handler shape ───────────────────────────────────────────────
+
+
+class TestSkillComposeCandidatesTool:
+    def test_handler_returns_json_array(self, isolated_db):
+        for i in range(3):
+            sid = f"tool-{i}"
+            _seed_skill_usage("SK-X", sid)
+            _seed_skill_usage("SK-Y", sid)
+
+        from plugins.skills import handle_skill_compose_candidates
+        import json
+        out = handle_skill_compose_candidates(min_co_occurrence=3)
+        payload = json.loads(out)
+        assert isinstance(payload, list)
+        assert len(payload) == 1
+        assert payload[0]["skill_a"] in {"SK-X", "SK-Y"}
+
+    def test_handler_with_no_data_returns_empty_array(self, isolated_db):
+        from plugins.skills import handle_skill_compose_candidates
+        import json
+        out = handle_skill_compose_candidates(min_co_occurrence=3)
+        assert json.loads(out) == []


### PR DESCRIPTION
Closes Fase 5 item 5. Adds detect_skill_coactivation_candidates() that reads skill_usage rows, groups by session, builds co-occurrence counts over unordered skill pairs, returns candidates with co_occurrence >= min and joint_success_rate >= min. Each candidate carries a deterministic SK-COMPOSE-<a>+<b> id that nexo_skill_compose can take as input. New MCP tool nexo_skill_compose_candidates exposes it. 10 new tests.