### PR TITLE
site(v5.3.1): publish packaged runtime normalization

### DIFF
--- a/.well-known/llms.txt
+++ b/.well-known/llms.txt
@@ -1,8 +1,13 @@
 # NEXO Brain
 
-> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.2.0).
+> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.3.1).
 
-NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. Version 5.2.0 ships bilingual response discipline with Spanish and English high-stakes keyword parity and bilingual negation suppression, a numeric confidence safeguard layered on top of the existing response-contract decision tree with positive context signals (pre-action context hits and known project-atlas areas), and a cortex-quality cache reader that finally consumes the write-only snapshot that the `nexo-cortex-cycle` cron has been writing every 6h since v5.1.0. Builds on v5.1.0's closed evolution, adaptive, cognitive, and skills loops, bitemporal knowledge graph export to JSON-LD and GraphML with `as_of` historical replay, OpenTelemetry tool-span path behind a soft-import, and lint, security, coverage, and release-readiness gates on every PR, plus v5.0's goal, decision, outcome, reusable-skill, and public-proof loop across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, multimodal memory refs, pre-compaction auto-flush, a public claim wiki, readable memory export, richer user-state adaptation, long-horizon overnight analysis, and 150+ MCP tools.
+NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. It adds a local shared brain across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, smarter retrieval defaults, long-horizon overnight analysis, and 150+ MCP tools.
+
+v5.3.1: packaged runtime normalization — `nexo update` keeps normal npm installs anchored to `~/.nexo` and refreshes packaged artifacts cleanly
+v5.3.0: nexo uninstall — stops crons, removes runtime, preserves user data for clean reinstall
+v5.2.1: fix deep-sleep datetime crash in apply_findings.py; cortex_decide() auto-creates outcomes closing decision→verification loop
+v5.2.0: bilingual response-discipline scoring + cortex quality cache reader
 
 ## Core Product Model
 
@@ -12,33 +17,12 @@ NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cogniti
 - Codex is supported as both terminal client and automation backend.
 - Claude Desktop can share the same brain through MCP.
 
-## Current Release Focus
-
-- Bilingual response discipline: Spanish + English high-stakes detection with bilingual negation suppression, so boundary statements like "sin afectar producción" / "without touching production" no longer trigger false positives.
-- Positive signals on the confidence score so tasks that loaded real context and operate in a known project area are rewarded, not punished alongside unprepared ones.
-- Numeric safeguard layered over the boolean response-contract decision tree, monotonic over the existing rules (can only make discipline stricter, never looser).
-- Cortex-quality cache reader: `nexo_cortex_quality` now serves the snapshot that the `nexo-cortex-cycle` cron writes every 6 hours, with silent fallback to live SQL computation on any failure. Observable path via `"source": "cache" | "live"` in the response.
-- Goal profiles and Decision Cortex v2 keep shaping higher-stakes recommendations instead of leaving strategy selection to raw prompting.
-- Outcomes, impact scoring, and structured pattern capture connect action, result, and future prioritization more tightly.
-- Repeated winning patterns can seed or promote reusable skills, while poor evidence can demote or retire them.
-- Public proof combines the LoCoMo memory result with a broader operator runtime pack so the website reflects more than one memory benchmark.
-
 ## Key Features
 
 - Three-store memory: Sensory Register, Short-Term Memory, Long-Term Memory
 - Semantic search with local embeddings and optional HNSW acceleration
 - Claim graph, trust scoring, metacognitive guard, cognitive dissonance detection
-- Multimodal memory references for images, audio, video, PDFs, and other non-text artifacts
-- Structured auto-flush before compaction so actionable continuity survives compression
-- Public claim/wiki tools with evidence, freshness, verification state, and linting
-- Readable markdown memory export for auditability
-- Stronger inspectable user-state model beyond shallow sentiment heuristics
-- Public retrieval knobs for hybrid weighting, decomposition, dream exclusion, and dormant-memory handling
-- Explicit backend contract/status for newer memory layers
 - Episodic memory, reminders, learnings, followups, and session continuity
-- 24-hour hot context for recent operational continuity across sessions and channels
-- Transcript fallback tools for recent Claude Code / Codex conversations when the memory layer is too thin
-- Live system catalog for tools, plugins, skills, scripts, crons, projects, and artifacts
 - Context continuity across Claude Code compaction via hooks
 - Shared-brain client sync for Claude Code, Codex, and Claude Desktop
 - Managed bootstrap parity for `~/.claude/CLAUDE.md` and `~/.codex/AGENTS.md`
@@ -106,7 +90,6 @@ nexo clients sync
 - Changelog: https://nexo-brain.com/changelog/
 - Blog: https://nexo-brain.com/blog/
 - Docs: https://nexo-brain.com/docs/
-- Install flow: https://nexo-brain.com/docs/install-flow/
 - GitHub: https://github.com/wazionapps/nexo
 - npm: https://www.npmjs.com/package/nexo-brain
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![GitHub stars](https://img.shields.io/github/stars/wazionapps/nexo?style=social)](https://github.com/wazionapps/nexo/stargazers)
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
-> Local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Persistent memory, selectable terminal and automation backends, overnight learning, self-healing background jobs, startup preflight, and doctor diagnostics. 150+ MCP tools. Benchmarked on LoCoMo (F1 0.588, +55% vs GPT-4).
+> Local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Persistent memory, durable workflow runs, selectable terminal and automation backends, overnight learning, self-healing background jobs, startup preflight, and doctor diagnostics. 150+ MCP tools. Benchmarked on LoCoMo (F1 0.588, +55% vs GPT-4).
 
 **NEXO Brain transforms any MCP-compatible AI agent from a stateless assistant into a cognitive partner that remembers, learns, forgets, adapts, and builds a relationship with you over time.**
 
@@ -16,7 +16,22 @@
   </a>
 </p>
 
-[Watch the overview video](https://nexo-brain.com/watch/) · [Open the infographic](https://nexo-brain.com/assets/nexo-brain-infographic-v5.png)
+[Watch the overview video](https://nexo-brain.com/watch/) · [Watch on YouTube](https://www.youtube.com/watch?v=i2lkGhKyVqI) · [Open the infographic](https://nexo-brain.com/assets/nexo-brain-infographic-v5.png)
+
+Start here:
+- [5-minute quickstart](docs/quickstart-5-minutes.md)
+- [Workflow quickstart](docs/workflows-quickstart.md)
+- [Recent memory fallbacks + live system catalog](docs/recent-memory-fallbacks-and-system-catalog.md)
+- [Supported client guides](docs/integrations/cursor.md)
+- [Docker setup](docs/docker-setup.md)
+- [Architecture visuals](docs/architecture-visuals.md)
+- [Memory classes](docs/memory-classes.md)
+- [Session portability](docs/session-portability.md)
+- [Python SDK](docs/sdk-python.md)
+- [Reference verticals](docs/reference-verticals.md)
+- [Measured compare scorecard](compare/README.md)
+- [Memory benchmark harness](benchmarks/README.md)
+- [Public contribution guide](docs/public-contribution.md)
 
 Every time you close a session, everything is lost. Your agent doesn't remember yesterday's decisions, repeats the same mistakes, and starts from zero. NEXO Brain fixes this with a cognitive architecture modeled after how human memory actually works.
 
@@ -38,13 +53,101 @@ That means NEXO now manages not only the shared runtime and MCP wiring, but also
 - For Codex specifically, `nexo chat` and Codex headless automation inject the current bootstrap explicitly, so Codex starts as NEXO even when plain global Codex startup is inconsistent about global instructions.
 - Deep Sleep now reads both Claude Code and Codex transcript stores, so overnight analysis still works even when the user spends the day in Codex.
 
-Version `2.6.14` closes those parity gaps in practice, `2.6.15` hardens the installed-runtime migration path so existing users actually receive the managed bootstrap updates cleanly, `2.6.16` pushes the system further in three directions, and `2.6.17` finishes the annoying last-mile migration bugs for real existing installs:
+Versions `2.6.14` through `2.7.0` established the practical shared-brain baseline: managed Claude/Codex bootstrap, Codex config sync, transcript-aware Deep Sleep, 60-day long-horizon analysis, weekly/monthly summary artifacts, retrieval auto-mode, and the first measured engineering loop.
 
-- Codex now gets managed global bootstrap/model sync in `~/.codex/config.toml`, so sessions opened outside `nexo chat` are much less likely to start as plain Codex.
-- Retrieval is smarter by default: HyDE and spreading activation now auto-enable when the query shape benefits, while exact lookups remain conservative.
-- Deep Sleep now blends recent context with older context over a 60-day horizon, and memory decay now tracks per-memory `stability` and `difficulty` instead of relying only on global decay constants.
-- Existing installs that already had NEXO connected to Codex now backfill that client state automatically during update/sync, so the managed Codex bootstrap actually lands without manual cleanup.
-- Bootstrap docs now fall back to the operator name `NEXO` when local metadata is blank, avoiding broken headings in `CLAUDE.md` and `AGENTS.md`.
+Versions `3.0.0` and `3.0.1` close the next execution gap:
+
+- protocol discipline is now a runtime contract, not just instructions:
+  - `nexo_task_open`
+  - `nexo_task_close`
+  - persistent `protocol_debt`
+  - enforceable `Cortex` gates
+- durable execution is now first-class:
+  - resumable workflow runs
+  - checkpoints
+  - replay
+  - retries
+  - durable goals
+- conditioned learnings on critical files are now real guardrails across Claude hooks, Codex transcript audits, and headless automation prompts
+- repair/correction work now routes through canonical learning capture instead of depending on the model to remember to document after the fact
+- runtime truth is stricter:
+  - no more healthy-looking warning storms
+  - no more silent Deep Sleep schema drift
+  - keep-alive jobs report alive/degraded/duplicated honestly
+- public proof is stronger:
+  - measured compare scorecard
+  - external and internal ablations
+  - `cost_per_solved_task`
+  - SDK/API/quickstart surface
+
+Versions `3.1.7` through `3.2.0` close the recent-memory gap:
+
+- recent operational continuity is now first-class through `hot context` and `recent events`
+- the runtime can build a reusable pre-action bundle instead of reconstructing the last few hours from diaries and durable recall only
+- when even that misses, NEXO now exposes raw transcript fallback tools for Claude Code and Codex session stores
+- NEXO can now inspect itself through a live system catalog derived from canonical sources instead of relying only on stale docs or operator memory
+
+Version `5.3.1` normalizes packaged npm installs so they behave like packaged npm installs: `nexo update` now keeps the runtime anchored to `~/.nexo`, refreshes packaged bootstrap/client artifacts after upgrade, avoids repo-only release-artifact drift in installed runtimes, and keeps personal scripts on the canonical packaged path.
+
+Version `5.3.0` adds `nexo uninstall` — a CLI command that cleanly separates runtime from user data. It stops all crons, removes the MCP server config, and preserves databases, learnings, and personal scripts for safe reinstall.
+
+Version `5.2.1` fixes the Deep Sleep datetime regression and closes the decision-to-outcome feedback gap:
+
+- `_parse_any_datetime` in `apply_findings.py` now strips timezone info before comparison, fixing the offset-aware/offset-naive crash that was breaking Deep Sleep verification work.
+- `cortex_decide()` now auto-creates a `decision_outcome` when none is linked yet, so the outcome-checker cron can verify real decisions instead of leaving the loop open.
+
+Version `5.2.0` closes two focused gaps in the Cortex layer that were left open by the v5.1 audit — the high-stakes response-contract detector was English-only, and the `nexo-cortex-cycle` cron was writing a quality snapshot that no reader ever consumed:
+
+- `HIGH_STAKES_KEYWORDS_ES` adds ~45 Spanish keywords to the high-stakes detector with accented and unaccented variants, so a goal written in Spanish (`migrar la base de datos de producción`) trips the same gate as its English twin.
+- `NEGATION_PATTERNS` suppresses false positives when the user explicitly disclaims touching the sensitive area (`sin afectar producción`, `no tocar prod`, `without touching production`, `don't modify`). The raw keyword being present is no longer enough to flag the task.
+- `evaluate_response_confidence` accepts two new optional kwargs, `pre_action_context_hits` (+up to 10) and `area_has_atlas_entry` (+5), so the score can finally reward tasks that loaded real context instead of only punishing unprepared ones. Both signals are capped and cannot override a real risk penalty.
+- A monotonic numeric safeguard layers on top of the boolean decision tree: `answer` downgrades to `verify` when `final_score < 50`, and `verify` downgrades to `defer` when `high_stakes` and `final_score < 30`. The safeguard can only make response discipline stricter, never looser.
+- `handle_cortex_quality` in `src/plugins/cortex.py` now reads `$NEXO_HOME/operations/cortex-quality-latest.json` when the requested window (7 or 1 days) is fresh (<6h 30m) and the schema matches — silent fallback to the live SQL computation on any failure. The handler's JSON response now includes `"source": "cache" | "live"` for observability.
+
+Version `5.1.0` lands the full NEXO-AUDIT-2026-04-11 roadmap as a single minor bump — every open evolution / adaptive / cognitive / skills loop now closes under itself, the knowledge graph exports cleanly, OpenTelemetry spans can be turned on without a hard dependency, and every PR has to clear lint, security, coverage, and release-readiness gates before it can merge:
+
+- Evolution cycle now auto-applies user-approved proposals on the next run (backed by the new idempotent migration `m38`), adaptive learned-weight rollbacks surface as visible followups, outcome patterns auto-promote to draft skills, and a Voyager-style detector exposes co-occurring skill pairs as composite-skill candidates via `nexo_skill_compose_candidates`.
+- `cognitive._search.search()` now accepts `dream_weight` and reranks dream-insights through it, somatic markers fold into the same reranking path (max +0.10 boost), state watchers open and auto-resolve deterministic `NF-WATCHER-{id}` followups, and correction fatigue opens a visible followup instead of only decaying memory.
+- A new Cortex quality cron (every 6h) watches accept rate / linked-success / override gap and opens `NF-CORTEX-QUALITY-DROP` idempotently when the decision engine starts drifting between cycles.
+- Adding a new learning now walks recent decisions through `retroactive_learnings.apply_learning_retroactively()` and opens deterministic `NF-RETRO-L<id>-D<id>` followups for every decision the learning would have changed (exposed via `nexo_learning_apply_retroactively`).
+- Hook lifecycle observability: new `hook_runs` table (migration `m39`) + `nexo_hook_runs` tool expose recent hook runs, failure streaks, and a health summary. Hook drops are no longer invisible.
+- Knowledge graph bitemporal export: `nexo_kg_export` emits JSON-LD (with an `nexo:*` vocabulary) or GraphML, and accepts an `as_of` ISO timestamp that replays the historical snapshot through `kg_edges.valid_from / valid_until` for igraph, Gephi, NetworkX, and Cytoscape.
+- OpenTelemetry integration: new `src/observability.py` soft-imports `opentelemetry` and only activates when `OTEL_EXPORTER_OTLP_ENDPOINT` or `OTEL_SERVICE_NAME` is set. `tool_span()` becomes a real span when enabled and stays a no-op context manager when disabled.
+- CI gates on every PR: new workflows enforce ruff (`E9 / F63 / F7 / F82 / F821`), bandit at high severity / high confidence, coverage baselines, and `verify_release_readiness.py --ci`. A PR that breaks the release contract fails loudly instead of waiting until tag push.
+- Safer update path: `auto_update` is guarded by a POSIX `flock` with stale-steal at 10 minutes, and on macOS it now `launchctl unload`s and reloads every `com.nexo.*.plist` after a version bump so long-lived crons pick up the new codebase immediately.
+
+Version `5.0.4` tightens the local runtime bridge and trims false-positive doctor noise:
+
+- vendorable `nexo_helper.py` now resolves `NEXO_HOME` and the `nexo` CLI path robustly, so personal scripts and subprocess flows stop depending on a lucky PATH
+- doctor no longer degrades because of advisory-only self-audit warnings or a single missing usage-telemetry row
+- managed Claude Code and Codex bootstraps now force an immediate first answer after simple email/diary/reminder/followup reads instead of feeling hung while chaining extra lookups
+
+Version `5.0.3` closes the next post-5.0 runtime gap:
+
+- `nexo chat` now boots Claude Code and Codex with an explicit NEXO startup prompt instead of opening cold or leaking the target path as a fake prompt
+- terminal launches now use the requested working directory as real `cwd`, so the selected project path stops behaving like chat text
+- the vendorable `nexo_helper.py` bridge now bounds helper calls with a timeout instead of letting personal-script subprocess flows wait forever
+- the doctor hardening from `5.0.2` remains validated on a real upgraded runtime after sync
+
+Version `5.0.2` closes the small post-5.0.1 doctor drift:
+
+- deep doctor now reads the live `learnings` schema correctly whether the install uses `status` or the older `archived` flag
+- a real upgraded runtime was revalidated with `nexo update`, `nexo doctor --tier deep`, `nexo doctor --tier all`, and a fresh Claude Code startup smoke
+
+Version `5.0.1` hardens the live 5.0 upgrade path:
+
+- managed Claude Code hooks are now cleaned up when an older release left obsolete core-managed entries behind
+- upgrades no longer preserve the stale `heartbeat-guard.sh` path that could create warning storms and fake "hung" symptoms after `nexo update`
+- the corrected path has been revalidated on a real install with `nexo clients sync`, Codex/Claude Code headless runtime access, email-monitor recovery, and a full `nexo update`
+
+Version `5.0.0` closes the loop between memory, decisions, outcomes, and reusable behavior:
+
+- goal profiles are now explicit and auditable instead of living as hidden heuristics
+- the Cortex can rank alternatives with goals, outcomes, overrides, and structured penalties
+- repeated outcome patterns can become durable learnings that influence later decisions
+- outcome-backed evidence can seed, promote, demote, or retire reusable skills
+- the runtime benchmark pack now shows the operator/runtime advantage with checked-in artifacts instead of relying only on prose
+- personal-script/core runtime paths, protocol debt maintenance, and release doctoring are now strong enough that the live install path can be audited honestly before release
 
 ### Client Capability Matrix
 
@@ -52,12 +155,24 @@ Version `2.6.14` closes those parity gaps in practice, `2.6.15` hardens the inst
 |------------|-------------|-------|----------------|
 | Shared brain / MCP runtime | Yes | Yes | Yes |
 | Managed bootstrap document | `~/.claude/CLAUDE.md` | `~/.codex/AGENTS.md` | Not applicable |
-| Global startup bootstrap sync | Native via hooks + bootstrap | Managed via bootstrap + Codex config `initial_messages` | MCP only |
+| Global startup bootstrap sync | Native via hooks + bootstrap | Managed via bootstrap + Codex config `initial_messages` + `mcp_servers.nexo` | Managed MCP-only shared-brain metadata |
 | `nexo chat` terminal client | Yes | Yes | No |
 | Background automation backend | Recommended | Supported | No |
 | Raw transcript source for Deep Sleep | Yes | Yes | No |
 | Native hook depth | Deepest | Partial, compensated | None |
+| Runtime doctor parity audit | Yes | Yes | Shared-brain only |
 | Recommended today | Yes | Supported | Shared-brain companion |
+
+### Supported Clients
+
+| Client | Status | Integration style | Notes |
+|--------|--------|-------------------|-------|
+| Claude Code | First-class | Managed install + hooks + bootstrap | Deepest NEXO parity today |
+| Codex | First-class | Managed install + bootstrap + transcript parity | Best non-Claude terminal path |
+| Claude Desktop | Companion | MCP-only shared brain | Useful as read/chat companion |
+| Cursor | Documented companion | MCP + `.cursor/rules` | Good editor pairing; no Deep Sleep transcript parity yet |
+| Windsurf | Documented companion | MCP + `.windsurf/rules` or repo `AGENTS.md` | Native MCP support, manual companion mode |
+| Gemini CLI | Adapter included | MCP + `GEMINI.md` | Best when you want Gemini as a shared-brain companion, not the primary NEXO runtime |
 
 ## The Problem
 
@@ -193,6 +308,9 @@ Deep Sleep now also mixes **recent context with older context across a 60-day ho
 - recurring multi-week themes
 - cross-domain links between older learnings and current failures
 - stale followups and topics that keep being mentioned but never formalized
+- weighted project pressure based on diary activity, followups, learnings, and decision outcomes
+
+It now also writes **weekly and monthly Deep Sleep summaries** so the overnight system can reuse higher-horizon signals instead of rediscovering everything from scratch every day.
 
 ## Cognitive Cortex
 
@@ -220,6 +338,20 @@ User message → Fast Path check → Simple chat? → Respond directly
 | **Activation Metrics** | Tracks modes, inhibition rates, and task types for continuous improvement. |
 
 The Cortex was designed through a 3-way AI debate (Claude Opus 4.6 + GPT-5.4 + Gemini 3.1 Pro) and validated against 6 months of real production failures.
+
+## Durable Workflow Runtime
+
+Memory and guardrails are not enough if long work still restarts from zero.
+
+NEXO now ships a durable workflow runtime for multi-step and cross-session execution:
+
+- `nexo_workflow_open` creates a persistent run with step metadata, idempotency key, priority, and shared state
+- `nexo_workflow_update` records replayable checkpoints, retry metadata, approval gates, and the current actionable state
+- `nexo_workflow_resume` tells the agent what to do next without guessing
+- `nexo_workflow_replay` reconstructs the recent execution history honestly instead of pretending the run is still in memory
+- `nexo_workflow_list` keeps active and blocked work visible so it does not disappear into reminders or prose notes
+
+This is the bridge between "good memory" and "reliable execution": tasks can now preserve state, retries, approval gates, and next action across interruptions.
 
 ## Context Continuity (Auto-Compaction)
 
@@ -277,6 +409,15 @@ NEXO Brain provides **150+ MCP tools** across 23 categories. These features impl
 | **Auto-Migration** | Formal schema migration system (schema_migrations table) tracks all database changes. Safe, reversible schema evolution for production systems — upgrades never lose data. |
 | **Auto-Merge Duplicates** | Batch cosine deduplication during the 03:00 sleep cycle. Respects sibling discrimination — similar memories about different contexts are kept separate. |
 | **Memory Dreaming** | Discovers hidden connections between recent memories during the 03:00 sleep cycle and now feeds a 60-day long-horizon Deep Sleep blend, so older patterns can reappear when they become relevant again. |
+
+### Operational Continuity
+
+| Feature | What It Does |
+|---------|-------------|
+| **Hot Context 24h** | Keeps active topics, blockers, and waiting states fresh across sessions, clients, cron ticks, and channel changes. This is the shared recent-memory substrate for operational continuity. |
+| **Pre-Action Context Bundle** | Loads recent contexts, recent events, related reminders, and related followups before acting, so continuity is explicit instead of prompt-only. |
+| **Transcript Fallback** | When recent-memory capture is thin or missing, NEXO can now search and read recent Claude Code / Codex transcripts directly through MCP instead of pretending the conversation is lost. |
+| **Live System Catalog** | NEXO can now inspect its own current surface — core tools, plugin tools, skills, scripts, crons, projects, and artifacts — through a live catalog derived from canonical sources at read time. |
 
 ### Retrieval
 
@@ -514,7 +655,7 @@ npx nexo-brain  # detects current version, migrates automatically
 
 NEXO Brain includes a local CLI that runs independently of any single terminal client:
 
-- `nexo chat` — launch the configured terminal client with NEXO as the operator
+- `nexo chat` — launch a NEXO terminal client; if both Claude Code and Codex are available, it asks every time which one to open and puts the last-used client first
 - `nexo update` — sync runtime from source, run migrations, reconcile schedules
 - `nexo doctor --tier runtime` — boot/runtime/deep diagnostics with `--fix` mode
 - `nexo scripts list` — list all personal scripts and their status
@@ -535,6 +676,8 @@ Scripts in `NEXO_HOME/scripts/` are first-class managed entities:
 - `nexo doctor --tier runtime` detects orphaned schedules, missing plists, and drift
 
 Personal scripts are completely separate from core NEXO processes. The `crons/manifest.json` defines core; everything in `NEXO_HOME/scripts/` is personal.
+
+If you need to decide between a personal script, skill, plugin, or schedule, use [docs/personal-artifacts-manual.md](docs/personal-artifacts-manual.md). That is the canonical operational guide.
 
 ## Recovery-Aware Background Jobs (v2.6.2)
 
@@ -612,7 +755,7 @@ The installer handles everything and syncs the same `nexo` MCP brain into Claude
     - Node.js project detected
   Configuring MCP server...
   Setting up nervous system...
-    13 core recovery-aware jobs configured.
+    15 core recovery-aware jobs configured.
     Dashboard configured at localhost:6174.
   Caffeinate enabled.
   Generating operator instructions...
@@ -622,25 +765,63 @@ The installer handles everything and syncs the same `nexo` MCP brain into Claude
   +----------------------------------------------------------+
 ```
 
+### Docker Compose
+
+NEXO now ships a root-level [`docker-compose.yml`](docs/docker-setup.md) for a persistent containerized runtime. It does two things at once:
+
+- keeps `NEXO_HOME` on a named volume
+- exposes a remote MCP endpoint at `http://localhost:8000/mcp` for IDEs that support HTTP/SSE MCP
+
+Start it with:
+
+```bash
+docker compose up -d
+```
+
+For Claude Code and Codex, keep using stdio and point the MCP command at the running container:
+
+```bash
+docker compose exec -T nexo python src/server.py
+```
+
+That gives you the same persistent brain in the container while keeping terminal clients on their native stdio transport. The full step-by-step flow, health checks, and config examples live in [docs/docker-setup.md](docs/docker-setup.md).
+
 ### Starting a Session
 
 After install, use the runtime CLI:
 
 ```bash
-nexo chat          # Launch the configured terminal client (Claude Code or Codex)
+nexo chat          # Launch a NEXO terminal client (asks if both Claude Code and Codex are available)
 nexo doctor        # Check runtime health
 nexo update        # Pull latest version and sync
 nexo clients sync  # Re-sync Claude Code/Desktop/Codex to the same brain
 nexo scripts list  # See your personal scripts
 ```
 
-During install, NEXO now asks which interactive clients you want to connect, which one `nexo chat` should open by default, whether to enable background automation, which backend should run that automation, and which model profile each active terminal/backend should use. Shared brain stays on in every mode.
+During install, NEXO now asks which interactive clients you want to connect, which one `nexo chat` should suggest first when multiple terminal clients are available, whether to enable background automation, which backend should run that automation, and which model profile each active terminal/backend should use. Shared brain stays on in every mode.
+
+Public entry points for the mental model now stay intentionally small:
+- `nexo_remember`
+- `nexo_memory_recall`
+- `nexo_consolidate`
+- `nexo_run_workflow`
+- `nexo_pre_action_context`
+- `nexo_transcript_search`
+- `nexo_system_catalog`
+
+If you want the shell or Python wrappers instead of raw MCP tools:
+- [docs/quickstart-5-minutes.md](docs/quickstart-5-minutes.md)
+- [docs/memory-classes.md](docs/memory-classes.md)
+- [docs/recent-memory-fallbacks-and-system-catalog.md](docs/recent-memory-fallbacks-and-system-catalog.md)
+- [docs/sdk-python.md](docs/sdk-python.md)
+- [docs/reference-verticals.md](docs/reference-verticals.md)
+- [compare/README.md](compare/README.md)
 
 Recommended defaults:
 - Claude Code: `Opus 4.6 with 1M context`
 - Codex: `gpt-5.4` with `xhigh` reasoning
 
-Or use the shell alias created during install (e.g. `atlas`), which now runs `nexo chat .` so it opens whichever terminal client you selected as default.
+Or use the shell alias created during install (e.g. `atlas`), which now runs `nexo chat .` so it opens the terminal client you pick for that session, with the last-used option shown first.
 
 Your operator will greet you immediately — adapted to the time of day, resuming from where you left off. No cold starts.
 
@@ -653,6 +834,10 @@ NEXO is being hardened in public, and the best contributions now are not only co
 - If you use NEXO in production-like daily work, include exact runtime symptoms and commands in bug reports. This project improves fastest when the operational reality is concrete.
 
 The project still recommends Claude Code as the primary path, but contributions that improve Codex, client parity, installer clarity, and ecosystem integrations are especially valuable.
+
+Maintainers and contributors touching startup, bootstrap, Deep Sleep, or shared-brain behavior should also use the client parity checklist:
+- [docs/client-parity-checklist.md](docs/client-parity-checklist.md)
+- `python3 scripts/verify_release_readiness.py`
 
 ### What Gets Installed
 
@@ -704,9 +889,9 @@ nexo doctor --tier runtime --json  # Machine-readable health report
 nexo doctor --fix              # Apply deterministic repairs
 ```
 
-Personal scripts live in `NEXO_HOME/scripts/` with inline metadata. Their Python templates now include `run_automation_text(...)`, which routes work through the configured NEXO automation backend instead of hardcoding `claude -p` or provider-specific model names. See `docs/writing-scripts.md` for details.
+Personal scripts live in `NEXO_HOME/scripts/` with inline metadata. Their Python templates now include `run_automation_text(...)`, which routes work through the configured NEXO automation backend instead of hardcoding `claude -p` or provider-specific model names. `nexo-agent-run.py` now also supports task profiles (`fast`, `balanced`, `deep`) plus safe backend fallback, so automations can prefer cheaper/faster Codex paths or deeper Claude paths without hardcoding one provider forever. See `docs/writing-scripts.md` for details and `docs/personal-artifacts-manual.md` for the canonical artifact decision guide.
 
-Skills v2 combine procedural guides with optional executable scripts. Personal skills live in `NEXO_HOME/skills/`, packaged core skills live in `NEXO_CODE/skills/` during development and `NEXO_HOME/skills-core/` in installed environments, and staged runtime copies live in `NEXO_HOME/skills-runtime/`. Execution is fully autonomous: Deep Sleep can evolve mature guide skills into executable drafts automatically, and runtime execution no longer waits for manual approval. See `docs/skills-v2.md` for the full model.
+Skills v2 combine procedural guides with optional executable scripts. Personal skills live in `NEXO_HOME/skills/`, packaged core skills live in `NEXO_CODE/skills/` during development and `NEXO_HOME/skills-core/` in installed environments, and staged runtime copies live in `NEXO_HOME/skills-runtime/`. Execution is fully autonomous: Deep Sleep can evolve mature guide skills into executable drafts automatically, and runtime execution no longer waits for manual approval. See `docs/skills-v2.md` for the full model and `docs/personal-artifacts-manual.md` for the boundary between skills, scripts, plugins, and schedules.
 
 The Doctor system reads existing health artifacts (immune, watchdog, self-audit) without triggering repairs in default mode.
 
@@ -783,6 +968,8 @@ TOOLS = [
 
 Reload without restarting: `nexo_plugin_load("my_plugin.py")`
 
+Use a personal plugin only when you need a new MCP tool in the runtime surface. If the real need is autonomous execution or scheduling, use a personal script plus managed schedule instead. The canonical decision guide is [docs/personal-artifacts-manual.md](docs/personal-artifacts-manual.md).
+
 ### Data Privacy
 
 - **Everything stays local.** All data in `~/.nexo/`, never uploaded anywhere.
@@ -830,7 +1017,19 @@ When Claude Desktop is installed, `nexo-brain`, `nexo update`, and `nexo clients
 
 ### Codex
 
-When Codex CLI is available, `nexo-brain`, `nexo update`, and `nexo clients sync` register the same `nexo` MCP server via `codex mcp add`, so Codex uses the same local memory store as Claude Code and Claude Desktop. If selected during install, `nexo chat` can open Codex directly and background automation can also run through Codex. The current recommended Codex profile is `gpt-5.4` with `xhigh` reasoning.
+When Codex CLI is available, `nexo-brain`, `nexo update`, and `nexo clients sync` register the same `nexo` MCP server via `codex mcp add`, so Codex uses the same local memory store as Claude Code and Claude Desktop. If selected during install, `nexo chat` can open Codex directly and background automation can also run through Codex. Interactive `nexo chat` launches use Codex's aggressive no-confirmation mode so the session does not stall on repetitive approval prompts. The current recommended Codex profile is `gpt-5.4` with `xhigh` reasoning. Runtime Doctor also audits recent Codex sessions for NEXO startup markers and conditioned-file protocol discipline so parity drift does not hide behind the lack of native Claude-style hooks.
+
+### Cursor
+
+Cursor works well as a documented companion client. Point Cursor at the same local `nexo` MCP server and add a project rule that forces `nexo_startup`, `nexo_heartbeat`, and the protocol path on real work. See [docs/integrations/cursor.md](docs/integrations/cursor.md).
+
+### Windsurf
+
+Windsurf/Cascade supports MCP plus durable repo rules. Use the same local `nexo` server and add NEXO startup/protocol instructions in `.windsurf/rules/` or your repo `AGENTS.md`. See [docs/integrations/windsurf.md](docs/integrations/windsurf.md).
+
+### Gemini CLI
+
+Gemini CLI can share the same local NEXO brain through `mcpServers` in `~/.gemini/settings.json` plus a repo `GEMINI.md`. NEXO now ships a starter adapter in [adapters/gemini/README.md](adapters/gemini/README.md).
 
 ### OpenClaw
 
@@ -912,10 +1111,45 @@ If NEXO Brain is useful to you, consider:
 - **[Sponsor on GitHub](https://github.com/sponsors/wazionapps)** — support ongoing development directly
 - **Share your experience** — tell others how you're using cognitive memory in your AI workflows
 - **Contribute** — see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines. Issues and PRs welcome
+- **Client parity / shared-brain maintenance** — see [docs/client-parity-checklist.md](docs/client-parity-checklist.md)
 
 [![Star History Chart](https://api.star-history.com/svg?repos=wazionapps/nexo&type=Date)](https://star-history.com/#wazionapps/nexo&Date)
 
+## Memory Benchmark Snapshot
+
+The full harness is in [benchmarks/README.md](benchmarks/README.md). The first checked-in micro-benchmark compares the NEXO runtime against a static `CLAUDE.md`-only baseline on five recall-heavy scenarios:
+
+| Scenario | NEXO full stack | Static `CLAUDE.md` | No memory |
+|----------|-----------------|--------------------|-----------|
+| Decision rationale recall | Pass | Partial | Fail |
+| User preference recall | Pass | Partial | Fail |
+| Repeat-error avoidance | Pass | Partial | Fail |
+| Resume interrupted task | Pass | Partial | Fail |
+| Related-context stitching | Pass | Fail | Fail |
+
+See [benchmarks/results/memory-recall-vs-static.md](benchmarks/results/memory-recall-vs-static.md) for the rubric, prompt shape, and first-run notes.
+
 ## Changelog
+
+### v3.0.1 — Python 3.10 Compatibility Patch (2026-04-06)
+- Restored Python 3.10 compatibility by replacing Python 3.11-only `datetime.UTC` with `timezone.utc`.
+- Added `tomllib` → `tomli` fallback plus declared runtime dependency for Python < 3.11.
+- Boot doctor now validates all critical JSON config artifacts: `schedule.json`, `optionals.json`, `crons/manifest.json`.
+
+### v3.0.0 — Protocol Discipline, Durable Execution, Measured Runtime (2026-04-06)
+- **Protocol discipline runtime**: Enforceable `nexo_task_open`/`nexo_task_close`, persistent `protocol_debt`, `Cortex` gates with durable `check_id`, conditioned-file guardrails across Claude hooks and Codex transcript audits.
+- **Durable workflow runtime**: `nexo_workflow_open`/`update`/`resume`/`replay`/`list` with persistent runs, steps, checkpoints, replay history, retry bookkeeping, and idempotent open keys.
+- **Durable goals**: `nexo_goal_open`/`update`/`get`/`list` for long-running work that stays active/blocked/abandoned/completed.
+- **Operational truth**: Deep Sleep survives schema drift, `keep_alive` reports alive/degraded/duplicated honestly, warning storms no longer count as healthy.
+- **Measured product surface**: 5-minute quickstart, Python SDK, reference verticals, measured compare scorecard with LoCoMo baselines and `cost_per_solved_task`.
+- **Skill lifecycle**: Testing, promotion, retirement, and composition flows. Evolution public-core peer-review for opt-in PRs.
+
+### v2.7.0 — Shared Brain Baseline (2026-04-06)
+- Managed Claude Code + Codex bootstrap with explicit `CORE`/`USER` contract.
+- Codex config sync and transcript-aware Deep Sleep across both clients.
+- 60-day long-horizon analysis, weekly/monthly summary artifacts.
+- Retrieval auto-mode and first measured engineering loop.
+- `nexo chat` opens the configured client instead of assuming Claude Code.
 
 ### v2.6.9 — Integration Sync, CI/CD Pipeline (2026-04-04)
 - **Release artifact sync**: Automated version synchronization across Claude Code plugin, OpenClaw package, and ClawHub skill before every publish.
@@ -943,7 +1177,7 @@ If NEXO Brain is useful to you, consider:
 - **Personal scripts registry**: Scripts in `NEXO_HOME/scripts/` tracked in SQLite with metadata, categories, schedules. Full lifecycle: create, sync, reconcile, schedule, unschedule, remove.
 - **Orchestrator removed from core** (breaking): Was opt-in personal automation adding complexity for all users. Existing users keep their setup in `NEXO_HOME/scripts/`.
 - **Claude Code plugin structure**: `plugin.json`, entry point, packaging for marketplace submission.
-- **`nexo chat`**: Official command to launch the configured terminal client with NEXO as operator.
+- **`nexo chat`**: Official command to launch a NEXO terminal client, asking when multiple supported terminal clients are available.
 - **Managed Evolution hardening**: Can modify core behavior modules with rollback followups.
 - Cron recovery hardened: TCC diagnostics, keepalive sync, personal schedule catchup.
 

--- a/blog/index.html
+++ b/blog/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Blog — NEXO Brain</title>
-    <meta name="description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the v5.2.0 bilingual response discipline and cortex-quality cache release, the v5.1.0 closed-loops release, and the v5.0.0 goal/decision/outcome release line.">
+    <meta name="description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, now including the v5.3.1 packaged runtime normalization release that makes nexo update behave like a normal npm user path.">
     <meta name="robots" content="index, follow">
     <link rel="canonical" href="https://nexo-brain.com/blog/">
 
@@ -12,7 +12,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://nexo-brain.com/blog/">
     <meta property="og:title" content="Blog — NEXO Brain">
-    <meta property="og:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the v5.2.0 bilingual response discipline and cortex-quality cache release, the v5.1.0 closed-loops release, and the v5.0.0 goal/decision/outcome release line.">
+    <meta property="og:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, now including the v5.3.1 packaged runtime normalization release that makes nexo update behave like a normal npm user path.">
     <meta property="og:image" content="https://nexo-brain.com/assets/og/og-blog.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -20,7 +20,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Blog — NEXO Brain">
-    <meta name="twitter:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the v5.2.0 bilingual response discipline and cortex-quality cache release, the v5.1.0 closed-loops release, and the v5.0.0 goal/decision/outcome release line.">
+    <meta name="twitter:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, now including the v5.3.1 packaged runtime normalization release that makes nexo update behave like a normal npm user path.">
     <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-blog.png">
 
     <script type="application/ld+json">
@@ -28,7 +28,7 @@
         "@context": "https://schema.org",
         "@type": "CollectionPage",
         "name": "Blog — NEXO Brain",
-        "description": "Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the v5.2.0 bilingual response discipline and cortex-quality cache release, the v5.1.0 closed-loops release, and the v5.0.0 goal/decision/outcome release line.",
+        "description": "Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, now including the v5.3.1 packaged runtime normalization release that makes nexo update behave like a normal npm user path.",
         "url": "https://nexo-brain.com/blog/",
         "isPartOf": {
             "@type": "WebSite",
@@ -134,7 +134,7 @@
                     <span class="page-chip">Competitive analysis</span>
                 </div>
                 <div class="hero-actions" style="justify-content:flex-start;">
-                    <a href="/blog/nexo-5-2-0-bilingual-response-discipline/" class="btn btn-primary">Read latest release</a>
+                    <a href="/blog/nexo-5-3-1-packaged-runtime-normalization/" class="btn btn-primary">Read latest release</a>
                     <a href="/changelog/" class="btn btn-secondary">Latest release notes</a>
                     <a href="/evolution/" class="btn btn-secondary">See Evolution</a>
                 </div>
@@ -143,22 +143,22 @@
                 <div class="section-label">Latest release</div>
                 <div class="blog-featured-meta">
                     <span class="compare-chip">April 12, 2026</span>
-                    <span class="compare-chip">Bilingual response discipline + cortex cache loop</span>
+                    <span class="compare-chip">Packaged runtime normalization</span>
                 </div>
-                <h2>NEXO 5.2.0: Bilingual Response Discipline &amp; Closed Cortex-Quality Loop</h2>
-                <p>NEXO 5.2.0 closes two focused gaps in the Cortex layer. The response-contract detector now covers Spanish as well as English, bilingual negation patterns suppress false positives on boundary statements, positive signals reward tasks that loaded real context, a numeric safeguard layers on top of the decision tree, and <code>nexo_cortex_quality</code> finally reads the snapshot the v5.1.0 cron has been writing every 6h.</p>
+                <h2>NEXO 5.3.1: Packaged Runtime Normalization for Real npm Users</h2>
+                <p>NEXO 5.3.1 fixes the packaged install path that older users actually feel in the wild: <code>nexo update</code> now stays anchored to <code>~/.nexo</code>, refreshes packaged bootstrap/client artifacts after upgrade, skips repo-only drift inside installed runtimes, and keeps personal scripts on the canonical packaged path.</p>
                 <div class="hero-actions" style="justify-content:flex-start;margin-bottom:18px;">
-                    <a href="/blog/nexo-5-2-0-bilingual-response-discipline/" class="btn btn-primary">Open article</a>
-                    <a href="/changelog/#v520" class="btn btn-secondary">Open changelog</a>
+                    <a href="/blog/nexo-5-3-1-packaged-runtime-normalization/" class="btn btn-primary">Open article</a>
+                    <a href="/changelog/#v531" class="btn btn-secondary">Open changelog</a>
                 </div>
                 <div class="blog-mini-stack">
                     <div class="blog-mini-card">
                         <strong>Companion view</strong>
-                        <span><a href="/changelog/#v520">The 5.2.0 changelog section</a></span>
+                        <span><a href="/changelog/#v531">The 5.3.1 changelog section</a></span>
                     </div>
                     <div class="blog-mini-card">
-                        <strong>Previous closed-loops release</strong>
-                        <span><a href="/blog/nexo-5-1-0-closed-loops/">NEXO 5.1.0: Every Open Loop Closes Under Itself</a>.</span>
+                        <strong>Previous release</strong>
+                        <span><a href="/blog/nexo-5-2-0-bilingual-response-discipline/">NEXO 5.2.0: Bilingual Response Discipline &amp; Closed Cortex-Quality Loop</a>.</span>
                     </div>
                 </div>
             </div>
@@ -170,6 +170,13 @@
 <section class="section-flush-top">
     <div class="container">
         <div class="blog-grid">
+
+            <div class="blog-card">
+                <div class="blog-card-date">April 12, 2026</div>
+                <h2><a href="/blog/nexo-5-3-1-packaged-runtime-normalization/">NEXO 5.3.1: Packaged Runtime Normalization for Real npm Users</a></h2>
+                <p>A packaging patch that makes <code>nexo update</code> behave like a normal user expects: the installed runtime stays anchored to <code>~/.nexo</code>, packaged artifacts refresh after upgrade, repo-only drift stays out of user installs, and personal scripts keep resolving against the canonical packaged home.</p>
+                <a href="/blog/nexo-5-3-1-packaged-runtime-normalization/" class="read-more">Read article <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14"/><path d="M12 5l7 7-7 7"/></svg></a>
+            </div>
 
             <div class="blog-card">
                 <div class="blog-card-date">April 12, 2026</div>

--- a/blog/nexo-5-3-1-packaged-runtime-normalization/index.html
+++ b/blog/nexo-5-3-1-packaged-runtime-normalization/index.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <title>NEXO 5.3.1: Packaged Runtime Normalization for Real npm Users</title>
+    <meta name="description" content="NEXO 5.3.1 fixes the packaged install path that older users actually feel: nexo update now stays anchored to ~/.nexo, refreshes packaged bootstrap and client artifacts, avoids repo-only drift in installed runtimes, and keeps personal scripts on the canonical packaged path.">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://nexo-brain.com/blog/nexo-5-3-1-packaged-runtime-normalization/">
+
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://nexo-brain.com/blog/nexo-5-3-1-packaged-runtime-normalization/">
+    <meta property="og:title" content="NEXO 5.3.1: Packaged Runtime Normalization for Real npm Users">
+    <meta property="og:description" content="A packaging patch that makes nexo update behave like a normal npm user expects: anchored to ~/.nexo, packaged artifacts refreshed after upgrade, repo-only drift kept out of installed runtimes, and personal scripts resolved from the canonical packaged home.">
+    <meta property="og:image" content="https://nexo-brain.com/assets/og/og-blog.png">
+    <meta property="article:published_time" content="2026-04-12">
+    <meta property="article:author" content="Francisco Cerda Puigserver">
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="NEXO 5.3.1: Packaged Runtime Normalization for Real npm Users">
+    <meta name="twitter:description" content="nexo update now stays anchored to ~/.nexo, refreshes packaged artifacts after upgrade, and avoids repo-only drift in installed runtimes.">
+    <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-blog.png">
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-1LNEMCJMS7"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-1LNEMCJMS7');
+    </script>
+
+    <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicon-32.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
+    <link rel="stylesheet" href="/assets/style.css">
+
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "NEXO 5.3.1: Packaged Runtime Normalization for Real npm Users",
+        "description": "NEXO 5.3.1 fixes the packaged install path that older users actually feel: nexo update now stays anchored to ~/.nexo, refreshes packaged bootstrap and client artifacts, avoids repo-only drift in installed runtimes, and keeps personal scripts on the canonical packaged path.",
+        "datePublished": "2026-04-12",
+        "dateModified": "2026-04-12",
+        "author": {
+            "@type": "Person",
+            "name": "Francisco Cerda Puigserver"
+        },
+        "publisher": {
+            "@type": "Organization",
+            "name": "WAzion",
+            "url": "https://www.wazion.com"
+        },
+        "mainEntityOfPage": {
+            "@type": "WebPage",
+            "@id": "https://nexo-brain.com/blog/nexo-5-3-1-packaged-runtime-normalization/"
+        },
+        "url": "https://nexo-brain.com/blog/nexo-5-3-1-packaged-runtime-normalization/",
+        "image": "https://nexo-brain.com/assets/nexo-brain-infographic-v5.png",
+        "keywords": ["NEXO 5.3.1", "nexo update", "npm install", "packaged runtime", "runtime normalization", "~/.nexo"]
+    }
+    </script>
+
+    <style>
+        .article-header { padding-top: 128px; padding-bottom: 40px; text-align: center; }
+        .article-meta { font-size: 14px; color: var(--text-muted); margin-bottom: 16px; }
+        .article-body {
+            max-width: 720px; margin: 0 auto; padding: 0 24px 80px;
+            font-size: 17px; line-height: 1.8; color: var(--text);
+        }
+        .article-body h2 { font-size: 28px; font-weight: 700; margin: 48px 0 16px; letter-spacing: -0.01em; }
+        .article-body p { margin-bottom: 20px; color: var(--text-muted); }
+        .article-body strong { color: var(--text); }
+        .article-body a { color: var(--purple-light); }
+        .article-body a:hover { color: var(--pink); }
+        .article-body ul { margin: 0 0 20px 24px; color: var(--text-muted); }
+        .article-body li { margin-bottom: 8px; }
+        .article-body code {
+            font-family: 'SF Mono', 'Fira Code', monospace;
+            font-size: 14px; color: var(--pink);
+            background: rgba(236, 72, 153, 0.1);
+            padding: 2px 8px; border-radius: 4px;
+        }
+        .article-back {
+            display: inline-flex; align-items: center; gap: 6px;
+            font-size: 14px; font-weight: 600; color: var(--text-muted);
+            margin-bottom: 24px;
+        }
+        .article-back:hover { color: var(--purple-light); }
+        .article-visual { margin: 32px 0 40px; text-align: center; }
+        .article-visual img {
+            max-width: 100%;
+            border-radius: 16px;
+            border: 1px solid var(--dark-border);
+            box-shadow: 0 8px 32px rgba(124,58,237,0.15);
+        }
+    </style>
+</head>
+<body>
+
+<nav>
+    <div class="container">
+        <a href="/" class="nav-logo">
+            <img src="/assets/logo-64.png" alt="NEXO Brain" class="logo-image">
+            <span class="logo-text">NEXO Brain</span>
+        </a>
+        <button class="mobile-menu-toggle" aria-label="Toggle navigation" onclick="toggleMobileMenu()">
+            <span></span><span></span><span></span>
+        </button>
+        <div class="nav-links">
+            <a href="/">Home</a>
+            <a href="/features/">Features</a>
+            <a href="/evolution/">Evolution</a>
+            <a href="/compare/">Compare</a>
+            <a href="/blog/">Blog</a>
+            <a href="/changelog/">Changelog</a>
+            <a href="/docs/">Docs</a>
+            <a href="https://github.com/wazionapps/nexo" class="nav-cta">GitHub</a>
+        </div>
+    </div>
+</nav>
+
+<section class="article-header">
+    <div class="container">
+        <a href="/blog/" class="article-back">← Back to blog</a>
+        <div class="article-meta">April 12, 2026 · Patch release · Packaging / update path</div>
+        <h1 class="section-title" style="font-size:clamp(28px,4.5vw,48px);max-width:920px;margin:0 auto 16px;">NEXO 5.3.1: Packaged Runtime Normalization for Real npm Users</h1>
+        <p class="section-subtitle" style="max-width:760px;margin:0 auto;">The public 5.3.0 line added <code>nexo uninstall</code>. 5.3.1 closes the next practical gap: older packaged installs could still carry legacy path assumptions after <code>nexo update</code>. This patch makes the installed runtime behave like a normal npm install again.</p>
+    </div>
+</section>
+
+<section>
+    <div class="article-body">
+        <div class="article-visual">
+            <img src="/assets/nexo-brain-infographic-v5.png" alt="NEXO Brain 5.3.1 release">
+        </div>
+
+        <p><strong>5.3.1 is a packaging and upgrade-path patch.</strong> It does not introduce a new cognitive subsystem. It fixes the path a real user feels after installation: upgrade the runtime, keep the data, and do not accidentally reintroduce legacy layout assumptions from earlier local installs or source checkouts.</p>
+
+        <h2>The user-facing problem</h2>
+        <p>NEXO has long separated runtime and user data conceptually, but a packaged install could still retain hidden assumptions from older layouts. In practice that meant wrappers, helpers, bootstrap refreshes, doctor checks, or personal-script flows could look at a legacy path such as <code>~/claude</code> or assume a source-tree shape that only makes sense inside the repo. A normal npm user should never need the source checkout present on disk to keep using <code>nexo update</code>.</p>
+
+        <h2>What 5.3.1 changes</h2>
+        <ul>
+            <li><strong>Canonical packaged home.</strong> Runtime-home resolution is normalized around <code>~/.nexo</code> for packaged installs instead of drifting toward legacy paths.</li>
+            <li><strong>Update refreshes packaged artifacts.</strong> After upgrade, managed bootstrap and client-facing packaged artifacts are refreshed so the installed runtime stays coherent.</li>
+            <li><strong>Doctor stays honest in user installs.</strong> Repo-only release-artifact drift checks no longer pollute packaged runtimes that are not source trees.</li>
+            <li><strong>Personal scripts stay on the packaged path.</strong> Script registry, helper resolution, startup preflight, and related runtime surfaces now consistently resolve against the canonical packaged home.</li>
+        </ul>
+
+        <h2>Why this matters</h2>
+        <p>The difference is operational, not cosmetic. A user can install NEXO from npm, keep years of their own data in <code>~/.nexo</code>, work on the source repo separately if they want to, and still use <code>nexo update</code> as a normal packaged workflow. The runtime remains replaceable; the data remains durable.</p>
+
+        <h2>Validation</h2>
+        <p>This release is backed by dedicated packaged-runtime tests covering runtime-home resolution, startup preflight, client sync, doctor behavior, update flow, and personal-script registry handling. It was also revalidated on a real packaged user runtime where legacy visible home paths were removed and personal scripts plus scheduled automations continued to work from the canonical <code>~/.nexo</code> install.</p>
+
+        <h2>Upgrade</h2>
+        <p>If you want the exact release record, open the <a href="/changelog/#v531">5.3.1 changelog section</a>. If you are already installed, the intended path is simply:</p>
+        <p><code>npm install -g nexo-brain@5.3.1</code><br><code>nexo update</code></p>
+        <p>Your data stays in <code>~/.nexo</code>. The runtime stays replaceable.</p>
+    </div>
+</section>
+
+<footer>
+    <div class="container">
+        <div class="footer-content">
+            <div class="footer-left">
+                Created by <strong>Francisco Cerd&agrave; Puigserver</strong> &amp; <strong>NEXO</strong> (Claude Opus) &bull; Built by <a href="https://www.wazion.com">WAzion</a> &bull; AGPL-3.0 License &bull; &copy; 2026
+            </div>
+            <div class="footer-links">
+                <a href="https://github.com/wazionapps/nexo">GitHub</a>
+                <a href="https://x.com/NEXOBRAIN">X / Twitter</a>
+                <a href="https://github.com/sponsors/wazionapps">Sponsor</a>
+                <a href="/docs/">Docs</a>
+                <a href="/compare/">Compare</a>
+                <a href="/blog/">Blog</a>
+                <a href="https://www.npmjs.com/package/nexo-brain">npm</a>
+                <a href="https://github.com/wazionapps/nexo/releases">Releases</a>
+            </div>
+            <div style="text-align:center;margin-top:12px;color:#6b7280;font-size:12px;">Last updated: April 2026</div>
+        </div>
+    </div>
+</footer>
+
+</body>
+</html>

--- a/changelog/index.html
+++ b/changelog/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Changelog — NEXO Brain</title>
-    <meta name="description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.3.0 adds nexo uninstall for clean runtime/data separation — stops crons, removes runtime, preserves user data for safe reinstall.">
+    <meta name="description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.3.1 normalizes packaged npm installs so nexo update stays anchored to ~/.nexo, refreshes packaged artifacts after upgrade, and avoids repo-only drift in user runtimes.">
     <meta name="robots" content="index, follow">
     <link rel="canonical" href="https://nexo-brain.com/changelog/">
 
@@ -12,7 +12,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://nexo-brain.com/changelog/">
     <meta property="og:title" content="Changelog — NEXO Brain">
-    <meta property="og:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.3.0 adds nexo uninstall for clean runtime/data separation — stops crons, removes runtime, preserves user data for safe reinstall.">
+    <meta property="og:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.3.1 normalizes packaged npm installs so nexo update stays anchored to ~/.nexo, refreshes packaged artifacts after upgrade, and avoids repo-only drift in user runtimes.">
     <meta property="og:image" content="https://nexo-brain.com/assets/og/og-changelog.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -20,7 +20,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Changelog — NEXO Brain">
-    <meta name="twitter:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.3.0 adds nexo uninstall for clean runtime/data separation — stops crons, removes runtime, preserves user data for safe reinstall.">
+    <meta name="twitter:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.3.1 normalizes packaged npm installs so nexo update stays anchored to ~/.nexo, refreshes packaged artifacts after upgrade, and avoids repo-only drift in user runtimes.">
     <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-changelog.png">
 
     <script type="application/ld+json">
@@ -28,7 +28,7 @@
         "@context": "https://schema.org",
         "@type": "CollectionPage",
         "name": "Changelog — NEXO Brain",
-        "description": "Full version history for NEXO Brain cognitive runtime. Latest release: v5.3.0 adds nexo uninstall for clean runtime/data separation — stops crons, removes runtime, preserves user data for safe reinstall.",
+        "description": "Full version history for NEXO Brain cognitive runtime. Latest release: v5.3.1 normalizes packaged npm installs so nexo update stays anchored to ~/.nexo, refreshes packaged artifacts after upgrade, and avoids repo-only drift in user runtimes.",
         "url": "https://nexo-brain.com/changelog/",
         "isPartOf": {
             "@type": "WebSite",
@@ -87,18 +87,22 @@
                 <h1 class="section-title" style="font-size:clamp(32px,5vw,56px);">Changelog</h1>
                 <p class="section-subtitle">Every feature, fix, and improvement &mdash; from the beginning, with the same visual clarity as the rest of the site.</p>
                 <div class="page-chip-row">
-                    <span class="page-chip">v5.3.0 live</span>
-                    <span class="page-chip">nexo uninstall &middot; Clean runtime/data separation</span>
-                    <span class="page-chip">Stop crons, preserve user data, reinstall cleanly</span>
+                    <span class="page-chip">v5.3.1 live</span>
+                    <span class="page-chip">Packaged runtime normalization</span>
+                    <span class="page-chip"><code>nexo update</code> now behaves like a normal npm user path</span>
                 </div>
                 <div class="hero-actions" style="justify-content:flex-start;">
-                    <a href="#v530" class="btn btn-primary">Start with v5.3.0</a>
+                    <a href="#v531" class="btn btn-primary">Start with v5.3.1</a>
                     <a href="#v400" class="btn btn-secondary">See v4.0.0</a>
                     <a href="/evolution/" class="btn btn-secondary">See Evolution</a>
                 </div>
             </div>
             <div class="page-visual">
                 <div class="page-stack">
+                    <div class="page-stack-card">
+                        <strong>v5.3.1</strong>
+                        <span>Packaged runtime normalization: <code>nexo update</code> stays anchored to <code>~/.nexo</code>, refreshes packaged artifacts, and stops installed runtimes from inheriting repo-only drift.</span>
+                    </div>
                     <div class="page-stack-card">
                         <strong>v5.3.0</strong>
                         <span><code>nexo uninstall</code> — stops all crons, removes runtime, preserves user data. Clean separation of runtime vs user data for safe reinstall.</span>
@@ -151,6 +155,29 @@
             <div>
                 <div id="changelog-page-meta" class="changelog-page-meta">Loading release pages…</div>
                 <div id="changelog-pager" class="changelog-pager" aria-label="Changelog pagination"></div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<!-- v5.3.1 packaged runtime normalization -->
+<section id="v531" class="section-compact" style="background:linear-gradient(135deg,#0b1120 0%,#7c3aed 55%,#ec4899 100%);">
+    <div class="container">
+        <div class="section-label">New in v5.3.1 <span style="opacity:.5;font-weight:400;">&mdash; April 12, 2026</span></div>
+        <h2 class="section-title">Packaged Runtime Normalization &amp; Clean <code>nexo update</code> Path</h2>
+        <p class="section-subtitle">
+            A patch release for real npm users. Installed runtimes now stay anchored to <code>~/.nexo</code>, packaged bootstrap and client artifacts are refreshed after upgrade, repo-only release-artifact drift is skipped inside user installs, and personal-script/runtime path resolution stays on the canonical packaged home.
+        </p>
+        <div class="cognitive-group">
+            <div class="cognitive-grid" style="grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:16px;">
+                <div class="cognitive-card">
+                    <h3>No more legacy path fallback</h3>
+                    <p>Packaged wrappers, helpers, hooks, and migrations now resolve the runtime from <code>~/.nexo</code> instead of drifting back to legacy <code>~/claude</code> assumptions or a local source checkout. A normal user install behaves like a normal user install again.</p>
+                </div>
+                <div class="cognitive-card">
+                    <h3>Update keeps packaged installs coherent</h3>
+                    <p><code>nexo update</code> now refreshes packaged client/bootstrap artifacts after upgrade and keeps personal scripts, startup preflight, and doctor behavior aligned with the packaged runtime. Your data stays in <code>~/.nexo</code>; the runtime stays replaceable.</p>
+                </div>
             </div>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents</title>
-    <meta name="description" content="Libre/open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.0 ships bilingual response discipline with Spanish and English high-stakes keyword parity and bilingual negation suppression, a numeric safeguard layer on top of the confidence decision tree with positive context signals, and a cortex-quality cache reader that closes the write-only snapshot loop from the v5.1.0 cortex-cycle cron. Builds on closed evolution, adaptive, cognitive, and skills loops, bitemporal JSON-LD/GraphML knowledge graph export, the OpenTelemetry tool-span path, and lint/security/coverage/release-readiness gates on every PR across 150+ MCP tools.">
+    <meta name="description" content="Libre/open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.1 normalizes packaged npm installs so nexo update stays anchored to ~/.nexo, refreshes packaged bootstrap and client artifacts after upgrade, avoids repo-only drift in installed runtimes, and keeps personal scripts on the canonical packaged path.">
     <meta name="keywords" content="AI memory, cognitive architecture, MCP, Claude Code, Codex, Claude Desktop, agent memory, vector search, AI agents, shared brain, open source">
     <meta name="author" content="WAzion">
     <meta name="robots" content="index, follow">
@@ -14,7 +14,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://nexo-brain.com">
     <meta property="og:title" content="NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents">
-    <meta property="og:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.0 ships bilingual response discipline with Spanish and English high-stakes keyword parity and bilingual negation suppression, a numeric safeguard layer on top of the confidence decision tree with positive context signals, and a cortex-quality cache reader that closes the write-only snapshot loop from the v5.1.0 cortex-cycle cron. Builds on closed evolution, adaptive, cognitive, and skills loops, bitemporal JSON-LD/GraphML knowledge graph export, the OpenTelemetry tool-span path, and lint/security/coverage/release-readiness gates on every PR across 150+ MCP tools.">
+    <meta property="og:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.1 normalizes packaged npm installs so nexo update stays anchored to ~/.nexo, refreshes packaged bootstrap and client artifacts after upgrade, avoids repo-only drift in installed runtimes, and keeps personal scripts on the canonical packaged path.">
     <meta property="og:image" content="https://nexo-brain.com/assets/og/og-home.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -22,7 +22,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents">
-    <meta name="twitter:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.0 ships bilingual response discipline with Spanish and English high-stakes keyword parity and bilingual negation suppression, a numeric safeguard layer on top of the confidence decision tree with positive context signals, and a cortex-quality cache reader that closes the write-only snapshot loop from the v5.1.0 cortex-cycle cron. Builds on closed evolution, adaptive, cognitive, and skills loops, bitemporal JSON-LD/GraphML knowledge graph export, the OpenTelemetry tool-span path, and lint/security/coverage/release-readiness gates on every PR across 150+ MCP tools.">
+    <meta name="twitter:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.1 normalizes packaged npm installs so nexo update stays anchored to ~/.nexo, refreshes packaged bootstrap and client artifacts after upgrade, avoids repo-only drift in installed runtimes, and keeps personal scripts on the canonical packaged path.">
     <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-home.png">
 
     <!-- Google Analytics (GA4) -->
@@ -46,12 +46,12 @@
         "@context": "https://schema.org",
         "@type": "SoftwareApplication",
         "name": "NEXO Brain",
-        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.0 ships bilingual response discipline with Spanish and English high-stakes keyword parity and bilingual negation suppression, a numeric safeguard layer on top of the confidence decision tree with positive context signals, and a cortex-quality cache reader that closes the write-only snapshot loop from the v5.1.0 cortex-cycle cron. Builds on closed evolution, adaptive, cognitive, and skills loops, bitemporal JSON-LD/GraphML knowledge graph export, the OpenTelemetry tool-span path, and lint/security/coverage/release-readiness gates on every PR across 150+ MCP tools.",
+        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.1 normalizes packaged npm installs so nexo update stays anchored to ~/.nexo, refreshes packaged bootstrap and client artifacts after upgrade, avoids repo-only drift in installed runtimes, and keeps personal scripts on the canonical packaged path.",
         "applicationCategory": "DeveloperApplication",
         "operatingSystem": "macOS, Linux, Windows",
         "url": "https://nexo-brain.com",
         "downloadUrl": "https://www.npmjs.com/package/nexo-brain",
-        "softwareVersion": "5.3.0",
+        "softwareVersion": "5.3.1",
         "license": "https://www.gnu.org/licenses/agpl-3.0",
         "author": {
             "@type": "Organization",
@@ -88,7 +88,7 @@
         "@type": "WebSite",
         "name": "NEXO Brain",
         "url": "https://nexo-brain.com",
-        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.0 ships bilingual response discipline with Spanish and English high-stakes keyword parity and bilingual negation suppression, a numeric safeguard layer on top of the confidence decision tree with positive context signals, and a cortex-quality cache reader that closes the write-only snapshot loop from the v5.1.0 cortex-cycle cron. Builds on closed evolution, adaptive, cognitive, and skills loops, bitemporal JSON-LD/GraphML knowledge graph export, the OpenTelemetry tool-span path, and lint/security/coverage/release-readiness gates on every PR across 150+ MCP tools.",
+        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.1 normalizes packaged npm installs so nexo update stays anchored to ~/.nexo, refreshes packaged bootstrap and client artifacts after upgrade, avoids repo-only drift in installed runtimes, and keeps personal scripts on the canonical packaged path.",
         "publisher": {
             "@type": "Organization",
             "name": "WAzion",
@@ -697,7 +697,7 @@
     <div class="container">
         <div class="hero-badge fade-up">
             <span class="dot"></span>
-            <span id="version-badge">v5.3.0</span> &mdash; Bilingual response discipline (Spanish + English high-stakes detection, negation-aware), numeric confidence safeguard with positive context signals, and a cortex-quality cache reader that closes the v5.1.0 cron's write-only snapshot loop
+            <span id="version-badge">v5.3.1</span> &mdash; Packaged runtime normalization so <code>nexo update</code> stays anchored to <code>~/.nexo</code>, refreshes packaged artifacts, and behaves like a normal npm install
         </div>
         <div class="fade-up" style="display:flex;gap:8px;justify-content:center;margin-bottom:12px;">
             <img src="https://img.shields.io/npm/v/nexo-brain?color=7C3AED&label=npm" alt="npm version">
@@ -1156,9 +1156,9 @@
 
         <div class="release-evolution-grid">
             <div class="release-evolution-card">
-                <div class="release-evolution-version">v5.3.0</div>
-                <h3>Bilingual response discipline and closed cortex-quality loop</h3>
-                <p>The response-contract layer now detects high-stakes context in Spanish as well as English and suppresses false positives when the text explicitly disclaims the sensitive area ("sin afectar producción", "don't touch prod"). A numeric safeguard sits on top of the existing decision tree with positive signals that reward loaded context. The <code>nexo_cortex_quality</code> tool finally reads the snapshot that the <code>cortex-cycle</code> cron has been writing every 6h since v5.1.0, with silent fallback to the live path on any failure.</p>
+                <div class="release-evolution-version">v5.3.1</div>
+                <h3>Packaged npm installs finally behave like packaged npm installs</h3>
+                <p><code>nexo update</code> now keeps installed runtimes anchored to <code>~/.nexo</code>, refreshes packaged bootstrap and client artifacts after upgrade, skips repo-only release drift inside user installs, and keeps personal scripts on the canonical packaged path instead of falling back to legacy <code>~/claude</code> assumptions.</p>
             </div>
             <div class="release-evolution-card">
                 <div class="release-evolution-version">v5.1.0</div>

--- a/llms.txt
+++ b/llms.txt
@@ -1,8 +1,13 @@
 # NEXO Brain
 
-> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.2.0).
+> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.3.1).
 
-NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. Version 5.2.0 ships bilingual response discipline with Spanish and English high-stakes keyword parity and bilingual negation suppression, a numeric confidence safeguard layered on top of the existing response-contract decision tree with positive context signals (pre-action context hits and known project-atlas areas), and a cortex-quality cache reader that finally consumes the write-only snapshot that the `nexo-cortex-cycle` cron has been writing every 6h since v5.1.0. Builds on v5.1.0's closed evolution, adaptive, cognitive, and skills loops, bitemporal knowledge graph export to JSON-LD and GraphML with `as_of` historical replay, OpenTelemetry tool-span path behind a soft-import, and lint, security, coverage, and release-readiness gates on every PR, plus v5.0's goal, decision, outcome, reusable-skill, and public-proof loop across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, multimodal memory refs, pre-compaction auto-flush, a public claim wiki, readable memory export, richer user-state adaptation, long-horizon overnight analysis, and 150+ MCP tools.
+NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. It adds a local shared brain across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, smarter retrieval defaults, long-horizon overnight analysis, and 150+ MCP tools.
+
+v5.3.1: packaged runtime normalization — `nexo update` keeps normal npm installs anchored to `~/.nexo` and refreshes packaged artifacts cleanly
+v5.3.0: nexo uninstall — stops crons, removes runtime, preserves user data for clean reinstall
+v5.2.1: fix deep-sleep datetime crash in apply_findings.py; cortex_decide() auto-creates outcomes closing decision→verification loop
+v5.2.0: bilingual response-discipline scoring + cortex quality cache reader
 
 ## Core Product Model
 
@@ -12,33 +17,12 @@ NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cogniti
 - Codex is supported as both terminal client and automation backend.
 - Claude Desktop can share the same brain through MCP.
 
-## Current Release Focus
-
-- Bilingual response discipline: Spanish + English high-stakes detection with bilingual negation suppression, so boundary statements like "sin afectar producción" / "without touching production" no longer trigger false positives.
-- Positive signals on the confidence score so tasks that loaded real context and operate in a known project area are rewarded, not punished alongside unprepared ones.
-- Numeric safeguard layered over the boolean response-contract decision tree, monotonic over the existing rules (can only make discipline stricter, never looser).
-- Cortex-quality cache reader: `nexo_cortex_quality` now serves the snapshot that the `nexo-cortex-cycle` cron writes every 6 hours, with silent fallback to live SQL computation on any failure. Observable path via `"source": "cache" | "live"` in the response.
-- Goal profiles and Decision Cortex v2 keep shaping higher-stakes recommendations instead of leaving strategy selection to raw prompting.
-- Outcomes, impact scoring, and structured pattern capture connect action, result, and future prioritization more tightly.
-- Repeated winning patterns can seed or promote reusable skills, while poor evidence can demote or retire them.
-- Public proof combines the LoCoMo memory result with a broader operator runtime pack so the website reflects more than one memory benchmark.
-
 ## Key Features
 
 - Three-store memory: Sensory Register, Short-Term Memory, Long-Term Memory
 - Semantic search with local embeddings and optional HNSW acceleration
 - Claim graph, trust scoring, metacognitive guard, cognitive dissonance detection
-- Multimodal memory references for images, audio, video, PDFs, and other non-text artifacts
-- Structured auto-flush before compaction so actionable continuity survives compression
-- Public claim/wiki tools with evidence, freshness, verification state, and linting
-- Readable markdown memory export for auditability
-- Stronger inspectable user-state model beyond shallow sentiment heuristics
-- Public retrieval knobs for hybrid weighting, decomposition, dream exclusion, and dormant-memory handling
-- Explicit backend contract/status for newer memory layers
 - Episodic memory, reminders, learnings, followups, and session continuity
-- 24-hour hot context for recent operational continuity across sessions and channels
-- Transcript fallback tools for recent Claude Code / Codex conversations when the memory layer is too thin
-- Live system catalog for tools, plugins, skills, scripts, crons, projects, and artifacts
 - Context continuity across Claude Code compaction via hooks
 - Shared-brain client sync for Claude Code, Codex, and Claude Desktop
 - Managed bootstrap parity for `~/.claude/CLAUDE.md` and `~/.codex/AGENTS.md`
@@ -106,7 +90,6 @@ nexo clients sync
 - Changelog: https://nexo-brain.com/changelog/
 - Blog: https://nexo-brain.com/blog/
 - Docs: https://nexo-brain.com/docs/
-- Install flow: https://nexo-brain.com/docs/install-flow/
 - GitHub: https://github.com/wazionapps/nexo
 - npm: https://www.npmjs.com/package/nexo-brain
 


### PR DESCRIPTION
## Summary
- update site home/changelog/blog surfaces for v5.3.1 packaged runtime normalization
- add the v5.3.1 release article
- sync public README and llms.txt surfaces to 5.3.1

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 scripts/verify_release_readiness.py --ci --website-root /tmp/nexo-site-v531