### PR TITLE
release(v5.1.1): bump + CHANGELOG for release trace hygiene patch

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [5.1.1] - 2026-04-12
+
+### Release trace hygiene — runtime + self-audit + diary
+
+A focused patch that closes the gap where audit-phase workflow traces and
+self-audit placeholder goals silently accumulated in the runtime. No breaking
+changes, no bootstrap / startup / Deep Sleep / client-parity surfaces touched.
+
+- **New runtime doctor check `runtime.release_trace_hygiene`** flags stale
+  `audit-phase` `workflow_runs` (>6h open) and stale active `WG-AUDIT-*` /
+  `NEXO-AUDIT-*` `workflow_goals` with no open runs, so drifted release traces
+  surface as a visible `degraded` check instead of quietly accumulating.
+- **Daily self-audit auto-retires stale `WG-AUDIT-*` placeholder goals** via
+  `_retire_stale_audit_goals_inline()`. Goals owned by `system:self-audit`
+  with the placeholder `next_action`, no open runs, and no activity for
+  >36h are marked `abandoned` with an explicit `blocker_reason`. The
+  self-audit recreates them only if the underlying pattern reappears.
+- **`episodic_memory.handle_session_diary_write` splits commit_ref warnings**
+  into recent (last 7 days) vs historical buckets, so diary warnings
+  distinguish live drift from dormant debt instead of lumping them together.
+
+Tests:
+- `tests/test_doctor.py::test_release_trace_hygiene_flags_stale_audit_artifacts`
+- `tests/test_self_audit.py::test_retire_stale_audit_goals_inline_abandons_old_placeholders`
+- `tests/test_episodic_memory.py::test_session_diary_write_distinguishes_recent_and_historical_commit_ref_gaps`
+
+All three pass locally and in CI (Lint / Security / Release readiness /
+Verify integrations / Verify client parity all green on PR #127).
+
 ## [5.1.0] - 2026-04-11
 
 ### NEXO-AUDIT-2026-04-11 — Phases 2-5 delivered end-to-end

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 5.1.0
+version: 5.1.1
 metadata:
   openclaw:
     requires:

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.1.0" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.1.1" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",


### PR DESCRIPTION
## Summary

Version bump 5.1.0 → 5.1.1 after PR #127 (release trace hygiene) merged to main.

- Bumps `package.json`, `.claude-plugin/plugin.json`, `openclaw-plugin/package.json`, `openclaw-plugin/src/mcp-bridge.ts` (auto-synced by `sync_release_artifacts.py`), and `clawhub-skill/SKILL.md`.
- Adds the `[5.1.1] - 2026-04-12` CHANGELOG entry covering the three runtime hygiene improvements shipped in PR #127.

No breaking changes. No bootstrap / startup / Deep Sleep / client-parity surfaces touched.

## Test plan

- [x] `python3 scripts/verify_release_readiness.py --ci` passes locally
- [x] Sync artifacts pass (`sync_release_artifacts.py --check`)
- [x] Client parity verification passes
- [x] Changelog top version matches package.json (5.1.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)