### PR TITLE
site: publish v5.2.0 — bilingual response discipline + cortex quality cache

### DIFF
--- a/.well-known/llms.txt
+++ b/.well-known/llms.txt
@@ -1,8 +1,8 @@
 # NEXO Brain
 
-> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.1.0).
+> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.2.0).
 
-NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. Version 5.1.0 closes every open evolution, adaptive, cognitive, and skills loop under itself, ships bitemporal knowledge graph export to JSON-LD and GraphML with `as_of` historical replay, adds an OpenTelemetry tool-span path behind a soft-import, and puts lint, security, coverage, and release-readiness gates on every PR, on top of the 5.0 goal, decision, outcome, reusable-skill, and public-proof loop across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, multimodal memory refs, pre-compaction auto-flush, a public claim wiki, readable memory export, richer user-state adaptation, long-horizon overnight analysis, and 150+ MCP tools.
+NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. Version 5.2.0 ships bilingual response discipline with Spanish and English high-stakes keyword parity and bilingual negation suppression, a numeric confidence safeguard layered on top of the existing response-contract decision tree with positive context signals (pre-action context hits and known project-atlas areas), and a cortex-quality cache reader that finally consumes the write-only snapshot that the `nexo-cortex-cycle` cron has been writing every 6h since v5.1.0. Builds on v5.1.0's closed evolution, adaptive, cognitive, and skills loops, bitemporal knowledge graph export to JSON-LD and GraphML with `as_of` historical replay, OpenTelemetry tool-span path behind a soft-import, and lint, security, coverage, and release-readiness gates on every PR, plus v5.0's goal, decision, outcome, reusable-skill, and public-proof loop across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, multimodal memory refs, pre-compaction auto-flush, a public claim wiki, readable memory export, richer user-state adaptation, long-horizon overnight analysis, and 150+ MCP tools.
 
 ## Core Product Model
 
@@ -14,10 +14,14 @@ NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cogniti
 
 ## Current Release Focus
 
-- Goal profiles and Decision Cortex v2 shape higher-stakes recommendations instead of leaving strategy selection to raw prompting.
+- Bilingual response discipline: Spanish + English high-stakes detection with bilingual negation suppression, so boundary statements like "sin afectar producción" / "without touching production" no longer trigger false positives.
+- Positive signals on the confidence score so tasks that loaded real context and operate in a known project area are rewarded, not punished alongside unprepared ones.
+- Numeric safeguard layered over the boolean response-contract decision tree, monotonic over the existing rules (can only make discipline stricter, never looser).
+- Cortex-quality cache reader: `nexo_cortex_quality` now serves the snapshot that the `nexo-cortex-cycle` cron writes every 6 hours, with silent fallback to live SQL computation on any failure. Observable path via `"source": "cache" | "live"` in the response.
+- Goal profiles and Decision Cortex v2 keep shaping higher-stakes recommendations instead of leaving strategy selection to raw prompting.
 - Outcomes, impact scoring, and structured pattern capture connect action, result, and future prioritization more tightly.
 - Repeated winning patterns can seed or promote reusable skills, while poor evidence can demote or retire them.
-- Public proof now combines the LoCoMo memory result with a broader operator runtime pack so the website reflects more than one memory benchmark.
+- Public proof combines the LoCoMo memory result with a broader operator runtime pack so the website reflects more than one memory benchmark.
 
 ## Key Features
 

--- a/blog/index.html
+++ b/blog/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Blog — NEXO Brain</title>
-    <meta name="description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the v5.1.0 closed-loops release and the v5.0.0 goal/decision/outcome release line.">
+    <meta name="description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the v5.2.0 bilingual response discipline and cortex-quality cache release, the v5.1.0 closed-loops release, and the v5.0.0 goal/decision/outcome release line.">
     <meta name="robots" content="index, follow">
     <link rel="canonical" href="https://nexo-brain.com/blog/">
 
@@ -12,7 +12,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://nexo-brain.com/blog/">
     <meta property="og:title" content="Blog — NEXO Brain">
-    <meta property="og:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the v5.1.0 closed-loops release and the v5.0.0 goal/decision/outcome release line.">
+    <meta property="og:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the v5.2.0 bilingual response discipline and cortex-quality cache release, the v5.1.0 closed-loops release, and the v5.0.0 goal/decision/outcome release line.">
     <meta property="og:image" content="https://nexo-brain.com/assets/og/og-blog.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -20,7 +20,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Blog — NEXO Brain">
-    <meta name="twitter:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the v5.1.0 closed-loops release and the v5.0.0 goal/decision/outcome release line.">
+    <meta name="twitter:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the v5.2.0 bilingual response discipline and cortex-quality cache release, the v5.1.0 closed-loops release, and the v5.0.0 goal/decision/outcome release line.">
     <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-blog.png">
 
     <script type="application/ld+json">
@@ -28,7 +28,7 @@
         "@context": "https://schema.org",
         "@type": "CollectionPage",
         "name": "Blog — NEXO Brain",
-        "description": "Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the v5.1.0 closed-loops release and the v5.0.0 goal/decision/outcome release line.",
+        "description": "Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the v5.2.0 bilingual response discipline and cortex-quality cache release, the v5.1.0 closed-loops release, and the v5.0.0 goal/decision/outcome release line.",
         "url": "https://nexo-brain.com/blog/",
         "isPartOf": {
             "@type": "WebSite",
@@ -134,7 +134,7 @@
                     <span class="page-chip">Competitive analysis</span>
                 </div>
                 <div class="hero-actions" style="justify-content:flex-start;">
-                    <a href="/blog/nexo-5-0-0-goal-driven-runtime-close-loops/" class="btn btn-primary">Read latest release</a>
+                    <a href="/blog/nexo-5-2-0-bilingual-response-discipline/" class="btn btn-primary">Read latest release</a>
                     <a href="/changelog/" class="btn btn-secondary">Latest release notes</a>
                     <a href="/evolution/" class="btn btn-secondary">See Evolution</a>
                 </div>
@@ -142,23 +142,23 @@
             <div class="blog-featured-card">
                 <div class="section-label">Latest release</div>
                 <div class="blog-featured-meta">
-                    <span class="compare-chip">April 11, 2026</span>
-                    <span class="compare-chip">Closed loops + bitemporal KG export</span>
+                    <span class="compare-chip">April 12, 2026</span>
+                    <span class="compare-chip">Bilingual response discipline + cortex cache loop</span>
                 </div>
-                <h2>NEXO 5.1.0: Every Open Loop Closes Under Itself</h2>
-                <p>NEXO 5.1.0 lands the full NEXO-AUDIT-2026-04-11 roadmap. Evolution, adaptive, cognitive, and skills loops close under themselves, the bitemporal knowledge graph exports cleanly to JSON-LD and GraphML, OpenTelemetry spans hook in on demand, and every PR has to clear lint, security, coverage, and release-readiness gates before it can merge.</p>
+                <h2>NEXO 5.2.0: Bilingual Response Discipline &amp; Closed Cortex-Quality Loop</h2>
+                <p>NEXO 5.2.0 closes two focused gaps in the Cortex layer. The response-contract detector now covers Spanish as well as English, bilingual negation patterns suppress false positives on boundary statements, positive signals reward tasks that loaded real context, a numeric safeguard layers on top of the decision tree, and <code>nexo_cortex_quality</code> finally reads the snapshot the v5.1.0 cron has been writing every 6h.</p>
                 <div class="hero-actions" style="justify-content:flex-start;margin-bottom:18px;">
-                    <a href="/blog/nexo-5-1-0-closed-loops/" class="btn btn-primary">Open article</a>
-                    <a href="/changelog/#v510" class="btn btn-secondary">Open changelog</a>
+                    <a href="/blog/nexo-5-2-0-bilingual-response-discipline/" class="btn btn-primary">Open article</a>
+                    <a href="/changelog/#v520" class="btn btn-secondary">Open changelog</a>
                 </div>
                 <div class="blog-mini-stack">
                     <div class="blog-mini-card">
                         <strong>Companion view</strong>
-                        <span><a href="/changelog/#v510">The 5.1.0 changelog section</a></span>
+                        <span><a href="/changelog/#v520">The 5.2.0 changelog section</a></span>
                     </div>
                     <div class="blog-mini-card">
-                        <strong>Previous backbone</strong>
-                        <span><a href="/blog/nexo-5-0-0-goal-driven-runtime-close-loops/">NEXO 5.0.0: goals, decisions, outcomes, and public proof</a>.</span>
+                        <strong>Previous closed-loops release</strong>
+                        <span><a href="/blog/nexo-5-1-0-closed-loops/">NEXO 5.1.0: Every Open Loop Closes Under Itself</a>.</span>
                     </div>
                 </div>
             </div>
@@ -170,6 +170,13 @@
 <section class="section-flush-top">
     <div class="container">
         <div class="blog-grid">
+
+            <div class="blog-card">
+                <div class="blog-card-date">April 12, 2026</div>
+                <h2><a href="/blog/nexo-5-2-0-bilingual-response-discipline/">NEXO 5.2.0: Bilingual Response Discipline &amp; Closed Cortex-Quality Loop</a></h2>
+                <p>Two focused gaps close in the Cortex layer: Spanish/English high-stakes detection with bilingual negation suppression, positive signals on the confidence score, a numeric safeguard over the decision tree, and a cortex-quality cache reader that finally consumes the v5.1.0 cron's write-only snapshot.</p>
+                <a href="/blog/nexo-5-2-0-bilingual-response-discipline/" class="read-more">Read article <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14"/><path d="M12 5l7 7-7 7"/></svg></a>
+            </div>
 
             <div class="blog-card">
                 <div class="blog-card-date">April 11, 2026</div>

--- a/blog/nexo-5-2-0-bilingual-response-discipline/index.html
+++ b/blog/nexo-5-2-0-bilingual-response-discipline/index.html
@@ -1,0 +1,217 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <title>NEXO 5.2.0: Bilingual Response Discipline &amp; Closed Cortex-Quality Loop</title>
+    <meta name="description" content="NEXO 5.2.0 ships bilingual response discipline with Spanish and English high-stakes detection, bilingual negation suppression, positive signals on the confidence score, a numeric safeguard layered over the decision tree, and a cortex-quality cache reader that finally consumes the v5.1.0 cron's write-only snapshot.">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://nexo-brain.com/blog/nexo-5-2-0-bilingual-response-discipline/">
+
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://nexo-brain.com/blog/nexo-5-2-0-bilingual-response-discipline/">
+    <meta property="og:title" content="NEXO 5.2.0: Bilingual Response Discipline &amp; Closed Cortex-Quality Loop">
+    <meta property="og:description" content="v5.2.0 closes two real gaps in the Cortex layer: the high-stakes detector was English-only with no way to reward well-prepared tasks, and the cortex-cycle cron was writing a quality snapshot that no reader ever consumed. Both loops close in this release.">
+    <meta property="og:image" content="https://nexo-brain.com/assets/og/og-blog.png">
+    <meta property="article:published_time" content="2026-04-12">
+    <meta property="article:author" content="Francisco Cerda Puigserver">
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="NEXO 5.2.0: Bilingual Response Discipline &amp; Closed Cortex-Quality Loop">
+    <meta name="twitter:description" content="Spanish + English high-stakes detection with negation suppression, numeric confidence safeguard with positive context signals, and a cortex-quality cache reader closing the v5.1.0 cron loop.">
+    <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-blog.png">
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-1LNEMCJMS7"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-1LNEMCJMS7');
+    </script>
+
+    <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicon-32.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
+    <link rel="stylesheet" href="/assets/style.css">
+
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "NEXO 5.2.0: Bilingual Response Discipline & Closed Cortex-Quality Loop",
+        "description": "NEXO 5.2.0 ships bilingual response discipline with Spanish and English high-stakes detection, bilingual negation suppression, positive signals on the confidence score, a numeric safeguard layered over the decision tree, and a cortex-quality cache reader that finally consumes the v5.1.0 cron's write-only snapshot.",
+        "datePublished": "2026-04-12",
+        "dateModified": "2026-04-12",
+        "author": {
+            "@type": "Person",
+            "name": "Francisco Cerda Puigserver"
+        },
+        "publisher": {
+            "@type": "Organization",
+            "name": "WAzion",
+            "url": "https://www.wazion.com"
+        },
+        "mainEntityOfPage": {
+            "@type": "WebPage",
+            "@id": "https://nexo-brain.com/blog/nexo-5-2-0-bilingual-response-discipline/"
+        },
+        "url": "https://nexo-brain.com/blog/nexo-5-2-0-bilingual-response-discipline/",
+        "image": "https://nexo-brain.com/assets/nexo-brain-infographic-v5.png",
+        "keywords": ["NEXO 5.2.0", "response discipline", "high-stakes detection", "bilingual", "cortex quality cache", "confidence scoring"]
+    }
+    </script>
+
+    <style>
+        .article-header { padding-top: 128px; padding-bottom: 40px; text-align: center; }
+        .article-meta { font-size: 14px; color: var(--text-muted); margin-bottom: 16px; }
+        .article-body {
+            max-width: 720px; margin: 0 auto; padding: 0 24px 80px;
+            font-size: 17px; line-height: 1.8; color: var(--text);
+        }
+        .article-body h2 { font-size: 28px; font-weight: 700; margin: 48px 0 16px; letter-spacing: -0.01em; }
+        .article-body p { margin-bottom: 20px; color: var(--text-muted); }
+        .article-body strong { color: var(--text); }
+        .article-body a { color: var(--purple-light); }
+        .article-body a:hover { color: var(--pink); }
+        .article-body ul { margin: 0 0 20px 24px; color: var(--text-muted); }
+        .article-body li { margin-bottom: 8px; }
+        .article-body code {
+            font-family: 'SF Mono', 'Fira Code', monospace;
+            font-size: 14px; color: var(--pink);
+            background: rgba(236, 72, 153, 0.1);
+            padding: 2px 8px; border-radius: 4px;
+        }
+        .article-back {
+            display: inline-flex; align-items: center; gap: 6px;
+            font-size: 14px; font-weight: 600; color: var(--text-muted);
+            margin-bottom: 24px;
+        }
+        .article-back:hover { color: var(--purple-light); }
+        .article-visual { margin: 32px 0 40px; text-align: center; }
+        .article-visual img {
+            max-width: 100%;
+            border-radius: 16px;
+            border: 1px solid var(--dark-border);
+            box-shadow: 0 8px 32px rgba(124,58,237,0.15);
+        }
+    </style>
+</head>
+<body>
+
+<nav>
+    <div class="container">
+        <a href="/" class="nav-logo">
+            <img src="/assets/logo-64.png" alt="NEXO Brain" class="logo-image">
+            <span class="logo-text">NEXO Brain</span>
+        </a>
+        <button class="mobile-menu-toggle" aria-label="Toggle navigation" onclick="toggleMobileMenu()">
+            <span></span><span></span><span></span>
+        </button>
+        <div class="nav-links">
+            <a href="/">Home</a>
+            <a href="/features/">Features</a>
+            <a href="/evolution/">Evolution</a>
+            <a href="/compare/">Compare</a>
+            <a href="/blog/">Blog</a>
+            <a href="/changelog/">Changelog</a>
+            <a href="/docs/">Docs</a>
+            <a href="https://github.com/wazionapps/nexo" class="nav-cta">GitHub</a>
+        </div>
+    </div>
+</nav>
+
+<section class="article-header">
+    <div class="container">
+        <a href="/blog/" class="article-back">← Back to blog</a>
+        <div class="article-meta">April 12, 2026 · Minor release · Cortex layer</div>
+        <h1 class="section-title" style="font-size:clamp(28px,4.5vw,48px);max-width:920px;margin:0 auto 16px;">NEXO 5.2.0: Bilingual Response Discipline &amp; Closed Cortex-Quality Loop</h1>
+        <p class="section-subtitle" style="max-width:760px;margin:0 auto;">5.1.0 closed the big subsystem loops. 5.1.1 was a trace-hygiene patch. 5.2.0 closes two smaller but real gaps in the Cortex layer that the v5.1 audit left open on purpose &mdash; the high-stakes detector was English-only, and the <code>nexo-cortex-cycle</code> cron was writing a quality snapshot nobody ever consumed.</p>
+    </div>
+</section>
+
+<section>
+    <div class="article-body">
+        <div class="article-visual">
+            <img src="/assets/nexo-brain-infographic-v5.png" alt="NEXO Brain 5.2.0 release">
+        </div>
+
+        <p><strong>5.2.0 is a focused minor release.</strong> No breaking changes. No bootstrap, startup, Deep Sleep, or client-parity surfaces touched. Two concrete gaps in the Cortex layer close under themselves, both identified during the audit of the response-contract behaviour that landed in 5.1.</p>
+
+        <h2>The response-contract recap</h2>
+        <p>When a NEXO agent calls <code>nexo_task_open</code>, the runtime does not just accept the task. A pure function called <code>evaluate_response_confidence</code> inspects the goal, task type, area, evidence references, verification step, and stakes, and returns a <strong>response contract</strong> that tells the agent how to answer: <code>answer</code> (you can respond directly), <code>verify</code> (respond but confirm with evidence first), <code>ask</code> (you are missing information, request it), or <code>defer</code> (do not answer yet, this is high-stakes and under-evidenced).</p>
+        <p>This is deterministic reasoning on top of the LLM &mdash; no hidden model call, no temperature, just a 50-line function with an explicit score and an explicit decision tree. The advantage is auditability: every response-contract decision comes with a <code>reasons</code> array that explains exactly why it landed where it did. The disadvantage, pre-5.2.0, was that the function had two real limits: it was monolingual, and it could only push the score <em>down</em>.</p>
+
+        <h2>Bilingual high-stakes detection</h2>
+        <p>The <code>HIGH_STAKES_KEYWORDS</code> set that triggers the high-stakes penalty on the score was English-only. Roughly 25 words &mdash; <code>production</code>, <code>deploy</code>, <code>migration</code>, <code>customer</code>, <code>credential</code>, <code>delete</code>, and so on. A goal written in Spanish like <em>"migrar la base de datos de producción al nuevo servidor"</em> silently skipped every single one. It had the same risk profile as its English twin and the runtime treated it like an innocuous task.</p>
+        <p>5.2.0 adds <code>HIGH_STAKES_KEYWORDS_ES</code>: about 45 Spanish keywords including both accented and unaccented variants for the ones that carry diacritics (<code>crítico</code>/<code>critico</code>, <code>producción</code>/<code>produccion</code>, <code>facturación</code>/<code>facturacion</code>, <code>migración</code>/<code>migracion</code>, <code>reputación</code>/<code>reputacion</code>, <code>público</code>/<code>publico</code>, <code>médico</code>/<code>medico</code>). User prompts in the wild mix both forms, so accepting only one is effectively accepting neither. <code>_detect_high_stakes</code> now matches against the union of both sets.</p>
+
+        <h2>Negation-aware detection</h2>
+        <p>There is a subtler bug that keyword-matching always has: boundary statements. A user who writes <em>"refactor del parser interno sin tocar producción"</em> is explicitly disclaiming the sensitive area &mdash; the word <code>producción</code> appears in the string, but the user is stating where they will <em>not</em> go, not where they will act. Pre-5.2.0, this tripped the high-stakes flag anyway because the raw keyword was physically present. False positive.</p>
+        <p>5.2.0 adds <code>NEGATION_PATTERNS</code>: a small, conservative list of regex patterns that match these boundary statements bilingually. Examples: <code>no tocar prod</code>, <code>sin afectar</code>, <code>nunca borrar</code>, <code>evitar eliminar</code>, <code>without touching</code>, <code>don't modify</code>, <code>avoid deleting</code>. When any of these match, <code>_detect_high_stakes</code> short-circuits and returns <code>False</code> even if a high-stakes keyword is physically present. The effect is that the user can now describe the safe zone of their task without accidentally flagging the whole thing as a production operation.</p>
+
+        <h2>Positive signals on the confidence score</h2>
+        <p>Before 5.2.0, the confidence score inside <code>evaluate_response_confidence</code> was a pure penalty accumulator. Base 85, minus the penalties for unknowns, missing evidence, missing verification path, and high-stakes context. There was no mechanism to <em>reward</em> a task that had actually loaded the right context or that operated inside a known project area. The score drifted downward even when the agent was well-prepared.</p>
+        <p>5.2.0 adds two optional kwargs:</p>
+        <ul>
+            <li><strong><code>pre_action_context_hits: int</code></strong> &mdash; adds <code>+min(10, hits*2)</code> when the pre-action context lookup returned relevant learnings, decisions, or past events for this task. The cap keeps the boost bounded.</li>
+            <li><strong><code>area_has_atlas_entry: bool</code></strong> &mdash; adds <code>+5</code> when the task's area is a known entry in <code>project-atlas.json</code>. Known projects start from more trusted footing than unknown ones.</li>
+        </ul>
+        <p>Both signals are capped &mdash; they can never override a real risk penalty. A high-stakes task with missing evidence stays high-stakes and under-evidenced no matter how much context the agent loaded. But a routine task that ran the right searches finally gets credit for it in the score.</p>
+
+        <h2>Numeric safeguard over the decision tree</h2>
+        <p>The boolean decision tree inside <code>evaluate_response_confidence</code> covers every obvious case. But tasks can accumulate soft penalties without tripping any single boolean rule. Imagine a task with no unknowns, no high-stakes context, no verification step, and no evidence refs: the tree maps it to <code>verify</code>, and the score ends up at 50 exactly.</p>
+        <p>5.2.0 adds a monotonic numeric safeguard on top of the tree. After the boolean rules pick a mode, two extra checks run:</p>
+        <ul>
+            <li>If <code>mode == "answer"</code> and <code>final_score &lt; 50</code>, downgrade to <code>verify</code>.</li>
+            <li>If <code>mode == "verify"</code> and <code>high_stakes</code> and <code>final_score &lt; 30</code>, downgrade to <code>defer</code>.</li>
+        </ul>
+        <p>The safeguard is <strong>monotonic</strong> &mdash; it can only make the response discipline stricter, never looser. This means it can never break an existing pass-case; it can only catch edge cases where soft penalties stacked below the threshold of any single rule but still meant the runtime had no business answering directly. The <code>reasons</code> array gets a dedicated <code>numeric safeguard: ...</code> entry so the downgrade is explicit.</p>
+
+        <h2>Cortex-quality cache reader</h2>
+        <p>The second real gap was outside the response-contract layer, over in the Cortex quality cron. Since 5.1.0, <code>src/scripts/nexo-cortex-cycle.py</code> has been running every 6 hours and writing a full quality snapshot to <code>$NEXO_HOME/operations/cortex-quality-latest.json</code>. The cron's own docstring makes an explicit promise:</p>
+        <p><em>"Persists the snapshot to ~/claude/operations/cortex-quality-latest.json so dashboards / morning briefings can read fresh metrics without re-running the SQL."</em></p>
+        <p>That reader never existed. <code>handle_cortex_quality</code> in <code>src/plugins/cortex.py</code> was still re-computing the summary from SQL on every call. The cache file sat there for weeks being overwritten every 6h with fresh data, and nobody ever read it. Not a bug. Just a half-delivered promise.</p>
+        <p>5.2.0 closes it. The handler now attempts the cache first when <code>days</code> is 7 or 1 (the two windows the cron actually writes), falls back silently to the live SQL path on any failure, and returns an observable <code>"source": "cache" | "live"</code> field in its JSON response. Failure conditions that trigger fallback:</p>
+        <ul>
+            <li>Cache file does not exist</li>
+            <li><code>captured_at</code> is older than 6h 30m (6h cron + 30m slack for a slightly-late run)</li>
+            <li><code>schema</code> field does not match the current version</li>
+            <li>JSON is corrupt or malformed</li>
+            <li>Requested window is not cached (e.g. <code>days=30</code> always hits live)</li>
+        </ul>
+        <p>The cache is a performance optimisation, never a correctness dependency. Any corruption routes transparently to live computation.</p>
+
+        <h2>Tests</h2>
+        <p>9 new tests lock in Spanish keyword detection, accented variants, bilingual negation suppression, positive signal boosting (including the caps), numeric safeguard transitions, and score bounds. 7 new tests cover the cache reader: fresh cache hits for both windows, stale cache, unknown schema, invalid JSON, missing file, and explicitly non-cached windows. Every pre-existing protocol and cortex test continues to pass &mdash; the new positive-signal kwargs default to safe values and the numeric safeguard is monotonic.</p>
+        <p>Lint, security, coverage, release-readiness, and client-parity gates all green on the release PR.</p>
+
+        <h2>What did not change</h2>
+        <p>5.2.0 does not replace the 5.1.0 closed-loops story, and it does not replace the 5.0.0 goal/decision/outcome backbone. Every subsystem from prior releases keeps behaving the same way for tasks written in English. The difference is that tasks written in Spanish now trip the same gates, boundary statements are no longer mistaken for action targets, well-prepared tasks get credit for the context they loaded, and the cortex-quality cron's promise to serve fresh metrics without re-running SQL is finally kept.</p>
+
+        <p>If you want the exact release record, open the <a href="/changelog/#v520">5.2.0 changelog section</a>. If you are on an older install, <code>nexo update</code> will pick up the new module on the next run automatically. No migration. No schema change. No bootstrap surface touched.</p>
+    </div>
+</section>
+
+<footer>
+    <div class="container">
+        <div class="footer-content">
+            <div class="footer-left">
+                Created by <strong>Francisco Cerd&agrave; Puigserver</strong> &amp; <strong>NEXO</strong> (Claude Opus) &bull; Built by <a href="https://www.wazion.com">WAzion</a> &bull; AGPL-3.0 License &bull; &copy; 2026
+            </div>
+            <div class="footer-links">
+                <a href="https://github.com/wazionapps/nexo">GitHub</a>
+                <a href="https://x.com/NEXOBRAIN">X / Twitter</a>
+                <a href="https://github.com/sponsors/wazionapps">Sponsor</a>
+                <a href="/docs/">Docs</a>
+                <a href="/compare/">Compare</a>
+                <a href="/blog/">Blog</a>
+                <a href="https://www.npmjs.com/package/nexo-brain">npm</a>
+                <a href="https://github.com/wazionapps/nexo/releases">Releases</a>
+            </div>
+            <div style="text-align:center;margin-top:12px;color:#6b7280;font-size:12px;">Last updated: April 2026</div>
+        </div>
+    </div>
+</footer>
+
+</body>
+</html>

--- a/changelog/index.html
+++ b/changelog/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Changelog — NEXO Brain</title>
-    <meta name="description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.1.0 closes every open evolution, adaptive, cognitive, and skills loop under itself, ships bitemporal JSON-LD and GraphML knowledge graph export, adds an OpenTelemetry tool-span path, and puts lint, security, coverage, and release-readiness gates on every PR.">
+    <meta name="description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.2.0 ships bilingual response discipline (Spanish and English high-stakes detection with negation suppression), a numeric confidence safeguard with positive context signals, and a cortex-quality cache reader that closes the v5.1.0 cron's write-only snapshot loop.">
     <meta name="robots" content="index, follow">
     <link rel="canonical" href="https://nexo-brain.com/changelog/">
 
@@ -12,7 +12,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://nexo-brain.com/changelog/">
     <meta property="og:title" content="Changelog — NEXO Brain">
-    <meta property="og:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.1.0 closes every open evolution, adaptive, cognitive, and skills loop under itself, ships bitemporal JSON-LD and GraphML knowledge graph export, adds an OpenTelemetry tool-span path, and puts lint, security, coverage, and release-readiness gates on every PR.">
+    <meta property="og:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.2.0 ships bilingual response discipline (Spanish and English high-stakes detection with negation suppression), a numeric confidence safeguard with positive context signals, and a cortex-quality cache reader that closes the v5.1.0 cron's write-only snapshot loop.">
     <meta property="og:image" content="https://nexo-brain.com/assets/og/og-changelog.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -20,7 +20,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Changelog — NEXO Brain">
-    <meta name="twitter:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.1.0 closes every open evolution, adaptive, cognitive, and skills loop under itself, ships bitemporal JSON-LD and GraphML knowledge graph export, adds an OpenTelemetry tool-span path, and puts lint, security, coverage, and release-readiness gates on every PR.">
+    <meta name="twitter:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.2.0 ships bilingual response discipline (Spanish and English high-stakes detection with negation suppression), a numeric confidence safeguard with positive context signals, and a cortex-quality cache reader that closes the v5.1.0 cron's write-only snapshot loop.">
     <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-changelog.png">
 
     <script type="application/ld+json">
@@ -28,7 +28,7 @@
         "@context": "https://schema.org",
         "@type": "CollectionPage",
         "name": "Changelog — NEXO Brain",
-        "description": "Full version history for NEXO Brain cognitive runtime. Latest release: v5.1.0 closes every open evolution, adaptive, cognitive, and skills loop under itself, ships bitemporal JSON-LD and GraphML knowledge graph export, adds an OpenTelemetry tool-span path, and puts lint, security, coverage, and release-readiness gates on every PR.",
+        "description": "Full version history for NEXO Brain cognitive runtime. Latest release: v5.2.0 ships bilingual response discipline (Spanish and English high-stakes detection with negation suppression), a numeric confidence safeguard with positive context signals, and a cortex-quality cache reader that closes the v5.1.0 cron's write-only snapshot loop.",
         "url": "https://nexo-brain.com/changelog/",
         "isPartOf": {
             "@type": "WebSite",
@@ -87,18 +87,22 @@
                 <h1 class="section-title" style="font-size:clamp(32px,5vw,56px);">Changelog</h1>
                 <p class="section-subtitle">Every feature, fix, and improvement &mdash; from the beginning, with the same visual clarity as the rest of the site.</p>
                 <div class="page-chip-row">
-                    <span class="page-chip">v5.1.1 live</span>
-                    <span class="page-chip">Release trace hygiene &middot; stale WG-AUDIT-* auto-retire</span>
-                    <span class="page-chip">Diary warning split: recent vs historical</span>
+                    <span class="page-chip">v5.2.0 live</span>
+                    <span class="page-chip">Bilingual response discipline &middot; ES/EN high-stakes detection</span>
+                    <span class="page-chip">Cortex-quality cache reader closes the v5.1.0 cron loop</span>
                 </div>
                 <div class="hero-actions" style="justify-content:flex-start;">
-                    <a href="#v511" class="btn btn-primary">Start with v5.1.1</a>
+                    <a href="#v520" class="btn btn-primary">Start with v5.2.0</a>
                     <a href="#v400" class="btn btn-secondary">See v4.0.0</a>
                     <a href="/evolution/" class="btn btn-secondary">See Evolution</a>
                 </div>
             </div>
             <div class="page-visual">
                 <div class="page-stack">
+                    <div class="page-stack-card">
+                        <strong>v5.2.0</strong>
+                        <span>Bilingual response discipline (Spanish + English high-stakes detection with negation suppression), numeric confidence safeguard with positive context signals, and a cortex-quality cache reader that closes the v5.1.0 cron's write-only snapshot loop.</span>
+                    </div>
                     <div class="page-stack-card">
                         <strong>v5.1.1</strong>
                         <span>Release trace hygiene patch. New doctor check surfaces stale audit-phase workflows; self-audit auto-retires stale WG-AUDIT-* placeholder goals; diary warnings split recent vs historical commit_ref gaps.</span>
@@ -141,6 +145,48 @@
                 <div id="changelog-pager" class="changelog-pager" aria-label="Changelog pagination"></div>
             </div>
         </div>
+    </div>
+</section>
+
+<!-- v5.2.0 Response contract i18n + cortex-quality cache reader -->
+<section id="v520" class="section-compact" style="background:linear-gradient(135deg,#0b1120 0%,#7c3aed 55%,#ec4899 100%);">
+    <div class="container">
+        <div class="section-label">New in v5.2.0 <span style="opacity:.5;font-weight:400;">&mdash; April 12, 2026</span></div>
+        <h2 class="section-title">Bilingual Response Discipline &amp; Closed Cortex-Quality Loop</h2>
+        <p class="section-subtitle">
+            A focused minor release that closes two real gaps in the Cortex layer: the high-stakes detector was English-only with no way to reward well-prepared tasks, and the <code>nexo-cortex-cycle</code> cron was writing a quality snapshot that no reader ever consumed. Both loops close in this release. No breaking changes; no bootstrap, startup, Deep Sleep, or client-parity surfaces were touched.
+        </p>
+        <div class="cognitive-group">
+            <div class="cognitive-grid" style="grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:16px;">
+                <div class="cognitive-card">
+                    <h3>Spanish keyword parity</h3>
+                    <p><code>HIGH_STAKES_KEYWORDS_ES</code> adds ~45 Spanish keywords (<code>crítico</code>, <code>producción</code>, <code>facturación</code>, <code>clientes</code>, <code>despliegue</code>, <code>credencial</code>, <code>privacidad</code>, <code>reembolso</code>, and both accented and unaccented variants). A goal written in Spanish now trips the same high-stakes gate as its English twin &mdash; something like <em>"migrar la base de datos de producción"</em> used to silently skip the penalty.</p>
+                </div>
+                <div class="cognitive-card">
+                    <h3>Negation-aware detection</h3>
+                    <p><code>NEGATION_PATTERNS</code> suppresses the high-stakes flag when the text explicitly disclaims touching the sensitive area (<em>"sin afectar producción"</em>, <em>"no tocar prod"</em>, <em>"without touching production"</em>, <em>"don't modify"</em>). Before this release these boundary statements caused false positives because the raw keyword was physically present.</p>
+                </div>
+                <div class="cognitive-card">
+                    <h3>Positive signals on the confidence score</h3>
+                    <p><code>evaluate_response_confidence</code> now accepts <code>pre_action_context_hits</code> (+up to 10) and <code>area_has_atlas_entry</code> (+5). The score was a pure penalty accumulator before this release &mdash; there was no way to reward a task that <em>did</em> load the right context. Both signals are capped so they can never override a real risk penalty.</p>
+                </div>
+                <div class="cognitive-card">
+                    <h3>Numeric safeguard over the decision tree</h3>
+                    <p>After the boolean <code>high_stakes/unknowns/evidence/verification</code> rules pick a mode, a monotonic safeguard downgrades <code>answer</code> to <code>verify</code> when <code>final_score &lt; 50</code> and <code>verify</code> to <code>defer</code> when <code>high_stakes</code> and <code>final_score &lt; 30</code>. The safeguard can only make response discipline <em>stricter</em>, never looser &mdash; catching edge cases where soft penalties stacked below the threshold of any single rule.</p>
+                </div>
+                <div class="cognitive-card">
+                    <h3>Cortex-quality cache reader</h3>
+                    <p>The <code>nexo-cortex-cycle</code> cron has been writing <code>$NEXO_HOME/operations/cortex-quality-latest.json</code> every 6h since v5.1.0, with an explicit promise in its own docstring that <em>"dashboards / morning briefings can read fresh metrics without re-running the SQL"</em>. That reader never existed. In v5.2.0, <code>nexo_cortex_quality</code> finally serves the cached snapshot for the 7d / 1d windows when the file is fresh (&lt; 6h 30m), the schema matches, and the window is cached &mdash; otherwise it falls back silently to the live <code>cortex_evaluation_summary</code> computation.</p>
+                </div>
+                <div class="cognitive-card">
+                    <h3>Observable cache path</h3>
+                    <p>The handler's response now includes <code>"source": "cache" | "live"</code> so callers (dashboards, morning briefings, agents) can see which path was taken without extra instrumentation. The cache is a performance optimisation, never a correctness dependency &mdash; any failure (missing file, corrupt JSON, stale timestamp, unknown schema, non-cached window) routes to live.</p>
+                </div>
+            </div>
+        </div>
+        <p class="section-subtitle" style="margin-top:24px;">
+            9 new tests in <code>tests/test_protocol.py</code> lock in Spanish detection, bilingual negation suppression, positive signal boosting, numeric safeguard transitions, and score bounds. 7 new tests in <code>tests/test_cortex_quality_cache.py</code> cover fresh cache hits, stale cache, corrupt schema, invalid JSON, missing file, and non-cached windows. Lint, security, coverage, release-readiness, and client-parity gates all green.
+        </p>
     </div>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents</title>
-    <meta name="description" content="Libre/open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.1.0 closes every open evolution, adaptive, cognitive, and skills loop under itself, ships bitemporal JSON-LD/GraphML knowledge graph export, adds an OpenTelemetry tool-span path, and puts lint, security, coverage, and release-readiness gates on every PR across 150+ MCP tools.">
+    <meta name="description" content="Libre/open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.2.0 ships bilingual response discipline with Spanish and English high-stakes keyword parity and bilingual negation suppression, a numeric safeguard layer on top of the confidence decision tree with positive context signals, and a cortex-quality cache reader that closes the write-only snapshot loop from the v5.1.0 cortex-cycle cron. Builds on closed evolution, adaptive, cognitive, and skills loops, bitemporal JSON-LD/GraphML knowledge graph export, the OpenTelemetry tool-span path, and lint/security/coverage/release-readiness gates on every PR across 150+ MCP tools.">
     <meta name="keywords" content="AI memory, cognitive architecture, MCP, Claude Code, Codex, Claude Desktop, agent memory, vector search, AI agents, shared brain, open source">
     <meta name="author" content="WAzion">
     <meta name="robots" content="index, follow">
@@ -14,7 +14,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://nexo-brain.com">
     <meta property="og:title" content="NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents">
-    <meta property="og:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.1.0 closes every open evolution, adaptive, cognitive, and skills loop under itself, ships bitemporal JSON-LD/GraphML knowledge graph export, adds an OpenTelemetry tool-span path, and puts lint, security, coverage, and release-readiness gates on every PR across 150+ MCP tools.">
+    <meta property="og:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.2.0 ships bilingual response discipline with Spanish and English high-stakes keyword parity and bilingual negation suppression, a numeric safeguard layer on top of the confidence decision tree with positive context signals, and a cortex-quality cache reader that closes the write-only snapshot loop from the v5.1.0 cortex-cycle cron. Builds on closed evolution, adaptive, cognitive, and skills loops, bitemporal JSON-LD/GraphML knowledge graph export, the OpenTelemetry tool-span path, and lint/security/coverage/release-readiness gates on every PR across 150+ MCP tools.">
     <meta property="og:image" content="https://nexo-brain.com/assets/og/og-home.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -22,7 +22,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents">
-    <meta name="twitter:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.1.0 closes every open evolution, adaptive, cognitive, and skills loop under itself, ships bitemporal JSON-LD/GraphML knowledge graph export, adds an OpenTelemetry tool-span path, and puts lint, security, coverage, and release-readiness gates on every PR across 150+ MCP tools.">
+    <meta name="twitter:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.2.0 ships bilingual response discipline with Spanish and English high-stakes keyword parity and bilingual negation suppression, a numeric safeguard layer on top of the confidence decision tree with positive context signals, and a cortex-quality cache reader that closes the write-only snapshot loop from the v5.1.0 cortex-cycle cron. Builds on closed evolution, adaptive, cognitive, and skills loops, bitemporal JSON-LD/GraphML knowledge graph export, the OpenTelemetry tool-span path, and lint/security/coverage/release-readiness gates on every PR across 150+ MCP tools.">
     <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-home.png">
 
     <!-- Google Analytics (GA4) -->
@@ -46,12 +46,12 @@
         "@context": "https://schema.org",
         "@type": "SoftwareApplication",
         "name": "NEXO Brain",
-        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.1.0 closes every open evolution, adaptive, cognitive, and skills loop under itself, ships bitemporal JSON-LD/GraphML knowledge graph export, adds an OpenTelemetry tool-span path, and puts lint, security, coverage, and release-readiness gates on every PR across 150+ MCP tools.",
+        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.2.0 ships bilingual response discipline with Spanish and English high-stakes keyword parity and bilingual negation suppression, a numeric safeguard layer on top of the confidence decision tree with positive context signals, and a cortex-quality cache reader that closes the write-only snapshot loop from the v5.1.0 cortex-cycle cron. Builds on closed evolution, adaptive, cognitive, and skills loops, bitemporal JSON-LD/GraphML knowledge graph export, the OpenTelemetry tool-span path, and lint/security/coverage/release-readiness gates on every PR across 150+ MCP tools.",
         "applicationCategory": "DeveloperApplication",
         "operatingSystem": "macOS, Linux, Windows",
         "url": "https://nexo-brain.com",
         "downloadUrl": "https://www.npmjs.com/package/nexo-brain",
-        "softwareVersion": "5.1.1",
+        "softwareVersion": "5.2.0",
         "license": "https://www.gnu.org/licenses/agpl-3.0",
         "author": {
             "@type": "Organization",
@@ -88,7 +88,7 @@
         "@type": "WebSite",
         "name": "NEXO Brain",
         "url": "https://nexo-brain.com",
-        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.1.0 closes every open evolution, adaptive, cognitive, and skills loop under itself, ships bitemporal JSON-LD/GraphML knowledge graph export, adds an OpenTelemetry tool-span path, and puts lint, security, coverage, and release-readiness gates on every PR across 150+ MCP tools.",
+        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.2.0 ships bilingual response discipline with Spanish and English high-stakes keyword parity and bilingual negation suppression, a numeric safeguard layer on top of the confidence decision tree with positive context signals, and a cortex-quality cache reader that closes the write-only snapshot loop from the v5.1.0 cortex-cycle cron. Builds on closed evolution, adaptive, cognitive, and skills loops, bitemporal JSON-LD/GraphML knowledge graph export, the OpenTelemetry tool-span path, and lint/security/coverage/release-readiness gates on every PR across 150+ MCP tools.",
         "publisher": {
             "@type": "Organization",
             "name": "WAzion",
@@ -697,7 +697,7 @@
     <div class="container">
         <div class="hero-badge fade-up">
             <span class="dot"></span>
-            <span id="version-badge">v5.1.1</span> &mdash; Release trace hygiene: runtime doctor check + self-audit auto-retires stale WG-AUDIT-* placeholders + diary warning split (recent vs historical)
+            <span id="version-badge">v5.2.0</span> &mdash; Bilingual response discipline (Spanish + English high-stakes detection, negation-aware), numeric confidence safeguard with positive context signals, and a cortex-quality cache reader that closes the v5.1.0 cron's write-only snapshot loop
         </div>
         <div class="fade-up" style="display:flex;gap:8px;justify-content:center;margin-bottom:12px;">
             <img src="https://img.shields.io/npm/v/nexo-brain?color=7C3AED&label=npm" alt="npm version">
@@ -1156,6 +1156,11 @@
 
         <div class="release-evolution-grid">
             <div class="release-evolution-card">
+                <div class="release-evolution-version">v5.2.0</div>
+                <h3>Bilingual response discipline and closed cortex-quality loop</h3>
+                <p>The response-contract layer now detects high-stakes context in Spanish as well as English and suppresses false positives when the text explicitly disclaims the sensitive area ("sin afectar producción", "don't touch prod"). A numeric safeguard sits on top of the existing decision tree with positive signals that reward loaded context. The <code>nexo_cortex_quality</code> tool finally reads the snapshot that the <code>cortex-cycle</code> cron has been writing every 6h since v5.1.0, with silent fallback to the live path on any failure.</p>
+            </div>
+            <div class="release-evolution-card">
                 <div class="release-evolution-version">v5.1.0</div>
                 <h3>Every open loop closes under itself</h3>
                 <p>Evolution, adaptive, cognitive, and skills subsystems now close their own loops under evidence instead of leaving half-delivered signals in the database. The bitemporal knowledge graph exports cleanly to JSON-LD and GraphML, OpenTelemetry spans hook in on demand, and every PR has to clear lint, security, coverage, and release-readiness gates before it can merge.</p>
@@ -1200,7 +1205,7 @@
         <div class="release-evolution-actions">
             <a href="/evolution/" class="btn btn-primary">How Evolution works</a>
             <a href="/changelog/" class="btn btn-secondary">Read the full changelog</a>
-            <a href="/changelog/#v510" class="btn btn-secondary">Read the latest release notes</a>
+            <a href="/changelog/#v520" class="btn btn-secondary">Read the latest release notes</a>
         </div>
     </div>
 </section>

--- a/llms.txt
+++ b/llms.txt
@@ -1,8 +1,8 @@
 # NEXO Brain
 
-> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.1.0).
+> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.2.0).
 
-NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. Version 5.1.0 closes every open evolution, adaptive, cognitive, and skills loop under itself, ships bitemporal knowledge graph export to JSON-LD and GraphML with `as_of` historical replay, adds an OpenTelemetry tool-span path behind a soft-import, and puts lint, security, coverage, and release-readiness gates on every PR, on top of the 5.0 goal, decision, outcome, reusable-skill, and public-proof loop across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, multimodal memory refs, pre-compaction auto-flush, a public claim wiki, readable memory export, richer user-state adaptation, long-horizon overnight analysis, and 150+ MCP tools.
+NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. Version 5.2.0 ships bilingual response discipline with Spanish and English high-stakes keyword parity and bilingual negation suppression, a numeric confidence safeguard layered on top of the existing response-contract decision tree with positive context signals (pre-action context hits and known project-atlas areas), and a cortex-quality cache reader that finally consumes the write-only snapshot that the `nexo-cortex-cycle` cron has been writing every 6h since v5.1.0. Builds on v5.1.0's closed evolution, adaptive, cognitive, and skills loops, bitemporal knowledge graph export to JSON-LD and GraphML with `as_of` historical replay, OpenTelemetry tool-span path behind a soft-import, and lint, security, coverage, and release-readiness gates on every PR, plus v5.0's goal, decision, outcome, reusable-skill, and public-proof loop across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, multimodal memory refs, pre-compaction auto-flush, a public claim wiki, readable memory export, richer user-state adaptation, long-horizon overnight analysis, and 150+ MCP tools.
 
 ## Core Product Model
 
@@ -14,10 +14,14 @@ NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cogniti
 
 ## Current Release Focus
 
-- Goal profiles and Decision Cortex v2 shape higher-stakes recommendations instead of leaving strategy selection to raw prompting.
+- Bilingual response discipline: Spanish + English high-stakes detection with bilingual negation suppression, so boundary statements like "sin afectar producción" / "without touching production" no longer trigger false positives.
+- Positive signals on the confidence score so tasks that loaded real context and operate in a known project area are rewarded, not punished alongside unprepared ones.
+- Numeric safeguard layered over the boolean response-contract decision tree, monotonic over the existing rules (can only make discipline stricter, never looser).
+- Cortex-quality cache reader: `nexo_cortex_quality` now serves the snapshot that the `nexo-cortex-cycle` cron writes every 6 hours, with silent fallback to live SQL computation on any failure. Observable path via `"source": "cache" | "live"` in the response.
+- Goal profiles and Decision Cortex v2 keep shaping higher-stakes recommendations instead of leaving strategy selection to raw prompting.
 - Outcomes, impact scoring, and structured pattern capture connect action, result, and future prioritization more tightly.
 - Repeated winning patterns can seed or promote reusable skills, while poor evidence can demote or retire them.
-- Public proof now combines the LoCoMo memory result with a broader operator runtime pack so the website reflects more than one memory benchmark.
+- Public proof combines the LoCoMo memory result with a broader operator runtime pack so the website reflects more than one memory benchmark.
 
 ## Key Features
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://nexo-brain.com/</loc>
-    <lastmod>2026-04-11</lastmod>
+    <lastmod>2026-04-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
@@ -44,9 +44,9 @@
   </url>
   <url>
     <loc>https://nexo-brain.com/changelog/</loc>
-    <lastmod>2026-04-11</lastmod>
+    <lastmod>2026-04-12</lastmod>
     <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
+    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://nexo-brain.com/docs/</loc>
@@ -140,15 +140,21 @@
   </url>
   <url>
     <loc>https://nexo-brain.com/blog/</loc>
-    <lastmod>2026-04-10</lastmod>
+    <lastmod>2026-04-12</lastmod>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://nexo-brain.com/blog/nexo-5-2-0-bilingual-response-discipline/</loc>
+    <lastmod>2026-04-12</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.95</priority>
   </url>
   <url>
     <loc>https://nexo-brain.com/blog/nexo-5-1-0-closed-loops/</loc>
     <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.95</priority>
+    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://nexo-brain.com/blog/nexo-5-0-0-goal-driven-runtime-close-loops/</loc>


### PR DESCRIPTION
## Summary

Public-site updates that track the v5.2.0 release in wazionapps/nexo#130.

## Pages updated

- **Home (`index.html`)** — softwareVersion schema → 5.2.0, hero badge refreshed, meta/OG/Twitter/schema descriptions rewritten to mention the new bilingual response discipline and cortex-quality cache reader, recent evolution grid gains a v5.2.0 card, latest-release-notes CTA links to `#v520`
- **Changelog (`changelog/index.html`)** — new `#v520` section with six cognitive cards, page hero chips / page-stack / Start-with CTA bumped, meta descriptions refreshed
- **LLMs txt (`llms.txt` + `.well-known/llms.txt`)** — summary rewritten for v5.2.0 while preserving v5.1.0 / v5.0.0 context so AI crawlers see the full stack; Current Release Focus bullets rewritten
- **Blog** — new long-form post `blog/nexo-5-2-0-bilingual-response-discipline/` with BlogPosting schema, OG/Twitter meta, and a technical breakdown of the two closed loops; `blog/index.html` featured card + blog-grid card promote v5.2.0 ahead of v5.1.0
- **Sitemap (`sitemap.xml`)** — new `<url>` for the v5.2.0 blog post at priority 0.95, lastmod bumps on home/changelog/blog index (2026-04-12)

## Test plan

- [x] Site release-readiness gate in the main repo reports `website OK` against v5.2.0
- [ ] After merge, verify nexo-brain.com renders the v5.2.0 home hero, changelog section, and blog post
- [ ] Spot-check `/llms.txt` and `/.well-known/llms.txt` return the v5.2.0 narrative
- [ ] Confirm `/sitemap.xml` includes the new blog URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)