### PR TITLE
feat(runtime): release trace hygiene — doctor check + self-audit retirement + diary split

### DIFF
--- a/src/doctor/providers/runtime.py
+++ b/src/doctor/providers/runtime.py
@@ -2710,6 +2710,137 @@ def check_release_artifact_sync() -> DoctorCheck:
     )
 
 
+def check_release_trace_hygiene() -> DoctorCheck:
+    db_path = NEXO_HOME / "data" / "nexo.db"
+    if not db_path.is_file():
+        return DoctorCheck(
+            id="runtime.release_trace_hygiene",
+            tier="runtime",
+            status="healthy",
+            severity="info",
+            summary="Release trace hygiene unavailable (no DB)",
+            evidence=[],
+            repair_plan=[],
+            escalation_prompt="",
+        )
+
+    try:
+        conn = sqlite3.connect(str(db_path), timeout=2)
+        conn.row_factory = sqlite3.Row
+        try:
+            tables = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('workflow_goals', 'workflow_runs')"
+                ).fetchall()
+            }
+            if "workflow_goals" not in tables or "workflow_runs" not in tables:
+                return DoctorCheck(
+                    id="runtime.release_trace_hygiene",
+                    tier="runtime",
+                    status="healthy",
+                    severity="info",
+                    summary="Release trace hygiene unavailable (workflow tables absent)",
+                    evidence=[],
+                    repair_plan=[],
+                    escalation_prompt="",
+                )
+
+            stale_run_samples: list[str] = []
+            stale_goal_samples: list[str] = []
+            now = dt.datetime.now(dt.timezone.utc)
+            stale_after_hours = 6
+
+            run_rows = conn.execute(
+                """SELECT run_id, goal, updated_at
+                   FROM workflow_runs
+                   WHERE workflow_kind = 'audit-phase'
+                     AND status NOT IN ('completed', 'failed', 'cancelled')
+                   ORDER BY updated_at DESC"""
+            ).fetchall()
+            for row in run_rows:
+                updated_at = _parse_timestamp(row["updated_at"] or "")
+                if updated_at is None:
+                    stale_run_samples.append(f"{row['run_id']}: unreadable updated_at")
+                    continue
+                if updated_at.tzinfo is None:
+                    updated_at = updated_at.replace(tzinfo=dt.timezone.utc)
+                age_hours = (now - updated_at).total_seconds() / 3600
+                if age_hours >= stale_after_hours:
+                    stale_run_samples.append(
+                        f"{row['run_id']}: {age_hours:.1f}h stale ({str(row['goal'] or '')[:72]})"
+                    )
+
+            goal_rows = conn.execute(
+                """SELECT g.goal_id, g.title, g.updated_at,
+                          COALESCE((SELECT COUNT(*) FROM workflow_runs r WHERE r.goal_id = g.goal_id), 0) AS run_count,
+                          COALESCE((SELECT COUNT(*) FROM workflow_runs r WHERE r.goal_id = g.goal_id
+                                    AND r.status NOT IN ('completed', 'failed', 'cancelled')), 0) AS open_run_count
+                   FROM workflow_goals g
+                   WHERE g.status = 'active'
+                     AND (g.goal_id LIKE 'WG-AUDIT-%' OR g.title LIKE 'NEXO-AUDIT-%')
+                   ORDER BY g.updated_at DESC"""
+            ).fetchall()
+            for row in goal_rows:
+                if int(row["open_run_count"] or 0) > 0:
+                    continue
+                updated_at = _parse_timestamp(row["updated_at"] or "")
+                if updated_at is None:
+                    stale_goal_samples.append(f"{row['goal_id']}: unreadable updated_at")
+                    continue
+                if updated_at.tzinfo is None:
+                    updated_at = updated_at.replace(tzinfo=dt.timezone.utc)
+                age_hours = (now - updated_at).total_seconds() / 3600
+                if age_hours >= stale_after_hours:
+                    stale_goal_samples.append(
+                        f"{row['goal_id']}: {age_hours:.1f}h stale ({str(row['title'] or '')[:72]})"
+                    )
+        finally:
+            conn.close()
+    except Exception as exc:
+        return DoctorCheck(
+            id="runtime.release_trace_hygiene",
+            tier="runtime",
+            status="degraded",
+            severity="warn",
+            summary="Release trace hygiene check failed",
+            evidence=[str(exc)],
+            repair_plan=["Inspect workflow_goals/workflow_runs state manually"],
+            escalation_prompt="Release traces could not be audited, so stale audit artifacts may be hiding in the runtime.",
+        )
+
+    evidence = [
+        f"stale audit workflows: {len(stale_run_samples)}",
+        f"stale audit goals: {len(stale_goal_samples)}",
+    ]
+    evidence.extend(stale_run_samples[:3])
+    evidence.extend(stale_goal_samples[:3])
+    if stale_run_samples or stale_goal_samples:
+        return DoctorCheck(
+            id="runtime.release_trace_hygiene",
+            tier="runtime",
+            status="degraded",
+            severity="warn",
+            summary="Release trace hygiene needs cleanup",
+            evidence=evidence,
+            repair_plan=[
+                "Close or complete stale audit-phase workflows and active audit goals",
+                "Keep workflow/goal state aligned with the real shipped state after releases",
+            ],
+            escalation_prompt="Audit/release traces drifted away from reality, which makes shipping state look ambiguous.",
+        )
+    return DoctorCheck(
+        id="runtime.release_trace_hygiene",
+        tier="runtime",
+        status="healthy",
+        severity="info",
+        summary="Release trace hygiene OK",
+        evidence=evidence,
+        repair_plan=[],
+        escalation_prompt="",
+    )
+
+
 def check_state_watchers() -> DoctorCheck:
     db_path = NEXO_HOME / "data" / "nexo.db"
     summary_path = NEXO_HOME / "operations" / "state-watchers-status.json"
@@ -2988,6 +3119,7 @@ def run_runtime_checks(fix: bool = False) -> list[DoctorCheck]:
         safe_check(check_automation_telemetry),
         safe_check(check_state_watchers),
         safe_check(check_release_artifact_sync),
+        safe_check(check_release_trace_hygiene),
         safe_check(check_launchagent_inventory),
         safe_check(check_launchagent_integrity, fix=fix),
         safe_check(check_personal_script_registry, fix=fix),

--- a/src/plugins/episodic_memory.py
+++ b/src/plugins/episodic_memory.py
@@ -229,8 +229,20 @@ def handle_session_diary_write(decisions: str, summary: str,
     orphan_changes = conn.execute(
         "SELECT COUNT(*) FROM change_log WHERE (commit_ref IS NULL OR commit_ref = '')"
     ).fetchone()[0]
+    recent_orphan_changes = conn.execute(
+        """SELECT COUNT(*) FROM change_log
+           WHERE (commit_ref IS NULL OR commit_ref = '')
+             AND created_at >= datetime('now', '-7 days')"""
+    ).fetchone()[0]
     if orphan_changes > 0:
-        warnings.append(f"{orphan_changes} changes sin commit_ref")
+        if recent_orphan_changes > 0 and recent_orphan_changes != orphan_changes:
+            warnings.append(
+                f"{recent_orphan_changes} changes recientes sin commit_ref ({orphan_changes} históricas total)"
+            )
+        elif recent_orphan_changes > 0:
+            warnings.append(f"{recent_orphan_changes} changes recientes sin commit_ref")
+        else:
+            warnings.append(f"{orphan_changes} changes históricas sin commit_ref")
     orphan_decisions = conn.execute(
         "SELECT COUNT(*) FROM decisions WHERE (outcome IS NULL OR outcome = '') AND created_at < datetime('now', '-7 days')"
     ).fetchone()[0]

--- a/src/scripts/nexo-daily-self-audit.py
+++ b/src/scripts/nexo-daily-self-audit.py
@@ -78,6 +78,10 @@ CLAUDE_CLI = _resolve_claude_cli()
 
 findings = []
 
+AUDIT_GOAL_NEXT_ACTION = "Convert the recurring theme into an explicit workflow or close it as intentional noise."
+AUDIT_GOAL_OWNER = "system:self-audit"
+AUDIT_GOAL_STALE_HOURS = 36
+
 
 def log(msg):
     ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
@@ -492,7 +496,7 @@ def _upsert_workflow_goal_inline(conn: sqlite3.Connection, *, area: str, sample_
         f"Recurring {area} theme detected by daily self-audit. "
         f"The theme '{sample_goal}' appeared {count} times without a durable goal, learning, or resolved workflow."
     )
-    next_action = "Convert the recurring theme into an explicit workflow or close it as intentional noise."
+    next_action = AUDIT_GOAL_NEXT_ACTION
     success_signal = "The theme stops resurfacing in unresolved protocol tasks."
     now_iso = datetime.now().isoformat(timespec="seconds")
     if existing:
@@ -504,7 +508,7 @@ def _upsert_workflow_goal_inline(conn: sqlite3.Connection, *, area: str, sample_
         if "priority" in columns:
             updates["priority"] = "high"
         if "owner" in columns:
-            updates["owner"] = "system:self-audit"
+            updates["owner"] = AUDIT_GOAL_OWNER
         if "next_action" in columns:
             updates["next_action"] = next_action
         if "success_signal" in columns:
@@ -534,7 +538,7 @@ def _upsert_workflow_goal_inline(conn: sqlite3.Connection, *, area: str, sample_
     if "priority" in columns:
         values["priority"] = "high"
     if "owner" in columns:
-        values["owner"] = "system:self-audit"
+        values["owner"] = AUDIT_GOAL_OWNER
     if "next_action" in columns:
         values["next_action"] = next_action
     if "success_signal" in columns:
@@ -551,6 +555,75 @@ def _upsert_workflow_goal_inline(conn: sqlite3.Connection, *, area: str, sample_
         list(values.values()),
     )
     return {"ok": True, "action": "created", "goal_id": goal_id}
+
+
+def _retire_stale_audit_goals_inline(
+    conn: sqlite3.Connection, *, max_age_hours: int = AUDIT_GOAL_STALE_HOURS
+) -> dict:
+    if not _table_exists(conn, "workflow_goals"):
+        return {"ok": False, "reason": "workflow_goals_missing"}
+
+    has_runs = _table_exists(conn, "workflow_runs")
+    if has_runs:
+        rows = conn.execute(
+            """SELECT g.goal_id, g.title, g.status, g.owner, g.next_action, g.opened_at, g.updated_at,
+                      COALESCE((SELECT COUNT(*) FROM workflow_runs r WHERE r.goal_id = g.goal_id), 0) AS run_count,
+                      COALESCE((SELECT COUNT(*) FROM workflow_runs r WHERE r.goal_id = g.goal_id
+                                AND r.status NOT IN ('completed', 'failed', 'cancelled')), 0) AS open_run_count
+               FROM workflow_goals g
+               WHERE g.status = 'active'
+                 AND g.goal_id LIKE 'WG-AUDIT-%'
+               ORDER BY g.updated_at DESC, g.opened_at DESC"""
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            """SELECT g.goal_id, g.title, g.status, g.owner, g.next_action, g.opened_at, g.updated_at,
+                      0 AS run_count,
+                      0 AS open_run_count
+               FROM workflow_goals g
+               WHERE g.status = 'active'
+                 AND g.goal_id LIKE 'WG-AUDIT-%'
+               ORDER BY g.updated_at DESC, g.opened_at DESC"""
+        ).fetchall()
+
+    if not rows:
+        return {"ok": True, "retired": 0}
+
+    now = datetime.now()
+    now_iso = now.isoformat(timespec="seconds")
+    retired = 0
+    for row in rows:
+        if str(row["next_action"] or "").strip() != AUDIT_GOAL_NEXT_ACTION:
+            continue
+        owner = str(row["owner"] or "").strip()
+        if owner and owner != AUDIT_GOAL_OWNER:
+            continue
+        if int(row["open_run_count"] or 0) > 0:
+            continue
+        updated_at = _parse_mixed_datetime(row["updated_at"]) or _parse_mixed_datetime(row["opened_at"])
+        if not updated_at:
+            continue
+        age_hours = (now - updated_at).total_seconds() / 3600
+        if age_hours < max_age_hours:
+            continue
+        conn.execute(
+            """UPDATE workflow_goals
+               SET status = 'abandoned',
+                   next_action = ?,
+                   blocker_reason = ?,
+                   updated_at = ?,
+                   closed_at = ?
+               WHERE goal_id = ?""",
+            (
+                "Ninguna. Placeholder stale retirado automáticamente; el self-audit lo recreará si el patrón reaparece.",
+                f"Self-audit placeholder stale >{max_age_hours}h sin workflow runs abiertos.",
+                now_iso,
+                now_iso,
+                row["goal_id"],
+            ),
+        )
+        retired += 1
+    return {"ok": True, "retired": retired}
 
 
 def _queue_public_core_handoff(
@@ -1173,6 +1246,11 @@ def check_unformalized_mentions():
     if not _table_exists(conn, "protocol_tasks"):
         conn.close()
         return
+
+    retired_result = _retire_stale_audit_goals_inline(conn)
+    retired_count = int(retired_result.get("retired") or 0)
+    if retired_count:
+        finding("INFO", "formalization", f"retired {retired_count} stale self-audit workflow goals")
 
     rows = conn.execute(
         """SELECT goal, area, learning_id, followup_id

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -918,6 +918,68 @@ class TestRuntimeChecks:
         assert check.status == "healthy"
         assert any("release artifacts in sync" in item for item in check.evidence)
 
+    def test_release_trace_hygiene_flags_stale_audit_artifacts(self, nexo_home, monkeypatch):
+        from doctor.providers import runtime
+
+        db_path = nexo_home / "data" / "nexo.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            """CREATE TABLE workflow_goals (
+                goal_id TEXT PRIMARY KEY,
+                session_id TEXT,
+                title TEXT,
+                objective TEXT,
+                parent_goal_id TEXT,
+                status TEXT,
+                priority TEXT,
+                owner TEXT,
+                next_action TEXT,
+                success_signal TEXT,
+                shared_state TEXT,
+                blocker_reason TEXT,
+                opened_at TEXT,
+                updated_at TEXT,
+                closed_at TEXT
+            )"""
+        )
+        conn.execute(
+            """CREATE TABLE workflow_runs (
+                run_id TEXT PRIMARY KEY,
+                session_id TEXT,
+                goal_id TEXT,
+                goal TEXT,
+                workflow_kind TEXT,
+                status TEXT,
+                updated_at TEXT
+            )"""
+        )
+        conn.execute(
+            """INSERT INTO workflow_goals (
+                goal_id, session_id, title, objective, parent_goal_id, status, priority, owner,
+                next_action, success_signal, shared_state, blocker_reason, opened_at, updated_at, closed_at
+            ) VALUES (
+                'WG-AUDIT-12345678', '', 'NEXO-AUDIT stale goal', '', '', 'active', 'high', 'system:self-audit',
+                'Convert the recurring theme into an explicit workflow or close it as intentional noise.',
+                '', '{}', '', datetime('now', '-2 days'), datetime('now', '-2 days'), NULL
+            )"""
+        )
+        conn.execute(
+            """INSERT INTO workflow_runs (
+                run_id, session_id, goal_id, goal, workflow_kind, status, updated_at
+            ) VALUES (
+                'WF-STALE-1', '', '', 'Ejecutar Fase 4...', 'audit-phase', 'open', datetime('now', '-8 hours')
+            )"""
+        )
+        conn.commit()
+        conn.close()
+
+        monkeypatch.setattr(runtime, "NEXO_HOME", nexo_home)
+        check = runtime.check_release_trace_hygiene()
+
+        assert check.status == "degraded"
+        assert any("WF-STALE-1" in item for item in check.evidence)
+        assert any("WG-AUDIT-12345678" in item for item in check.evidence)
+
     def test_transcript_source_parity_warns_when_codex_selected_without_sessions(self, nexo_home, monkeypatch):
         from doctor.providers import runtime
 

--- a/tests/test_episodic_memory.py
+++ b/tests/test_episodic_memory.py
@@ -1,0 +1,63 @@
+"""Tests for episodic memory diary warnings."""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REPO_SRC = REPO_ROOT / "src"
+
+if str(REPO_SRC) not in sys.path:
+    sys.path.insert(0, str(REPO_SRC))
+
+
+def test_session_diary_write_distinguishes_recent_and_historical_commit_ref_gaps(monkeypatch, tmp_path):
+    from plugins import episodic_memory
+    import db
+
+    db_path = tmp_path / "nexo.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        """CREATE TABLE change_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            commit_ref TEXT DEFAULT '',
+            created_at TEXT DEFAULT (datetime('now'))
+        )"""
+    )
+    conn.execute(
+        """CREATE TABLE decisions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            outcome TEXT DEFAULT '',
+            created_at TEXT DEFAULT (datetime('now'))
+        )"""
+    )
+    conn.execute(
+        "INSERT INTO change_log (commit_ref, created_at) VALUES ('', datetime('now', '-1 day'))"
+    )
+    conn.execute(
+        "INSERT INTO change_log (commit_ref, created_at) VALUES ('', datetime('now', '-20 days'))"
+    )
+    conn.commit()
+
+    monkeypatch.setattr(db, "delete_diary_draft", lambda sid: None)
+    monkeypatch.setattr(
+        episodic_memory,
+        "write_session_diary",
+        lambda *args, **kwargs: {"id": 1},
+    )
+    monkeypatch.setattr(episodic_memory, "get_db", lambda: conn)
+    monkeypatch.setattr(db, "get_db", lambda: conn)
+
+    result = episodic_memory.handle_session_diary_write(
+        decisions="none",
+        summary="Resumen corto",
+        session_id="sid-test",
+        self_critique="critica",
+        domain="nexo",
+    )
+    conn.close()
+
+    assert "1 changes recientes sin commit_ref (2 históricas total)" in result

--- a/tests/test_self_audit.py
+++ b/tests/test_self_audit.py
@@ -686,6 +686,66 @@ def test_check_unformalized_mentions_creates_workflow_goal_inline(self_audit_env
     assert "Recurring nexo theme detected by daily self-audit" in goal[2]
 
 
+def test_retire_stale_audit_goals_inline_abandons_old_placeholders(self_audit_env):
+    module = _load_self_audit_module()
+    conn = sqlite3.connect(str(self_audit_env / "data" / "nexo.db"))
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        """CREATE TABLE workflow_goals (
+            goal_id TEXT PRIMARY KEY,
+            session_id TEXT,
+            title TEXT,
+            objective TEXT,
+            parent_goal_id TEXT,
+            status TEXT,
+            priority TEXT,
+            owner TEXT,
+            next_action TEXT,
+            success_signal TEXT,
+            shared_state TEXT,
+            blocker_reason TEXT,
+            opened_at TEXT,
+            updated_at TEXT,
+            closed_at TEXT
+        )"""
+    )
+    conn.execute(
+        """CREATE TABLE workflow_runs (
+            run_id TEXT PRIMARY KEY,
+            goal_id TEXT,
+            workflow_kind TEXT,
+            status TEXT,
+            updated_at TEXT
+        )"""
+    )
+    conn.execute(
+        """INSERT INTO workflow_goals (
+            goal_id, session_id, title, objective, parent_goal_id, status, priority, owner,
+            next_action, success_signal, shared_state, blocker_reason, opened_at, updated_at, closed_at
+        ) VALUES (?, '', ?, '', '', 'active', 'high', ?, ?, '', '{}', '', datetime('now', '-3 days'), datetime('now', '-3 days'), NULL)""",
+        (
+            "WG-AUDIT-DEADBEEF",
+            "Placeholder stale",
+            module.AUDIT_GOAL_OWNER,
+            module.AUDIT_GOAL_NEXT_ACTION,
+        ),
+    )
+    conn.commit()
+
+    result = module._retire_stale_audit_goals_inline(conn, max_age_hours=24)
+    goal = conn.execute(
+        "SELECT status, next_action, blocker_reason, closed_at FROM workflow_goals WHERE goal_id = 'WG-AUDIT-DEADBEEF'"
+    ).fetchone()
+    conn.close()
+
+    assert result["ok"] is True
+    assert result["retired"] == 1
+    assert goal[0] == "abandoned"
+    assert "retirado automáticamente" in goal[1]
+    assert "stale >24h" in goal[2]
+    assert goal[3] is not None
+
+
 def test_check_automation_opportunities_creates_opportunity_followup(self_audit_env):
     module = _load_self_audit_module()
     module.findings.clear()


### PR DESCRIPTION
## Summary

Closes the gap where audit-phase workflow traces and self-audit placeholder goals silently accumulated in the runtime.

- **New doctor check `runtime.release_trace_hygiene`** — flags stale `audit-phase` `workflow_runs` (>6h open) and stale active `WG-AUDIT-*` / `NEXO-AUDIT-*` `workflow_goals` with no open runs. Drifted release traces now surface as a visible degraded check.
- **`nexo-daily-self-audit` auto-retirement** — `_retire_stale_audit_goals_inline()` abandons `WG-AUDIT-*` placeholder goals after 36h with an explicit `blocker_reason`, and the self-audit recreates them only if the pattern reappears.
- **`episodic_memory` diary warning split** — commit_ref gap warnings now distinguish recent (last 7 days) from historical, so live drift stands out from dormant debt.

## Test plan

- [x] `pytest tests/test_doctor.py::TestRuntimeChecks::test_release_trace_hygiene_flags_stale_audit_artifacts` — passes
- [x] `pytest tests/test_self_audit.py::test_retire_stale_audit_goals_inline_abandons_old_placeholders` — passes
- [x] `pytest tests/test_episodic_memory.py` — passes
- [x] All 3 new tests green in 11.65s
- [x] Already running in runtime: `nexo doctor --tier all` shows `✓ Release trace hygiene OK`

No breaking changes. No bootstrap / startup / Deep Sleep / client-parity surfaces touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)