### PR TITLE
fix(core): deep-sleep datetime crash + cortex outcome auto-creation

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [5.2.1] - 2026-04-12
+
+### Bug fixes & cortex outcome feedback loop
+
+- **fix(deep-sleep):** `_parse_any_datetime` in `apply_findings.py` now
+  explicitly strips timezone info, fixing TypeError when comparing
+  offset-naive and offset-aware datetimes (caused 7/8 Phase 4 failures).
+- **feat(cortex):** `cortex_decide()` auto-creates a `decision_outcome`
+  when no existing outcome is linked, closing the decision → verification
+  feedback loop. The daily `outcome-checker` cron verifies these
+  automatically.
+
 ## [5.2.0] - 2026-04-12
 
 ### Response contract i18n & scoring — cortex-quality snapshot reader

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 5.2.0
+version: 5.2.1
 metadata:
   openclaw:
     requires:

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.2.0" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.2.1" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/src/plugins/cortex.py
+++ b/src/plugins/cortex.py
@@ -19,7 +19,7 @@ import os
 import re
 import secrets
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 
 
@@ -896,6 +896,27 @@ def handle_cortex_decide(
         linked_outcome_id=linked_outcome_id,
         task_id=task_id,
     )
+
+    # Auto-create outcome when none exists, so cortex decisions
+    # get verified by outcome-checker and close the feedback loop.
+    if resolved_outcome_id is None and clean_goal and task_id:
+        try:
+            from db import create_outcome
+
+            _deadline = (datetime.now() + timedelta(days=7)).strftime("%Y-%m-%d")
+            _outcome = create_outcome(
+                action_type="cortex_decision",
+                description=f"Cortex decision: {clean_goal[:120]}",
+                expected_result=f"Recommended '{scored[0]['name']}' succeeds",
+                metric_source="decision_outcome",
+                action_id=task_id,
+                session_id=session_id,
+                deadline=_deadline,
+            )
+            if isinstance(_outcome, dict) and _outcome.get("id"):
+                resolved_outcome_id = int(_outcome["id"])
+        except Exception:
+            pass  # non-critical: decision still records without outcome
 
     try:
         from db import create_cortex_evaluation

--- a/src/scripts/deep-sleep/apply_findings.py
+++ b/src/scripts/deep-sleep/apply_findings.py
@@ -855,7 +855,8 @@ def _parse_any_datetime(value) -> datetime | None:
         except Exception:
             continue
     try:
-        return datetime.fromisoformat(raw.replace("Z", "+00:00").replace("+00:00", ""))
+        dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        return dt.replace(tzinfo=None)
     except Exception:
         return None
 


### PR DESCRIPTION
## Summary

- **apply_findings.py**: Fix TypeError comparing offset-naive and offset-aware datetimes in `_parse_any_datetime()`. Root cause of 7/8 Deep Sleep Phase 4 failures on 2026-04-12.
- **cortex.py**: Auto-create outcome when `cortex_decide()` finds no existing one linked to the task, closing the decision→verification feedback loop. Outcomes get verified by the daily outcome-checker.
- Bump to v5.2.1

## Test plan

- [x] 766 tests passed, 0 failed
- [x] AST parse of cortex.py verified `timedelta` import
- [x] Manual test: `_parse_any_datetime` returns naive datetimes for Z, +00:00, plain date formats
- [x] Comparison with naive target_day works without TypeError

🤖 Generated with [Claude Code](https://claude.com/claude-code)