### PR TITLE
Publish v5.1.0 public site updates

### DIFF
--- a/.well-known/llms.txt
+++ b/.well-known/llms.txt
@@ -1,8 +1,8 @@
 # NEXO Brain
 
-> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.0.2).
+> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.1.0).
 
-NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. Version 5.0.2 fixes the post-upgrade deep-doctor schema drift for the 5.0 runtime line while keeping the broader goal, decision, outcome, reusable-skill, and public-proof loop across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, multimodal memory refs, pre-compaction auto-flush, a public claim wiki, readable memory export, richer user-state adaptation, long-horizon overnight analysis, and 150+ MCP tools.
+NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. Version 5.1.0 closes every open evolution, adaptive, cognitive, and skills loop under itself, ships bitemporal knowledge graph export to JSON-LD and GraphML with `as_of` historical replay, adds an OpenTelemetry tool-span path behind a soft-import, and puts lint, security, coverage, and release-readiness gates on every PR, on top of the 5.0 goal, decision, outcome, reusable-skill, and public-proof loop across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, multimodal memory refs, pre-compaction auto-flush, a public claim wiki, readable memory export, richer user-state adaptation, long-horizon overnight analysis, and 150+ MCP tools.
 
 ## Core Product Model
 

--- a/blog/index.html
+++ b/blog/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Blog — NEXO Brain</title>
-    <meta name="description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the v5.0.0 goal/decision/outcome release line.">
+    <meta name="description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the v5.1.0 closed-loops release and the v5.0.0 goal/decision/outcome release line.">
     <meta name="robots" content="index, follow">
     <link rel="canonical" href="https://nexo-brain.com/blog/">
 
@@ -12,7 +12,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://nexo-brain.com/blog/">
     <meta property="og:title" content="Blog — NEXO Brain">
-    <meta property="og:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the v5.0.0 goal/decision/outcome release line.">
+    <meta property="og:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the v5.1.0 closed-loops release and the v5.0.0 goal/decision/outcome release line.">
     <meta property="og:image" content="https://nexo-brain.com/assets/og/og-blog.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -20,7 +20,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Blog — NEXO Brain">
-    <meta name="twitter:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the v5.0.0 goal/decision/outcome release line.">
+    <meta name="twitter:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the v5.1.0 closed-loops release and the v5.0.0 goal/decision/outcome release line.">
     <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-blog.png">
 
     <script type="application/ld+json">
@@ -28,7 +28,7 @@
         "@context": "https://schema.org",
         "@type": "CollectionPage",
         "name": "Blog — NEXO Brain",
-        "description": "Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the v5.0.0 goal/decision/outcome release line.",
+        "description": "Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the v5.1.0 closed-loops release and the v5.0.0 goal/decision/outcome release line.",
         "url": "https://nexo-brain.com/blog/",
         "isPartOf": {
             "@type": "WebSite",
@@ -142,23 +142,23 @@
             <div class="blog-featured-card">
                 <div class="section-label">Latest release</div>
                 <div class="blog-featured-meta">
-                    <span class="compare-chip">April 10, 2026</span>
-                    <span class="compare-chip">Goal-driven runtime</span>
+                    <span class="compare-chip">April 11, 2026</span>
+                    <span class="compare-chip">Closed loops + bitemporal KG export</span>
                 </div>
-                <h2>NEXO 5.0.0: Goals, Decisions, Outcomes, and Public Proof Finally Match</h2>
-                <p>NEXO 5.0.0 connects goal profiles, Decision Cortex v2, measured outcomes, reusable skill evolution, and a stronger benchmark/release surface, so the runtime no longer feels like powerful pieces with a few open loops between them.</p>
+                <h2>NEXO 5.1.0: Every Open Loop Closes Under Itself</h2>
+                <p>NEXO 5.1.0 lands the full NEXO-AUDIT-2026-04-11 roadmap. Evolution, adaptive, cognitive, and skills loops close under themselves, the bitemporal knowledge graph exports cleanly to JSON-LD and GraphML, OpenTelemetry spans hook in on demand, and every PR has to clear lint, security, coverage, and release-readiness gates before it can merge.</p>
                 <div class="hero-actions" style="justify-content:flex-start;margin-bottom:18px;">
-                    <a href="/blog/nexo-5-0-0-goal-driven-runtime-close-loops/" class="btn btn-primary">Open article</a>
-                    <a href="/changelog/#v500" class="btn btn-secondary">Open changelog</a>
+                    <a href="/blog/nexo-5-1-0-closed-loops/" class="btn btn-primary">Open article</a>
+                    <a href="/changelog/#v510" class="btn btn-secondary">Open changelog</a>
                 </div>
                 <div class="blog-mini-stack">
                     <div class="blog-mini-card">
                         <strong>Companion view</strong>
-                        <span><a href="/changelog/#v500">The 5.0.0 changelog section</a></span>
+                        <span><a href="/changelog/#v510">The 5.1.0 changelog section</a></span>
                     </div>
                     <div class="blog-mini-card">
-                        <strong>Still worth reading</strong>
-                        <span><a href="/blog/nexo-4-0-0-memory-surface-release/">the 4.0.0 memory-surface article</a> and <a href="/blog/how-to-give-ai-persistent-memory/">persistent memory basics</a>.</span>
+                        <strong>Previous backbone</strong>
+                        <span><a href="/blog/nexo-5-0-0-goal-driven-runtime-close-loops/">NEXO 5.0.0: goals, decisions, outcomes, and public proof</a>.</span>
                     </div>
                 </div>
             </div>
@@ -170,6 +170,13 @@
 <section class="section-flush-top">
     <div class="container">
         <div class="blog-grid">
+
+            <div class="blog-card">
+                <div class="blog-card-date">April 11, 2026</div>
+                <h2><a href="/blog/nexo-5-1-0-closed-loops/">NEXO 5.1.0: Every Open Loop Closes Under Itself</a></h2>
+                <p>The full NEXO-AUDIT-2026-04-11 roadmap lands as one minor bump. Evolution/adaptive/cognitive/skills loops close under themselves, bitemporal KG export, OpenTelemetry spans, and lint/security/coverage/release gates on every PR.</p>
+                <a href="/blog/nexo-5-1-0-closed-loops/" class="read-more">Read article <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14"/><path d="M12 5l7 7-7 7"/></svg></a>
+            </div>
 
             <div class="blog-card">
                 <div class="blog-card-date">April 10, 2026</div>

--- a/blog/nexo-5-1-0-closed-loops/index.html
+++ b/blog/nexo-5-1-0-closed-loops/index.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <title>NEXO 5.1.0: Every Open Loop Closes Under Itself</title>
+    <meta name="description" content="NEXO 5.1.0 lands the full NEXO-AUDIT-2026-04-11 roadmap: evolution, adaptive, cognitive, and skills loops close under themselves, the bitemporal knowledge graph exports cleanly, OpenTelemetry spans hook in on demand, and every PR has to clear lint, security, coverage, and release-readiness gates before it can merge.">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://nexo-brain.com/blog/nexo-5-1-0-closed-loops/">
+
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://nexo-brain.com/blog/nexo-5-1-0-closed-loops/">
+    <meta property="og:title" content="NEXO 5.1.0: Every Open Loop Closes Under Itself">
+    <meta property="og:description" content="NEXO 5.1.0 closes every open evolution, adaptive, cognitive, and skills loop under itself, ships bitemporal JSON-LD and GraphML knowledge graph export, adds an OpenTelemetry tool-span path, and puts lint, security, coverage, and release-readiness gates on every PR.">
+    <meta property="og:image" content="https://nexo-brain.com/assets/og/og-blog.png">
+    <meta property="article:published_time" content="2026-04-11">
+    <meta property="article:author" content="Francisco Cerda Puigserver">
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="NEXO 5.1.0: Every Open Loop Closes Under Itself">
+    <meta name="twitter:description" content="Closed loops across evolution, adaptive, cognitive, and skills subsystems. Bitemporal KG export. OpenTelemetry spans. Lint, security, coverage, and release-readiness gates on every PR.">
+    <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-blog.png">
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-1LNEMCJMS7"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-1LNEMCJMS7');
+    </script>
+
+    <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicon-32.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
+    <link rel="stylesheet" href="/assets/style.css">
+
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "NEXO 5.1.0: Every Open Loop Closes Under Itself",
+        "description": "NEXO 5.1.0 lands the full NEXO-AUDIT-2026-04-11 roadmap: evolution, adaptive, cognitive, and skills loops close under themselves, the bitemporal knowledge graph exports cleanly, OpenTelemetry spans hook in on demand, and every PR has to clear lint, security, coverage, and release-readiness gates before it can merge.",
+        "datePublished": "2026-04-11",
+        "dateModified": "2026-04-11",
+        "author": {
+            "@type": "Person",
+            "name": "Francisco Cerda Puigserver"
+        },
+        "publisher": {
+            "@type": "Organization",
+            "name": "WAzion",
+            "url": "https://www.wazion.com"
+        },
+        "mainEntityOfPage": {
+            "@type": "WebPage",
+            "@id": "https://nexo-brain.com/blog/nexo-5-1-0-closed-loops/"
+        },
+        "url": "https://nexo-brain.com/blog/nexo-5-1-0-closed-loops/",
+        "image": "https://nexo-brain.com/assets/nexo-brain-infographic-v5.png",
+        "keywords": ["NEXO 5.1.0", "closed loops", "bitemporal knowledge graph", "OpenTelemetry", "release readiness", "skill composition"]
+    }
+    </script>
+
+    <style>
+        .article-header { padding-top: 128px; padding-bottom: 40px; text-align: center; }
+        .article-meta { font-size: 14px; color: var(--text-muted); margin-bottom: 16px; }
+        .article-body {
+            max-width: 720px; margin: 0 auto; padding: 0 24px 80px;
+            font-size: 17px; line-height: 1.8; color: var(--text);
+        }
+        .article-body h2 { font-size: 28px; font-weight: 700; margin: 48px 0 16px; letter-spacing: -0.01em; }
+        .article-body p { margin-bottom: 20px; color: var(--text-muted); }
+        .article-body strong { color: var(--text); }
+        .article-body a { color: var(--purple-light); }
+        .article-body a:hover { color: var(--pink); }
+        .article-body ul { margin: 0 0 20px 24px; color: var(--text-muted); }
+        .article-body li { margin-bottom: 8px; }
+        .article-body code {
+            font-family: 'SF Mono', 'Fira Code', monospace;
+            font-size: 14px; color: var(--pink);
+            background: rgba(236, 72, 153, 0.1);
+            padding: 2px 8px; border-radius: 4px;
+        }
+        .article-back {
+            display: inline-flex; align-items: center; gap: 6px;
+            font-size: 14px; font-weight: 600; color: var(--text-muted);
+            margin-bottom: 24px;
+        }
+        .article-back:hover { color: var(--purple-light); }
+        .article-visual { margin: 32px 0 40px; text-align: center; }
+        .article-visual img {
+            max-width: 100%;
+            border-radius: 16px;
+            border: 1px solid var(--dark-border);
+            box-shadow: 0 8px 32px rgba(124,58,237,0.15);
+        }
+    </style>
+</head>
+<body>
+
+<nav>
+    <div class="container">
+        <a href="/" class="nav-logo">
+            <img src="/assets/logo-64.png" alt="NEXO Brain" class="logo-image">
+            <span class="logo-text">NEXO Brain</span>
+        </a>
+        <button class="mobile-menu-toggle" aria-label="Toggle navigation" onclick="toggleMobileMenu()">
+            <span></span><span></span><span></span>
+        </button>
+        <div class="nav-links">
+            <a href="/">Home</a>
+            <a href="/features/">Features</a>
+            <a href="/evolution/">Evolution</a>
+            <a href="/compare/">Compare</a>
+            <a href="/blog/">Blog</a>
+            <a href="/changelog/">Changelog</a>
+            <a href="/docs/">Docs</a>
+            <a href="https://github.com/wazionapps/nexo" class="nav-cta">GitHub</a>
+        </div>
+    </div>
+</nav>
+
+<section class="article-header">
+    <div class="container">
+        <a href="/blog/" class="article-back">← Back to blog</a>
+        <div class="article-meta">April 11, 2026 · Minor release · NEXO-AUDIT-2026-04-11</div>
+        <h1 class="section-title" style="font-size:clamp(28px,4.5vw,48px);max-width:920px;margin:0 auto 16px;">NEXO 5.1.0: Every Open Loop Closes Under Itself</h1>
+        <p class="section-subtitle" style="max-width:760px;margin:0 auto;">5.0.0 tied goals, decisions, outcomes, and reusable skills into one coherent runtime. 5.1.0 is the release where every remaining loop inside that runtime starts closing under itself instead of leaving half-delivered signals in the database.</p>
+    </div>
+</section>
+
+<section>
+    <div class="article-body">
+        <div class="article-visual">
+            <img src="/assets/nexo-brain-infographic-v5.png" alt="NEXO Brain 5.1.0 release">
+        </div>
+
+        <p><strong>5.1.0 is the output of a single audit: <code>NEXO-AUDIT-2026-04-11</code>.</strong> It walked every subsystem introduced between 4.x and 5.0 looking for loops that had been opened but not closed — adaptive signals that got computed but never surfaced, evolution proposals that got accepted but never applied, skills that got promoted but never composed, hook runs that could drop silently, and so on. About 46% of the originally-flagged items turned out to be false positives under empirical verification. What remained is what actually shipped in this release.</p>
+
+        <h2>Evolution, adaptive, skills, and cortex now close their own loops</h2>
+        <ul>
+            <li><strong>Accepted evolution proposals auto-apply on the next cycle.</strong> <code>nexo-evolution-run.py</code> now reads <code>evolution_log</code> rows marked <code>accepted</code> and runs them through the auto-proposal executor with snapshot and rollback, backed by the new idempotent migration <code>m38</code>. No more forever-pending approvals.</li>
+            <li><strong>Outcome patterns auto-promote to draft skills.</strong> <code>skills_runtime.auto_promote_outcome_patterns_to_skills()</code> materializes recurring successful patterns into draft skills without manual curation, and a Voyager-style detector groups <code>skill_usage</code> by session to surface co-occurring skill pairs as composite-skill candidates.</li>
+            <li><strong>Retroactive learnings.</strong> Adding a new learning now walks recent decisions, scores them against the rule, and opens deterministic <code>NF-RETRO-L&lt;id&gt;-D&lt;id&gt;</code> followups for every decision the learning would have changed. Exposed via <code>nexo_learning_apply_retroactively</code>.</li>
+            <li><strong>Adaptive rollbacks are visible.</strong> When adaptive learned-weights roll back, the runtime now surfaces that as a visible followup on the next heartbeat instead of hiding the signal inside <code>adaptive_log</code>.</li>
+            <li><strong>Cortex keeps watching itself.</strong> A new quality cron runs every 6 hours, watches accept rate, linked-success rate, and override gap, and opens <code>NF-CORTEX-QUALITY-DROP</code> idempotently when the decision engine starts drifting between cycles.</li>
+        </ul>
+
+        <h2>Cognitive subsystems get externally observable</h2>
+        <ul>
+            <li><strong>Dream + somatic reranking.</strong> <code>cognitive._search.search()</code> now accepts a <code>dream_weight</code> parameter and reranks dream-insight memories through it, while a new somatic boost step (max +0.10) folds emotional salience into the same reranking path. Both signals are first-class instead of dead columns.</li>
+            <li><strong>State watchers auto-open and auto-resolve followups.</strong> When a watcher fires, it opens a deterministic <code>NF-WATCHER-{id}</code> followup; when it clears, the followup resolves. Watcher activity is always externally observable instead of being buried in runtime logs.</li>
+            <li><strong>Correction fatigue surfaces as a followup.</strong> Cognitive-decay now opens a visible followup when the fatigue signal crosses its threshold, so the operator sees the runtime is getting tired of correcting the same thing instead of only adjusting memory weights invisibly.</li>
+            <li><strong>Hook lifecycle observability.</strong> A new <code>hook_runs</code> table (migration <code>m39</code>) + <code>nexo_hook_runs</code> MCP tool expose recent hook runs, failure streaks, and a health summary. Hook drops are no longer invisible.</li>
+        </ul>
+
+        <h2>Bitemporal Knowledge Graph exports</h2>
+        <p>NEXO's knowledge graph has been bitemporal since 4.x — every edge carries <code>valid_from</code> / <code>valid_until</code>, and the upsert/delete helpers maintain them. What it was missing was a way to <em>emit</em> the graph in a format external tools could ingest. 5.1.0 fixes that with <code>nexo_kg_export</code>:</p>
+        <ul>
+            <li><strong>JSON-LD</strong> output uses an <code>nexo:*</code> vocabulary so the graph is semantic-web friendly and human-readable.</li>
+            <li><strong>GraphML</strong> output plugs into igraph, Gephi, NetworkX, and Cytoscape for serious graph analysis.</li>
+            <li><strong><code>as_of</code> parameter</strong> replays the historical snapshot that was valid at any instant — this is what makes the export actually bitemporal rather than just "current state dumped to a file".</li>
+        </ul>
+
+        <h2>OpenTelemetry, opt-in</h2>
+        <p>A new <code>src/observability.py</code> module soft-imports <code>opentelemetry</code> and only activates when <code>OTEL_EXPORTER_OTLP_ENDPOINT</code> or <code>OTEL_SERVICE_NAME</code> is set. <code>tool_span()</code> is a no-op context manager when OTEL is disabled and a real span with <code>ai.tool.*</code> semantic attributes when enabled. The result: NEXO can be wired into any OTEL backend (Honeycomb, Jaeger, Tempo, Grafana Cloud, Dash0, Signoz, etc) without taking a hard dependency on OTEL for users who don't want it.</p>
+
+        <h2>CI gates on every PR</h2>
+        <p>The operational gap 5.0.x left open was not in the runtime — it was in the release pipeline. A PR could break the release contract and nobody would notice until tag push. 5.1.0 closes that:</p>
+        <ul>
+            <li><strong>ruff lint workflow</strong> enforces <code>E9 / F63 / F7 / F82 / F821</code> on every PR and push. Baseline pass fixed 5 latent <code>F821</code> bugs.</li>
+            <li><strong>bandit security workflow</strong> runs at high severity / high confidence. Baseline pass fixed 10 weak-hash flags (<code>usedforsecurity=False</code>) across protocol, deep-sleep, and daily-self-audit scripts.</li>
+            <li><strong>Coverage baseline tests</strong> pin the contract surface area of decay, trust, plugin loader, cognitive, and release so a refactor cannot silently delete them.</li>
+            <li><strong><code>verify_release_readiness.py --ci</code></strong> now runs on every PR, not just tags. A PR that breaks the release contract fails loudly immediately.</li>
+        </ul>
+
+        <h2>Safer update path</h2>
+        <p>Two long-standing footguns are gone in 5.1.0:</p>
+        <ul>
+            <li><strong>Concurrent <code>nexo update</code> protection.</strong> <code>auto_update</code> is now guarded by a POSIX <code>flock</code> with stale-steal at 10 minutes, so two overlapping update runs cannot stomp each other mid-sync.</li>
+            <li><strong>LaunchAgent hot-reload.</strong> On macOS, a version bump now <code>launchctl unload</code>s and reloads every <code>com.nexo.*.plist</code>, so long-lived crons pick up the new codebase immediately instead of running the pre-bump version until the next reboot.</li>
+        </ul>
+
+        <h2>Honest feature matrix vs peers</h2>
+        <p>The new <code>benchmarks/results/comparison-vs-competition-2026-04.md</code> lays out where NEXO wins, where it is on par, and where peers lead — across Letta, Mem0, Zep, Graphiti, Cognee, and DSPy. No cherry-picking. The defensible differentiators end up being the bitemporal knowledge graph, the metacognitive guard, trust scoring, Atkinson-Shiffrin decay, and the native MCP surface.</p>
+
+        <h2>What did not change</h2>
+        <p>5.1.0 does not replace the 5.0.0 story. Goal profiles, Decision Cortex v2, outcome-backed skill evolution, and the broader runtime pack are still the backbone. This release makes that backbone observable and maintainable under itself instead of relying on the operator to remember to look at every subsystem.</p>
+
+        <p>If you want the exact release record, open the <a href="/changelog/#v510">5.1.0 changelog section</a>. If you want to dig into the new graph exports and observability paths, start from <a href="/features/">Features</a> or the <a href="/docs/">docs map</a>. If you are on an older install, <code>nexo update</code> will handle the migration and cron reload automatically.</p>
+    </div>
+</section>
+
+<footer>
+    <div class="container">
+        <div class="footer-content">
+            <div class="footer-left">
+                Created by <strong>Francisco Cerd&agrave; Puigserver</strong> &amp; <strong>NEXO</strong> (Claude Opus) &bull; Built by <a href="https://www.wazion.com">WAzion</a> &bull; AGPL-3.0 License &bull; &copy; 2026
+            </div>
+            <div class="footer-links">
+                <a href="https://github.com/wazionapps/nexo">GitHub</a>
+                <a href="https://x.com/NEXOBRAIN">X / Twitter</a>
+                <a href="https://github.com/sponsors/wazionapps">Sponsor</a>
+                <a href="/docs/">Docs</a>
+                <a href="/compare/">Compare</a>
+                <a href="/blog/">Blog</a>
+                <a href="https://www.npmjs.com/package/nexo-brain">npm</a>
+                <a href="https://github.com/wazionapps/nexo/releases">Releases</a>
+            </div>
+            <div style="text-align:center;margin-top:12px;color:#6b7280;font-size:12px;">Last updated: April 2026</div>
+        </div>
+    </div>
+</footer>
+
+</body>
+</html>

--- a/changelog/index.html
+++ b/changelog/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Changelog — NEXO Brain</title>
-    <meta name="description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.0.4 with local runtime bridge hardening, quieter doctor signals, and tighter first-response pacing on top of the goal-driven 5.0 runtime line.">
+    <meta name="description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.1.0 closes every open evolution, adaptive, cognitive, and skills loop under itself, ships bitemporal JSON-LD and GraphML knowledge graph export, adds an OpenTelemetry tool-span path, and puts lint, security, coverage, and release-readiness gates on every PR.">
     <meta name="robots" content="index, follow">
     <link rel="canonical" href="https://nexo-brain.com/changelog/">
 
@@ -12,7 +12,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://nexo-brain.com/changelog/">
     <meta property="og:title" content="Changelog — NEXO Brain">
-    <meta property="og:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.0.4 with local runtime bridge hardening, quieter doctor signals, and tighter first-response pacing on top of the goal-driven 5.0 runtime line.">
+    <meta property="og:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.1.0 closes every open evolution, adaptive, cognitive, and skills loop under itself, ships bitemporal JSON-LD and GraphML knowledge graph export, adds an OpenTelemetry tool-span path, and puts lint, security, coverage, and release-readiness gates on every PR.">
     <meta property="og:image" content="https://nexo-brain.com/assets/og/og-changelog.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -20,7 +20,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Changelog — NEXO Brain">
-    <meta name="twitter:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.0.4 with local runtime bridge hardening, quieter doctor signals, and tighter first-response pacing on top of the goal-driven 5.0 runtime line.">
+    <meta name="twitter:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.1.0 closes every open evolution, adaptive, cognitive, and skills loop under itself, ships bitemporal JSON-LD and GraphML knowledge graph export, adds an OpenTelemetry tool-span path, and puts lint, security, coverage, and release-readiness gates on every PR.">
     <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-changelog.png">
 
     <script type="application/ld+json">
@@ -28,7 +28,7 @@
         "@context": "https://schema.org",
         "@type": "CollectionPage",
         "name": "Changelog — NEXO Brain",
-        "description": "Full version history for NEXO Brain cognitive runtime. Latest release: v5.0.4 with local runtime bridge hardening, quieter doctor signals, and tighter first-response pacing on top of the goal-driven 5.0 runtime line.",
+        "description": "Full version history for NEXO Brain cognitive runtime. Latest release: v5.1.0 closes every open evolution, adaptive, cognitive, and skills loop under itself, ships bitemporal JSON-LD and GraphML knowledge graph export, adds an OpenTelemetry tool-span path, and puts lint, security, coverage, and release-readiness gates on every PR.",
         "url": "https://nexo-brain.com/changelog/",
         "isPartOf": {
             "@type": "WebSite",
@@ -87,18 +87,22 @@
                 <h1 class="section-title" style="font-size:clamp(32px,5vw,56px);">Changelog</h1>
                 <p class="section-subtitle">Every feature, fix, and improvement &mdash; from the beginning, with the same visual clarity as the rest of the site.</p>
                 <div class="page-chip-row">
-                    <span class="page-chip">v5.0.4 live</span>
-                    <span class="page-chip">Runtime bridge + doctor cleanup</span>
-                    <span class="page-chip">Sharper first-response pacing</span>
+                    <span class="page-chip">v5.1.0 live</span>
+                    <span class="page-chip">Closed loops across evolution, adaptive, cognitive, skills</span>
+                    <span class="page-chip">Bitemporal KG export &middot; OTEL spans &middot; CI gates</span>
                 </div>
                 <div class="hero-actions" style="justify-content:flex-start;">
-                    <a href="#v504" class="btn btn-primary">Start with v5.0.4</a>
+                    <a href="#v510" class="btn btn-primary">Start with v5.1.0</a>
                     <a href="#v400" class="btn btn-secondary">See v4.0.0</a>
                     <a href="/evolution/" class="btn btn-secondary">See Evolution</a>
                 </div>
             </div>
             <div class="page-visual">
                 <div class="page-stack">
+                    <div class="page-stack-card">
+                        <strong>v5.1.0</strong>
+                        <span>Every open evolution, adaptive, cognitive, and skills loop closes under itself. Bitemporal KG export, OpenTelemetry spans, and lint/security/release gates on every PR.</span>
+                    </div>
                     <div class="page-stack-card">
                         <strong>v5.0.4</strong>
                         <span>Personal-script runtime bridges are more robust, doctor false positives are quieter, and simple artifact reads answer sooner instead of looking hung.</span>
@@ -132,6 +136,64 @@
                 <div id="changelog-page-meta" class="changelog-page-meta">Loading release pages…</div>
                 <div id="changelog-pager" class="changelog-pager" aria-label="Changelog pagination"></div>
             </div>
+        </div>
+    </div>
+</section>
+
+<!-- v5.1.0 NEXO-AUDIT Phases 2-5 -->
+<section id="v510" class="section-compact" style="background:linear-gradient(135deg,#111827 0%,#7c3aed 100%);">
+    <div class="container">
+        <div class="section-label">New in v5.1.0 <span style="opacity:.5;font-weight:400;">&mdash; April 11, 2026</span></div>
+        <h2 class="section-title">Every Open Loop Closes Under Itself</h2>
+        <p class="section-subtitle">
+            v5.1.0 lands the full NEXO-AUDIT-2026-04-11 roadmap as a single coordinated minor bump. Evolution, adaptive, cognitive, and skills subsystems now close their own loops instead of leaving half-delivered signals inside the database. The knowledge graph exports cleanly, OpenTelemetry spans hook in when you want them, and every PR now has to clear lint, security, coverage, and release-readiness gates before it can merge.
+        </p>
+        <div class="cognitive-group">
+            <div class="cognitive-grid" style="grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:16px;">
+                <div class="cognitive-card">
+                    <h3>Evolution + Adaptive + Skills Loops Close</h3>
+                    <p>Approved evolution proposals now auto-apply on the next cycle, adaptive rollbacks open visible followups instead of hiding inside <code>adaptive_log</code>, outcome patterns auto-promote to draft skills, and a Voyager-style detector surfaces co-occurring skill pairs as composite-skill candidates.</p>
+                </div>
+                <div class="cognitive-card">
+                    <h3>Cognitive Subsystems Get Loud</h3>
+                    <p>Search reranking now honours <code>dream_weight</code> and somatic markers as first-class signals. State watchers open deterministic <code>NF-WATCHER-{id}</code> followups and auto-resolve them, and correction fatigue surfaces as a visible followup instead of silently decaying memory.</p>
+                </div>
+                <div class="cognitive-card">
+                    <h3>Cortex Keeps Watching Itself</h3>
+                    <p>A new Cortex quality cron runs every 6 hours, watches accept rate, linked-success rate, and override gap, and opens <code>NF-CORTEX-QUALITY-DROP</code> idempotently when the decision engine starts drifting between cycles.</p>
+                </div>
+                <div class="cognitive-card">
+                    <h3>Retroactive Learnings</h3>
+                    <p>Adding a new learning now walks recent decisions, scores them against the rule, and opens deterministic <code>NF-RETRO-L&lt;id&gt;-D&lt;id&gt;</code> followups for every decision the learning would have changed &mdash; exposed via <code>nexo_learning_apply_retroactively</code>.</p>
+                </div>
+                <div class="cognitive-card">
+                    <h3>Bitemporal Knowledge Graph Export</h3>
+                    <p>The KG already tracked <code>valid_from</code> / <code>valid_until</code> on every edge. v5.1.0 adds <code>nexo_kg_export</code> with JSON-LD (using an <code>nexo:*</code> vocabulary) and GraphML output, and the <code>as_of</code> parameter replays historical snapshots for igraph, Gephi, NetworkX, and Cytoscape.</p>
+                </div>
+                <div class="cognitive-card">
+                    <h3>OpenTelemetry, Opt-In</h3>
+                    <p>A new soft-import observability layer activates only when <code>OTEL_EXPORTER_OTLP_ENDPOINT</code> or <code>OTEL_SERVICE_NAME</code> is set. When enabled, every tool call becomes a real span with <code>ai.tool.*</code> semantic attributes. When disabled, the wrapper stays a no-op so runtime cost is zero.</p>
+                </div>
+                <div class="cognitive-card">
+                    <h3>Hook Lifecycle Observability</h3>
+                    <p>A new <code>hook_runs</code> table and <code>nexo_hook_runs</code> tool surface recent hook runs, failure streaks, and latency. Hook drops are no longer invisible.</p>
+                </div>
+                <div class="cognitive-card">
+                    <h3>CI Gates On Every PR</h3>
+                    <p>New GitHub Actions workflows enforce ruff (E9/F63/F7/F82/F821), bandit at high severity/high confidence, coverage baselines for decay/trust/plugin loader, and <code>verify_release_readiness.py --ci</code>. A PR that breaks the release contract now fails loudly instead of waiting until tag push.</p>
+                </div>
+                <div class="cognitive-card">
+                    <h3>Safer v5.0.x &rarr; v5.1.0 Update Path</h3>
+                    <p>On a version bump, macOS installs now <code>launchctl unload</code> and reload every <code>com.nexo.*.plist</code> so long-lived crons pick up the new codebase immediately. <code>auto_update</code> is guarded by a POSIX <code>flock</code> with stale-steal at 10 minutes so two concurrent <code>nexo update</code> runs cannot stomp each other.</p>
+                </div>
+                <div class="cognitive-card">
+                    <h3>Honest Feature Matrix vs Peers</h3>
+                    <p>The new <code>benchmarks/results/comparison-vs-competition-2026-04.md</code> lays out where NEXO wins, where it is on par, and where peers lead &mdash; across Letta, Mem0, Zep, Graphiti, Cognee, and DSPy. No cherry-picking.</p>
+                </div>
+            </div>
+        </div>
+        <div style="margin-top:24px;font-size:14px;opacity:.6;">
+            Closed loops across evolution / adaptive / cognitive / skills &bull; bitemporal KG export &bull; OpenTelemetry spans &bull; lint/security/coverage/release gates on every PR &bull; safer update path
         </div>
     </div>
 </section>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents</title>
-    <meta name="description" content="Libre/open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.0.4 hardens the local runtime bridge for personal scripts, trims false-positive doctor noise, and makes simple read/respond flows feel less hung on top of the 5.0 goal, decision, outcome, and reusable-skill loop across 150+ MCP tools.">
+    <meta name="description" content="Libre/open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.1.0 closes every open evolution, adaptive, cognitive, and skills loop under itself, ships bitemporal JSON-LD/GraphML knowledge graph export, adds an OpenTelemetry tool-span path, and puts lint, security, coverage, and release-readiness gates on every PR across 150+ MCP tools.">
     <meta name="keywords" content="AI memory, cognitive architecture, MCP, Claude Code, Codex, Claude Desktop, agent memory, vector search, AI agents, shared brain, open source">
     <meta name="author" content="WAzion">
     <meta name="robots" content="index, follow">
@@ -14,7 +14,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://nexo-brain.com">
     <meta property="og:title" content="NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents">
-    <meta property="og:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.0.4 hardens the local runtime bridge for personal scripts, trims false-positive doctor noise, and makes simple read/respond flows feel less hung on top of the 5.0 goal, decision, outcome, and reusable-skill loop across 150+ MCP tools.">
+    <meta property="og:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.1.0 closes every open evolution, adaptive, cognitive, and skills loop under itself, ships bitemporal JSON-LD/GraphML knowledge graph export, adds an OpenTelemetry tool-span path, and puts lint, security, coverage, and release-readiness gates on every PR across 150+ MCP tools.">
     <meta property="og:image" content="https://nexo-brain.com/assets/og/og-home.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -22,7 +22,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents">
-    <meta name="twitter:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.0.4 hardens the local runtime bridge for personal scripts, trims false-positive doctor noise, and makes simple read/respond flows feel less hung on top of the 5.0 goal, decision, outcome, and reusable-skill loop across 150+ MCP tools.">
+    <meta name="twitter:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.1.0 closes every open evolution, adaptive, cognitive, and skills loop under itself, ships bitemporal JSON-LD/GraphML knowledge graph export, adds an OpenTelemetry tool-span path, and puts lint, security, coverage, and release-readiness gates on every PR across 150+ MCP tools.">
     <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-home.png">
 
     <!-- Google Analytics (GA4) -->
@@ -46,12 +46,12 @@
         "@context": "https://schema.org",
         "@type": "SoftwareApplication",
         "name": "NEXO Brain",
-        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.0.4 hardens the local runtime bridge for personal scripts, trims false-positive doctor noise, and makes simple read/respond flows feel less hung on top of the 5.0 goal, decision, outcome, and reusable-skill loop across 150+ MCP tools.",
+        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.1.0 closes every open evolution, adaptive, cognitive, and skills loop under itself, ships bitemporal JSON-LD/GraphML knowledge graph export, adds an OpenTelemetry tool-span path, and puts lint, security, coverage, and release-readiness gates on every PR across 150+ MCP tools.",
         "applicationCategory": "DeveloperApplication",
         "operatingSystem": "macOS, Linux, Windows",
         "url": "https://nexo-brain.com",
         "downloadUrl": "https://www.npmjs.com/package/nexo-brain",
-        "softwareVersion": "5.0.4",
+        "softwareVersion": "5.1.0",
         "license": "https://www.gnu.org/licenses/agpl-3.0",
         "author": {
             "@type": "Organization",
@@ -88,7 +88,7 @@
         "@type": "WebSite",
         "name": "NEXO Brain",
         "url": "https://nexo-brain.com",
-        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.0.4 hardens the local runtime bridge for personal scripts, trims false-positive doctor noise, and makes simple read/respond flows feel less hung on top of the 5.0 goal, decision, outcome, and reusable-skill loop across 150+ MCP tools.",
+        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.1.0 closes every open evolution, adaptive, cognitive, and skills loop under itself, ships bitemporal JSON-LD/GraphML knowledge graph export, adds an OpenTelemetry tool-span path, and puts lint, security, coverage, and release-readiness gates on every PR across 150+ MCP tools.",
         "publisher": {
             "@type": "Organization",
             "name": "WAzion",
@@ -697,7 +697,7 @@
     <div class="container">
         <div class="hero-badge fade-up">
             <span class="dot"></span>
-            <span id="version-badge">v5.0.4</span> &mdash; Local runtime bridge hardening, quieter doctor signals, and faster first answers on simple read/respond flows
+            <span id="version-badge">v5.1.0</span> &mdash; Closed loops across evolution, adaptive, cognitive, and skills &middot; bitemporal KG export &middot; OpenTelemetry spans &middot; lint/security/coverage/release gates on every PR
         </div>
         <div class="fade-up" style="display:flex;gap:8px;justify-content:center;margin-bottom:12px;">
             <img src="https://img.shields.io/npm/v/nexo-brain?color=7C3AED&label=npm" alt="npm version">
@@ -1156,9 +1156,14 @@
 
         <div class="release-evolution-grid">
             <div class="release-evolution-card">
-                <div class="release-evolution-version">v5.0.1</div>
-                <h3>The 5.0 line now upgrades cleanly on real installs</h3>
-                <p>NEXO now purges obsolete managed Claude Code hooks left by older releases, so upgraded installs stop carrying fake warning storms and “hung” symptoms while keeping the broader 5.0 goal, outcome, skill, and public-proof story intact.</p>
+                <div class="release-evolution-version">v5.1.0</div>
+                <h3>Every open loop closes under itself</h3>
+                <p>Evolution, adaptive, cognitive, and skills subsystems now close their own loops under evidence instead of leaving half-delivered signals in the database. The bitemporal knowledge graph exports cleanly to JSON-LD and GraphML, OpenTelemetry spans hook in on demand, and every PR has to clear lint, security, coverage, and release-readiness gates before it can merge.</p>
+            </div>
+            <div class="release-evolution-card">
+                <div class="release-evolution-version">v5.0.0</div>
+                <h3>Goals, decisions, outcomes, and public proof finally match</h3>
+                <p>Goal profiles shape decisions, decisions connect to measured outcomes, outcomes seed reusable skills, and the public proof surface finally matches the broader runtime instead of stretching a single memory benchmark.</p>
             </div>
             <div class="release-evolution-card">
                 <div class="release-evolution-version">v4.1.0</div>
@@ -1195,7 +1200,7 @@
         <div class="release-evolution-actions">
             <a href="/evolution/" class="btn btn-primary">How Evolution works</a>
             <a href="/changelog/" class="btn btn-secondary">Read the full changelog</a>
-            <a href="/changelog/#v500" class="btn btn-secondary">Read the latest release notes</a>
+            <a href="/changelog/#v510" class="btn btn-secondary">Read the latest release notes</a>
         </div>
     </div>
 </section>

--- a/llms.txt
+++ b/llms.txt
@@ -1,8 +1,8 @@
 # NEXO Brain
 
-> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.0.2).
+> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.1.0).
 
-NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. Version 5.0.2 fixes the post-upgrade deep-doctor schema drift for the 5.0 runtime line while keeping the broader goal, decision, outcome, reusable-skill, and public-proof loop across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, multimodal memory refs, pre-compaction auto-flush, a public claim wiki, readable memory export, richer user-state adaptation, long-horizon overnight analysis, and 150+ MCP tools.
+NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. Version 5.1.0 closes every open evolution, adaptive, cognitive, and skills loop under itself, ships bitemporal knowledge graph export to JSON-LD and GraphML with `as_of` historical replay, adds an OpenTelemetry tool-span path behind a soft-import, and puts lint, security, coverage, and release-readiness gates on every PR, on top of the 5.0 goal, decision, outcome, reusable-skill, and public-proof loop across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, multimodal memory refs, pre-compaction auto-flush, a public claim wiki, readable memory export, richer user-state adaptation, long-horizon overnight analysis, and 150+ MCP tools.
 
 ## Core Product Model
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://nexo-brain.com/</loc>
-    <lastmod>2026-04-10</lastmod>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
@@ -44,7 +44,7 @@
   </url>
   <url>
     <loc>https://nexo-brain.com/changelog/</loc>
-    <lastmod>2026-04-10</lastmod>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -143,6 +143,12 @@
     <lastmod>2026-04-10</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://nexo-brain.com/blog/nexo-5-1-0-closed-loops/</loc>
+    <lastmod>2026-04-11</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.95</priority>
   </url>
   <url>
     <loc>https://nexo-brain.com/blog/nexo-5-0-0-goal-driven-runtime-close-loops/</loc>

--- a/watch/index.html
+++ b/watch/index.html
@@ -3,18 +3,18 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-    <title>Watch — NEXO Brain v5.0.4</title>
-    <meta name="description" content="Watch the latest NEXO Brain v5.0.4 overview video, the official YouTube mirror, and inspect the current architecture infographic in one place.">
+    <title>Watch — NEXO Brain v5.1.0</title>
+    <meta name="description" content="Watch the latest NEXO Brain v5.1.0 overview video, the official YouTube mirror, and inspect the current architecture infographic in one place.">
     <meta name="robots" content="index, follow">
     <link rel="canonical" href="https://nexo-brain.com/watch/">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://nexo-brain.com/watch/">
-    <meta property="og:title" content="Watch — NEXO Brain v5.0.4">
-    <meta property="og:description" content="The current NEXO Brain v5.0.4 overview video, official YouTube mirror, and updated infographic.">
+    <meta property="og:title" content="Watch — NEXO Brain v5.1.0">
+    <meta property="og:description" content="The current NEXO Brain v5.1.0 overview video, official YouTube mirror, and updated infographic.">
     <meta property="og:image" content="https://nexo-brain.com/assets/social-preview.png">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Watch — NEXO Brain v5.0.4">
-    <meta name="twitter:description" content="The current NEXO Brain v5.0.4 overview video, official YouTube mirror, and updated infographic.">
+    <meta name="twitter:title" content="Watch — NEXO Brain v5.1.0">
+    <meta name="twitter:description" content="The current NEXO Brain v5.1.0 overview video, official YouTube mirror, and updated infographic.">
     <meta name="twitter:image" content="https://nexo-brain.com/assets/social-preview.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicon-32.png">
     <link rel="apple-touch-icon" sizes="180x180" href="/assets/apple-touch-icon.png">
@@ -47,7 +47,7 @@
         <div class="page-hero-grid">
             <div class="page-hero-copy">
                 <div class="section-label">Watch</div>
-                <h1 class="section-title" style="font-size:clamp(34px,5vw,58px);">NEXO Brain v5.0.4 overview</h1>
+                <h1 class="section-title" style="font-size:clamp(34px,5vw,58px);">NEXO Brain v5.1.0 overview</h1>
                 <p class="section-subtitle">
                     One place for the current launch video and the current architecture infographic. This is the clean public asset pair to use in README, docs, and share links.
                 </p>


### PR DESCRIPTION
## Summary

Publishes the full v5.1.0 story across the public website as one
coordinated deploy. Every page that mentions the current release
now points at **5.1.0** instead of 5.0.4.

### Pages updated

- **index.html**: meta descriptions, OG/Twitter cards, JSON-LD
  `softwareVersion`, version-badge, and Recent Evolution. Recent
  Evolution now leads with a v5.1.0 card and keeps v5.0.0 as the
  backbone card.
- **changelog/index.html**: adds the full v5.1.0 section at the top
  (closed loops, cognitive observability, bitemporal KG export,
  OpenTelemetry opt-in, CI gates, safer update path, comparison
  matrix). v5.0.4 section kept as historical record below.
- **watch/index.html**: title / meta / hero now label the overview
  video as the v5.1.0 overview.
- **blog/index.html**: featured card and top card replaced by the
  new v5.1.0 post. v5.0.0 kept as companion.
- **blog/nexo-5-1-0-closed-loops/index.html** (new): long-form
  release article covering the full NEXO-AUDIT-2026-04-11 story.
- **sitemap.xml**: adds the new blog post, refreshes top-level
  lastmod dates.
- **llms.txt** + **.well-known/llms.txt**: release tagline updated
  to describe v5.1.0.

## Test plan

- [x] `python3 scripts/verify_release_readiness.py --ci --contract release-contracts/v5.1.0.json --require-contract-complete` passes against this worktree (the CI script greps for `v5.1.0` in `changelog/index.html` and `5.1.0` in `index.html`).
- [ ] After merge: GitHub Pages auto-deploys from `gh-pages`; verify at https://nexo-brain.com/changelog/#v510.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
