### PR TITLE
release(v5.1.0): bump version + CHANGELOG + release contract

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.0.4",
+  "version": "5.1.0",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,134 @@
 # Changelog
 
+## [5.1.0] - 2026-04-11
+
+### NEXO-AUDIT-2026-04-11 — Phases 2-5 delivered end-to-end
+
+This release lands the entire NEXO-AUDIT-2026-04-11 roadmap (Phases 2 through 5
+plus the pre-release Bloques A-D) as a single coordinated version bump. Every
+item was empirically verified before touching code — about 46% of the audit's
+originally-flagged gaps turned out to be false positives, which is why this
+changelog focuses on what actually changed rather than on the audit list
+itself.
+
+### Phase 2 — open evolution / adaptive / skills / cortex loops now close under themselves
+- Evolution cycle now auto-applies user-approved proposals on the next run
+  via `_apply_accepted_proposals()` in `scripts/nexo-evolution-run.py`, backed
+  by the new `evolution_log.proposal_payload` column (migration m38). Accepted
+  proposals can no longer linger in `accepted` state indefinitely.
+- `skills_runtime.auto_promote_outcome_patterns_to_skills()` now materializes
+  recurring outcome patterns into draft skills without manual curation, and
+  `detect_skill_coactivation_candidates()` exposes a Voyager-style detector
+  that groups `skill_usage` by session and surfaces co-occurring pairs as
+  composite-skill candidates via `nexo_skill_compose_candidates`.
+- New `retroactive_learnings.apply_learning_retroactively()` walks recent
+  decisions, scores them against a newly-added learning, and opens
+  deterministic `NF-RETRO-L<id>-D<id>` followups when the learning would have
+  changed the decision. Exposed via `nexo_learning_apply_retroactively`.
+- Adaptive learned-weight rollback now surfaces as a visible followup on the
+  next heartbeat so the operator sees the runtime has backed off instead of
+  the signal staying inside `adaptive_log`.
+- New Cortex quality cron (`scripts/nexo-cortex-cycle.py`, every 6h via
+  `src/crons/manifest.json`) watches accept_rate / linked_success /
+  override_gap thresholds and opens `NF-CORTEX-QUALITY-DROP` idempotently
+  when Cortex quality degrades between cycles.
+- `nexo_heartbeat` surfaces open `protocol_debt` rows for the active task so
+  the agent cannot drift past a dropped discipline rule silently.
+- Deep-sleep `code_change` actions now stage their findings into
+  `evolution_log` with proposal payloads so the evolution cycle can apply
+  them, closing the end-to-end loop from observation → synthesis → apply.
+
+### Phase 3 — cognitive subsystems close their own loops with user-visible evidence
+- `cognitive._search.search()` now accepts `dream_weight: float` and reranks
+  dream-insight memories through that weight when set. A new
+  `_somatic_boost_results()` step (max +0.10) folds somatic markers into the
+  same reranking path, so emotional salience and dream salience are both
+  first-class signals instead of dead columns.
+- State watchers now open and auto-resolve deterministic `NF-WATCHER-{id}`
+  followups through `_open_watcher_followup` /
+  `_resolve_watcher_followup`, so a watcher firing is always externally
+  observable rather than buried in runtime logs.
+- Cognitive-decay now surfaces correction fatigue as a visible followup when
+  the fatigue signal crosses its threshold, instead of only adjusting
+  memory weights invisibly.
+- Hook lifecycle observability: new `src/hook_observability.py` +
+  `src/scripts/nexo-hook-record.py` shim record hook runs into a `hook_runs`
+  table (migration m39) with 3 indexes. `nexo_hook_runs` tool exposes recent
+  runs + a health summary so hook failures surface instead of silently
+  dropping work.
+- `auto_update` is now guarded by POSIX `fcntl.flock` with stale-steal at 10
+  minutes, fixing a race where two concurrent `nexo update` invocations could
+  stomp each other mid-sync.
+
+### Phase 4 — automated lint / security / coverage / release gates on every PR
+- New `.github/workflows/lint.yml` enforces ruff `E9 / F63 / F7 / F82 / F821`
+  on every PR and push to main. Baseline pass fixed 5 latent F821 bugs in
+  `cognitive/_memory.py`, `cognitive/_ingest.py`, `tools_menu.py`.
+- New `.github/workflows/security.yml` runs `bandit -r src/` at
+  `high severity + high confidence`. Baseline pass fixed 10 weak-hash flags
+  (`usedforsecurity=False`) across `plugins/protocol.py`, `plugins/simple_api.py`,
+  `scripts/check-context.py`, `scripts/deep-sleep/apply_findings.py`,
+  `scripts/deep-sleep/synthesize.py`, and `scripts/nexo-daily-self-audit.py`.
+- Coverage baseline tests (`test_decay_baseline.py`, `test_trust_baseline.py`,
+  `test_plugin_loader_baseline.py`, `test_fase4_lint_baseline.py`,
+  `test_security_baseline.py`, `test_release_readiness_baseline.py`) pin the
+  contract surface area of the cognitive / plugin loading / security / release
+  stack so a refactor cannot silently delete it.
+- `.github/workflows/release-readiness.yml` now runs
+  `verify_release_readiness.py --ci` on **every PR** instead of only on tag
+  push, which means a PR that breaks the release contract fails loudly
+  instead of waiting until release time to surface.
+- `requirements-dev.txt` pins `ruff>=0.6.0`, `pytest-cov>=4.0`, and
+  `bandit[toml]>=1.7`. `pyproject.toml` carries the ruff / bandit / pytest
+  configuration so local dev matches CI exactly.
+
+### Phase 5 — shippable differentiators vs existing memory frameworks
+- Bitemporal Knowledge Graph export: `knowledge_graph.export_to_jsonld()` and
+  `knowledge_graph.export_to_graphml()` emit the full graph in JSON-LD (with
+  `nexo:*` vocabulary) or GraphML (for igraph / Gephi / NetworkX / Cytoscape).
+  Both accept an `as_of` ISO timestamp that replays the historical snapshot
+  through `kg_edges.valid_from / valid_until`. Exposed via `nexo_kg_export`.
+- OpenTelemetry integration: new `src/observability.py` soft-imports
+  `opentelemetry` and only activates when `OTEL_EXPORTER_OTLP_ENDPOINT` or
+  `OTEL_SERVICE_NAME` is set. `tool_span()` is a no-op context manager when
+  OTEL is disabled and a real span when enabled, so NEXO can be traced with
+  `ai.tool.*` semantic conventions without a hard dependency.
+- `benchmarks/results/comparison-vs-competition-2026-04.md` documents an
+  honest feature matrix vs Letta, Mem0, Zep, Graphiti, Cognee, and DSPy so
+  the differentiators (bitemporal KG, metacognitive guard, trust scoring,
+  Atkinson-Shiffrin decay, native MCP surface) are defensible with receipts.
+- Voyager-style skill co-activation detector (see Phase 2) ships as the first
+  evidence of automated skill composition from live usage.
+
+### Audit followups (NEXO-AUDIT-2026-04-11) — closed under evidence
+- `nexo_heartbeat` now auto-fires `compute_mode` every heartbeat so
+  `adaptive_log` actually gets populated from live signals instead of staying
+  empty.
+- Server FastMCP instructions now tell the agent to register outcomes
+  proactively, closing the gap where tools existed but the agent didn't know
+  it was supposed to call them.
+- Every other Phase 2-5 followup was either marked `resolved` with evidence
+  or left as an explicit tracked followup with a clear next action.
+
+### Release safety — v5.0.x → v5.1.0 update path
+- `auto_update._reload_launch_agents_after_bump()` now `launchctl unload`s
+  and re-`load`s every `com.nexo.*.plist` after a version bump on macOS, so
+  long-lived crons pick up the new codebase automatically instead of running
+  the pre-bump version until the next reboot.
+- Migrations m38 (`evolution_log.proposal_payload`) and m39 (`hook_runs` +
+  3 indexes) are idempotent `ALTER TABLE` / `CREATE TABLE IF NOT EXISTS`
+  statements safe to re-run across every v5.0.x baseline.
+- `tests/test_update_path_and_reload.py` pins the hot-reload + migration
+  contract. `tests/test_auto_update_lock.py` pins the concurrent-run
+  protection so a regression here fails CI instead of corrupting a real
+  install.
+
+### Validation
+- `python3 -m pytest tests/ -q` — all tests passing.
+- `python3 scripts/verify_release_readiness.py --ci --contract release-contracts/v5.1.0.json --require-contract-complete` passes locally and in CI.
+- ruff + bandit + release-readiness workflows all green on main.
+- Live runtime `nexo doctor --tier all` returns `HEALTHY` after sync.
+
 ## [5.0.4] - 2026-04-11
 
 ### Runtime Bridge + Doctor Signal Cleanup

--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ Versions `3.1.7` through `3.2.0` close the recent-memory gap:
 - when even that misses, NEXO now exposes raw transcript fallback tools for Claude Code and Codex session stores
 - NEXO can now inspect itself through a live system catalog derived from canonical sources instead of relying only on stale docs or operator memory
 
+Version `5.1.0` lands the full NEXO-AUDIT-2026-04-11 roadmap as a single minor bump — every open evolution / adaptive / cognitive / skills loop now closes under itself, the knowledge graph exports cleanly, OpenTelemetry spans can be turned on without a hard dependency, and every PR has to clear lint, security, coverage, and release-readiness gates before it can merge:
+
+- Evolution cycle now auto-applies user-approved proposals on the next run (backed by the new idempotent migration `m38`), adaptive learned-weight rollbacks surface as visible followups, outcome patterns auto-promote to draft skills, and a Voyager-style detector exposes co-occurring skill pairs as composite-skill candidates via `nexo_skill_compose_candidates`.
+- `cognitive._search.search()` now accepts `dream_weight` and reranks dream-insights through it, somatic markers fold into the same reranking path (max +0.10 boost), state watchers open and auto-resolve deterministic `NF-WATCHER-{id}` followups, and correction fatigue opens a visible followup instead of only decaying memory.
+- A new Cortex quality cron (every 6h) watches accept rate / linked-success / override gap and opens `NF-CORTEX-QUALITY-DROP` idempotently when the decision engine starts drifting between cycles.
+- Adding a new learning now walks recent decisions through `retroactive_learnings.apply_learning_retroactively()` and opens deterministic `NF-RETRO-L<id>-D<id>` followups for every decision the learning would have changed (exposed via `nexo_learning_apply_retroactively`).
+- Hook lifecycle observability: new `hook_runs` table (migration `m39`) + `nexo_hook_runs` tool expose recent hook runs, failure streaks, and a health summary. Hook drops are no longer invisible.
+- Knowledge graph bitemporal export: `nexo_kg_export` emits JSON-LD (with an `nexo:*` vocabulary) or GraphML, and accepts an `as_of` ISO timestamp that replays the historical snapshot through `kg_edges.valid_from / valid_until` for igraph, Gephi, NetworkX, and Cytoscape.
+- OpenTelemetry integration: new `src/observability.py` soft-imports `opentelemetry` and only activates when `OTEL_EXPORTER_OTLP_ENDPOINT` or `OTEL_SERVICE_NAME` is set. `tool_span()` becomes a real span when enabled and stays a no-op context manager when disabled.
+- CI gates on every PR: new workflows enforce ruff (`E9 / F63 / F7 / F82 / F821`), bandit at high severity / high confidence, coverage baselines, and `verify_release_readiness.py --ci`. A PR that breaks the release contract fails loudly instead of waiting until tag push.
+- Safer update path: `auto_update` is guarded by a POSIX `flock` with stale-steal at 10 minutes, and on macOS it now `launchctl unload`s and reloads every `com.nexo.*.plist` after a version bump so long-lived crons pick up the new codebase immediately.
+
 Version `5.0.4` tightens the local runtime bridge and trims false-positive doctor noise:
 
 - vendorable `nexo_helper.py` now resolves `NEXO_HOME` and the `nexo` CLI path robustly, so personal scripts and subprocess flows stop depending on a lucky PATH

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 5.0.4
+version: 5.1.0
 metadata:
   openclaw:
     requires:

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "5.0.4",
+  "version": "5.1.0",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.0.4" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.1.0" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.0.4",
+  "version": "5.1.0",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/release-contracts/v5.1.0.json
+++ b/release-contracts/v5.1.0.json
@@ -1,0 +1,144 @@
+{
+  "release_line": "v5.1",
+  "target_version": "5.1.0",
+  "scope_owner": "NEXO",
+  "distribution": {
+    "git_updates_on": "merge_to_main",
+    "packaged_release_on": "tag_publish"
+  },
+  "required_repo_files": [
+    "scripts/verify_release_readiness.py",
+    "scripts/run_v5_0_smoke.py",
+    "release-contracts/v5.1.0.json",
+    ".github/workflows/lint.yml",
+    ".github/workflows/security.yml",
+    ".github/workflows/release-readiness.yml",
+    "pyproject.toml",
+    "requirements-dev.txt",
+    "src/auto_update.py",
+    "src/hook_observability.py",
+    "src/observability.py",
+    "src/retroactive_learnings.py",
+    "src/skills_runtime.py",
+    "src/state_watchers_runtime.py",
+    "src/knowledge_graph.py",
+    "src/tools_sessions.py",
+    "src/cognitive/_search.py",
+    "src/cognitive/_memory.py",
+    "src/cognitive/_ingest.py",
+    "src/plugins/skills.py",
+    "src/plugins/knowledge_graph_tools.py",
+    "src/plugins/protocol.py",
+    "src/scripts/nexo-cortex-cycle.py",
+    "src/scripts/nexo-evolution-run.py",
+    "src/scripts/nexo-hook-record.py",
+    "src/server.py",
+    "tests/test_auto_update_lock.py",
+    "tests/test_update_path_and_reload.py",
+    "tests/test_evolution.py",
+    "tests/test_cortex_cycle.py",
+    "tests/test_skills_v2.py",
+    "tests/test_adaptive_weights_rollback.py",
+    "tests/test_deep_sleep_apply.py",
+    "tests/test_retroactive_learnings.py",
+    "tests/test_hook_observability.py",
+    "tests/test_state_watchers.py",
+    "tests/test_correction_fatigue_followup.py",
+    "tests/test_cognitive.py",
+    "tests/test_kg_export.py",
+    "tests/test_skill_coactivation.py",
+    "tests/test_observability.py",
+    "tests/test_security_baseline.py",
+    "tests/test_release_readiness_baseline.py",
+    "tests/test_decay_baseline.py",
+    "tests/test_trust_baseline.py",
+    "tests/test_plugin_loader_baseline.py",
+    "tests/test_fase4_lint_baseline.py",
+    "tests/test_heartbeat_adaptive_log_wire.py",
+    "tests/test_protocol.py",
+    "benchmarks/results/comparison-vs-competition-2026-04.md",
+    "README.md"
+  ],
+  "required_website_files": [
+    "index.html",
+    "watch/index.html",
+    "features/index.html",
+    "changelog/index.html",
+    "compare/index.html",
+    "docs/index.html",
+    "assets/nexo-brain-infographic-v5.png",
+    "assets/video/nexo-brain-v5-overview.mp4"
+  ],
+  "gates": [
+    {
+      "id": "phase2_loop_closed",
+      "title": "Phase 2 — every open evolution/adaptive/skills/cortex loop closes under itself",
+      "status": "complete",
+      "evidence_required": [
+        "evolution_log accepted proposals are auto-applied on next cycle (PR #101)",
+        "outcome patterns auto-promote to draft skills and Voyager co-activation detector exposed (#103 + #121)",
+        "retroactive learnings create deterministic NF-RETRO followups on application (#106)",
+        "adaptive weight rollback surfaces as visible followup (#104)",
+        "Cortex quality cron runs every 6h and opens NF-CORTEX-QUALITY-DROP on degradation (#102)",
+        "protocol_debt is surfaced by heartbeat for active tasks (#100)",
+        "deep-sleep code_change action stages findings into evolution_log (#105)"
+      ]
+    },
+    {
+      "id": "phase3_cognitive_robustness",
+      "title": "Phase 3 — cognitive subsystems close their own loops with user-visible evidence",
+      "status": "complete",
+      "evidence_required": [
+        "search() accepts dream_weight and somatic boost is wired into reranking (#109 + #110)",
+        "state watchers auto-create and auto-resolve deterministic NF-WATCHER followups (#107)",
+        "correction fatigue surfaces as visible followup via cognitive-decay (#108)",
+        "hook lifecycle observability exposes hook_runs table + nexo_hook_runs tool (#111)",
+        "auto_update guarded by POSIX flock with stale-steal (#112)"
+      ]
+    },
+    {
+      "id": "phase4_qa_pipeline",
+      "title": "Phase 4 — automated lint/security/coverage/release gates run on every PR",
+      "status": "complete",
+      "evidence_required": [
+        "ruff lint workflow enforces E9/F63/F7/F82/F821 on PR and push (#113)",
+        "bandit high-severity workflow runs on PR and push; 10 weak-hash sites fixed (#115)",
+        "coverage baseline tests pin decay/trust/plugin_loader contracts (#114)",
+        "verify_release_readiness.py --ci gates every PR, not just tags (#116)",
+        "requirements-dev.txt pins ruff, pytest-cov, bandit toml extras (#117)"
+      ]
+    },
+    {
+      "id": "phase5_market_differentiation",
+      "title": "Phase 5 — shippable differentiators vs existing memory frameworks",
+      "status": "complete",
+      "evidence_required": [
+        "Bitemporal KG export to JSON-LD and GraphML with as_of support (#120)",
+        "OpenTelemetry tool_span soft-import activates only when OTEL env vars set (#123)",
+        "benchmarks/results/comparison-vs-competition-2026-04.md documents honest feature matrix vs Letta/Mem0/Zep/Graphiti/Cognee/DSPy (#122)",
+        "Voyager-style skill co-activation detector exposes composite skill candidates (#121)"
+      ]
+    },
+    {
+      "id": "audit_followups_resolved",
+      "title": "NEXO-AUDIT-2026-04-11 followups closed under evidence",
+      "status": "complete",
+      "evidence_required": [
+        "heartbeat auto-fires compute_mode so adaptive_log stays populated (#118)",
+        "server instructions tell agents to register outcomes proactively (#119)",
+        "every Phase 2-5 audit followup marked resolved with evidence or left as explicit open followup"
+      ]
+    },
+    {
+      "id": "update_path_safety",
+      "title": "Update path v5.0.x → v5.1.0 leaves runtime in a consistent state",
+      "status": "complete",
+      "evidence_required": [
+        "auto_update reloads LaunchAgents after version bump on macOS (#124)",
+        "migrations m38 (evolution_log.proposal_payload) and m39 (hook_runs) are idempotent across every v5.0.x baseline",
+        "test_update_path_and_reload.py pins the hot-reload + migration contract",
+        "auto_update concurrent run protection pinned by test_auto_update_lock.py"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

This PR bumps NEXO Brain to **v5.1.0** and lands the full
`NEXO-AUDIT-2026-04-11` roadmap as a single coordinated minor release.

All 25 audit PRs (#100-#124) are already merged into `main`. This PR
adds only the version/release markers that complete the contract:

- `package.json` and `openclaw-plugin/package.json` → `5.1.0`
- `openclaw-plugin/src/mcp-bridge.ts` clientInfo version → `5.1.0`
- `CHANGELOG.md` new `[5.1.0]` entry summarizing every subsystem change
- `release-contracts/v5.1.0.json` with 6 gates (all marked complete)
- `README.md` story updated with the v5.1.0 section
- `.claude-plugin/plugin.json` and `clawhub-skill/SKILL.md` re-synced
  via `scripts/sync_release_artifacts.py`

## What v5.1.0 delivers

- **Phase 2 — closed loops**: evolution auto-apply, adaptive rollback
  visible, outcome→skill auto-promotion, Voyager co-activation
  detector, Cortex quality cron, heartbeat protocol_debt.
- **Phase 3 — observable cognition**: `dream_weight` + somatic boost
  in search reranking, state watcher followups, correction fatigue
  followup, hook_runs observability, auto_update flock.
- **Phase 4 — CI gates**: ruff, bandit, coverage baselines,
  release-readiness on every PR, dev deps pinned.
- **Phase 5 — differentiators**: bitemporal KG export (JSON-LD +
  GraphML, `as_of` replay), OpenTelemetry tool_span soft-import,
  honest comparison vs Letta/Mem0/Zep/Graphiti/Cognee/DSPy.
- **Audit followups closed**: heartbeat `compute_mode` auto-fire,
  server outcome-registration instructions.
- **Update path safety**: macOS LaunchAgent hot-reload after bump,
  migrations `m38` + `m39` idempotent across every v5.0.x baseline.

## Test plan

- [x] `python3 scripts/verify_release_readiness.py --ci --contract release-contracts/v5.1.0.json --require-contract-complete` passes locally
- [x] `PYTHONPATH=src python3 -m pytest tests/ -q` → 747 passed, 3 skipped
- [x] `python3 scripts/sync_release_artifacts.py --check` clean
- [x] `python3 scripts/verify_client_parity.py` clean
- [x] gh-pages worktree already updated with `v5.1.0` content (separate PR)

## Companion work

- gh-pages website PR (index, changelog, watch, blog landing, new
  `/blog/nexo-5-1-0-closed-loops/` post, sitemap, llms.txt) ships in
  parallel on the `nexo-gh-pages` repo.
- After merge: tag `v5.1.0` → triggers `publish.yml` (npm publish
  `nexo-brain` + `@wazionapps/openclaw-memory-nexo-brain`, GitHub
  Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
