### PR TITLE
site(v5.3.2): publish runtime boundary hardening

### DIFF
--- a/.well-known/llms.txt
+++ b/.well-known/llms.txt
@@ -1,9 +1,10 @@
 # NEXO Brain
 
-> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.3.1).
+> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.3.2).
 
 NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. It adds a local shared brain across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, smarter retrieval defaults, long-horizon overnight analysis, and 150+ MCP tools.
 
+v5.3.2: runtime boundary hardening — packaged installs track core runtime artifacts, `nexo scripts` stops mixing core with personal, and `nexo update` migrates legacy heartbeat wrappers into managed core hooks
 v5.3.1: packaged runtime normalization — `nexo update` keeps normal npm installs anchored to `~/.nexo` and refreshes packaged artifacts cleanly
 v5.3.0: nexo uninstall — stops crons, removes runtime, preserves user data for clean reinstall
 v5.2.1: fix deep-sleep datetime crash in apply_findings.py; cortex_decide() auto-creates outcomes closing decision→verification loop

--- a/blog/index.html
+++ b/blog/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Blog — NEXO Brain</title>
-    <meta name="description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, now including the v5.3.1 packaged runtime normalization release that makes nexo update behave like a normal npm user path.">
+    <meta name="description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, now including the v5.3.2 runtime-boundary release that makes core product surface and personal runtime behave like separate layers again.">
     <meta name="robots" content="index, follow">
     <link rel="canonical" href="https://nexo-brain.com/blog/">
 
@@ -12,7 +12,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://nexo-brain.com/blog/">
     <meta property="og:title" content="Blog — NEXO Brain">
-    <meta property="og:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, now including the v5.3.1 packaged runtime normalization release that makes nexo update behave like a normal npm user path.">
+    <meta property="og:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, now including the v5.3.2 runtime-boundary release that makes core product surface and personal runtime behave like separate layers again.">
     <meta property="og:image" content="https://nexo-brain.com/assets/og/og-blog.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -20,7 +20,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Blog — NEXO Brain">
-    <meta name="twitter:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, now including the v5.3.1 packaged runtime normalization release that makes nexo update behave like a normal npm user path.">
+    <meta name="twitter:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, now including the v5.3.2 runtime-boundary release that makes core product surface and personal runtime behave like separate layers again.">
     <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-blog.png">
 
     <script type="application/ld+json">
@@ -28,7 +28,7 @@
         "@context": "https://schema.org",
         "@type": "CollectionPage",
         "name": "Blog — NEXO Brain",
-        "description": "Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, now including the v5.3.1 packaged runtime normalization release that makes nexo update behave like a normal npm user path.",
+        "description": "Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, now including the v5.3.2 runtime-boundary release that makes core product surface and personal runtime behave like separate layers again.",
         "url": "https://nexo-brain.com/blog/",
         "isPartOf": {
             "@type": "WebSite",
@@ -134,7 +134,7 @@
                     <span class="page-chip">Competitive analysis</span>
                 </div>
                 <div class="hero-actions" style="justify-content:flex-start;">
-                    <a href="/blog/nexo-5-3-1-packaged-runtime-normalization/" class="btn btn-primary">Read latest release</a>
+                    <a href="/blog/nexo-5-3-2-runtime-boundary-hardening/" class="btn btn-primary">Read latest release</a>
                     <a href="/changelog/" class="btn btn-secondary">Latest release notes</a>
                     <a href="/evolution/" class="btn btn-secondary">See Evolution</a>
                 </div>
@@ -143,22 +143,22 @@
                 <div class="section-label">Latest release</div>
                 <div class="blog-featured-meta">
                     <span class="compare-chip">April 12, 2026</span>
-                    <span class="compare-chip">Packaged runtime normalization</span>
+                    <span class="compare-chip">Runtime boundary hardening</span>
                 </div>
-                <h2>NEXO 5.3.1: Packaged Runtime Normalization for Real npm Users</h2>
-                <p>NEXO 5.3.1 fixes the packaged install path that older users actually feel in the wild: <code>nexo update</code> now stays anchored to <code>~/.nexo</code>, refreshes packaged bootstrap/client artifacts after upgrade, skips repo-only drift inside installed runtimes, and keeps personal scripts on the canonical packaged path.</p>
+                <h2>NEXO 5.3.2: Runtime Boundary Hardening for Real Shared-Brain Installs</h2>
+                <p>NEXO 5.3.2 finishes the packaging cleanup by making the boundary explicit: packaged core scripts/hooks are tracked as product artifacts, <code>nexo scripts</code> stops mixing them into the personal bucket, and <code>nexo update</code> migrates the last legacy heartbeat wrappers into managed core hooks.</p>
                 <div class="hero-actions" style="justify-content:flex-start;margin-bottom:18px;">
-                    <a href="/blog/nexo-5-3-1-packaged-runtime-normalization/" class="btn btn-primary">Open article</a>
-                    <a href="/changelog/#v531" class="btn btn-secondary">Open changelog</a>
+                    <a href="/blog/nexo-5-3-2-runtime-boundary-hardening/" class="btn btn-primary">Open article</a>
+                    <a href="/changelog/#v532" class="btn btn-secondary">Open changelog</a>
                 </div>
                 <div class="blog-mini-stack">
                     <div class="blog-mini-card">
                         <strong>Companion view</strong>
-                        <span><a href="/changelog/#v531">The 5.3.1 changelog section</a></span>
+                        <span><a href="/changelog/#v532">The 5.3.2 changelog section</a></span>
                     </div>
                     <div class="blog-mini-card">
                         <strong>Previous release</strong>
-                        <span><a href="/blog/nexo-5-2-0-bilingual-response-discipline/">NEXO 5.2.0: Bilingual Response Discipline &amp; Closed Cortex-Quality Loop</a>.</span>
+                        <span><a href="/blog/nexo-5-3-1-packaged-runtime-normalization/">NEXO 5.3.1: Packaged Runtime Normalization for Real npm Users</a>.</span>
                     </div>
                 </div>
             </div>
@@ -170,6 +170,13 @@
 <section class="section-flush-top">
     <div class="container">
         <div class="blog-grid">
+
+            <div class="blog-card">
+                <div class="blog-card-date">April 12, 2026</div>
+                <h2><a href="/blog/nexo-5-3-2-runtime-boundary-hardening/">NEXO 5.3.2: Runtime Boundary Hardening for Real Shared-Brain Installs</a></h2>
+                <p>A trust-boundary patch for packaged users: NEXO now tracks which runtime scripts and hooks are product artifacts, `nexo scripts` stops mixing them into the personal bucket, and `nexo update` migrates the last legacy Claude Code heartbeat wrappers into managed core hooks.</p>
+                <a href="/blog/nexo-5-3-2-runtime-boundary-hardening/" class="read-more">Read article <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14"/><path d="M12 5l7 7-7 7"/></svg></a>
+            </div>
 
             <div class="blog-card">
                 <div class="blog-card-date">April 12, 2026</div>

--- a/blog/nexo-5-3-2-runtime-boundary-hardening/index.html
+++ b/blog/nexo-5-3-2-runtime-boundary-hardening/index.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <title>NEXO 5.3.2: Runtime Boundary Hardening for Real Shared-Brain Installs</title>
+    <meta name="description" content="NEXO 5.3.2 turns the packaged runtime boundary into something explicit and testable: core runtime scripts/hooks are tracked as product artifacts, nexo scripts stops mixing them into the personal bucket, and nexo update migrates legacy heartbeat wrappers into managed core hooks.">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://nexo-brain.com/blog/nexo-5-3-2-runtime-boundary-hardening/">
+
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://nexo-brain.com/blog/nexo-5-3-2-runtime-boundary-hardening/">
+    <meta property="og:title" content="NEXO 5.3.2: Runtime Boundary Hardening for Real Shared-Brain Installs">
+    <meta property="og:description" content="A trust-boundary patch for packaged users: core runtime scripts/hooks are now tracked explicitly, nexo scripts stops mixing them into the personal bucket, and nexo update migrates legacy heartbeat wrappers into managed core hooks.">
+    <meta property="og:image" content="https://nexo-brain.com/assets/og/og-blog.png">
+    <meta property="article:published_time" content="2026-04-12">
+    <meta property="article:author" content="Francisco Cerda Puigserver">
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="NEXO 5.3.2: Runtime Boundary Hardening for Real Shared-Brain Installs">
+    <meta name="twitter:description" content="Packaged users now get an explicit core-vs-personal boundary, managed heartbeat hooks, and nexo update that cleans the last legacy heartbeat wrappers out of the personal bucket.">
+    <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-blog.png">
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-1LNEMCJMS7"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-1LNEMCJMS7');
+    </script>
+
+    <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicon-32.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
+    <link rel="stylesheet" href="/assets/style.css">
+
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "NEXO 5.3.2: Runtime Boundary Hardening for Real Shared-Brain Installs",
+        "description": "NEXO 5.3.2 turns the packaged runtime boundary into something explicit and testable: core runtime scripts/hooks are tracked as product artifacts, nexo scripts stops mixing them into the personal bucket, and nexo update migrates legacy heartbeat wrappers into managed core hooks.",
+        "datePublished": "2026-04-12",
+        "dateModified": "2026-04-12",
+        "author": {
+            "@type": "Person",
+            "name": "Francisco Cerda Puigserver"
+        },
+        "publisher": {
+            "@type": "Organization",
+            "name": "WAzion",
+            "url": "https://www.wazion.com"
+        },
+        "mainEntityOfPage": {
+            "@type": "WebPage",
+            "@id": "https://nexo-brain.com/blog/nexo-5-3-2-runtime-boundary-hardening/"
+        },
+        "url": "https://nexo-brain.com/blog/nexo-5-3-2-runtime-boundary-hardening/",
+        "image": "https://nexo-brain.com/assets/nexo-brain-infographic-v5.png",
+        "keywords": ["NEXO 5.3.2", "nexo update", "personal scripts", "core runtime artifacts", "Claude Code hooks", "~/.nexo"]
+    }
+    </script>
+
+    <style>
+        .article-header { padding-top: 128px; padding-bottom: 40px; text-align: center; }
+        .article-meta { font-size: 14px; color: var(--text-muted); margin-bottom: 16px; }
+        .article-body {
+            max-width: 720px; margin: 0 auto; padding: 0 24px 80px;
+            font-size: 17px; line-height: 1.8; color: var(--text);
+        }
+        .article-body h2 { font-size: 28px; font-weight: 700; margin: 48px 0 16px; letter-spacing: -0.01em; }
+        .article-body p { margin-bottom: 20px; color: var(--text-muted); }
+        .article-body strong { color: var(--text); }
+        .article-body a { color: var(--purple-light); }
+        .article-body a:hover { color: var(--pink); }
+        .article-body ul { margin: 0 0 20px 24px; color: var(--text-muted); }
+        .article-body li { margin-bottom: 8px; }
+        .article-body code {
+            font-family: 'SF Mono', 'Fira Code', monospace;
+            font-size: 14px; color: var(--pink);
+            background: rgba(236, 72, 153, 0.1);
+            padding: 2px 8px; border-radius: 4px;
+        }
+        .article-back {
+            display: inline-flex; align-items: center; gap: 6px;
+            font-size: 14px; font-weight: 600; color: var(--text-muted);
+            margin-bottom: 24px;
+        }
+        .article-back:hover { color: var(--purple-light); }
+        .article-visual { margin: 32px 0 40px; text-align: center; }
+        .article-visual img {
+            max-width: 100%;
+            border-radius: 16px;
+            border: 1px solid var(--dark-border);
+            box-shadow: 0 8px 32px rgba(124,58,237,0.15);
+        }
+    </style>
+</head>
+<body>
+
+<nav>
+    <div class="container">
+        <a href="/" class="nav-logo">
+            <img src="/assets/logo-64.png" alt="NEXO Brain" class="logo-image">
+            <span class="logo-text">NEXO Brain</span>
+        </a>
+        <button class="mobile-menu-toggle" aria-label="Toggle navigation" onclick="toggleMobileMenu()">
+            <span></span><span></span><span></span>
+        </button>
+        <div class="nav-links">
+            <a href="/">Home</a>
+            <a href="/features/">Features</a>
+            <a href="/evolution/">Evolution</a>
+            <a href="/compare/">Compare</a>
+            <a href="/blog/">Blog</a>
+            <a href="/changelog/">Changelog</a>
+            <a href="/docs/">Docs</a>
+            <a href="https://github.com/wazionapps/nexo" class="nav-cta">GitHub</a>
+        </div>
+    </div>
+</nav>
+
+<section class="article-header">
+    <div class="container">
+        <a href="/blog/" class="article-back">← Back to blog</a>
+        <div class="article-meta">April 12, 2026 · Patch release · Runtime boundary / packaged upgrade path</div>
+        <h1 class="section-title" style="font-size:clamp(28px,4.5vw,48px);max-width:920px;margin:0 auto 16px;">NEXO 5.3.2: Runtime Boundary Hardening for Real Shared-Brain Installs</h1>
+        <p class="section-subtitle" style="max-width:760px;margin:0 auto;">5.3.1 fixed the packaged path. 5.3.2 fixes the trust boundary on top of that: a normal packaged user should be able to tell which scripts are product surface, which scripts are theirs, and let <code>nexo update</code> keep those layers clean over time.</p>
+    </div>
+</section>
+
+<section>
+    <div class="article-body">
+        <div class="article-visual">
+            <img src="/assets/nexo-brain-infographic-v5.png" alt="NEXO Brain 5.3.2 release">
+        </div>
+
+        <p><strong>5.3.2 is a runtime-boundary patch.</strong> It does not add a brand-new cognitive subsystem. It makes a subtler but equally important promise enforceable: packaged core runtime files should not masquerade as operator-owned scripts just because they happen to live under the same runtime home.</p>
+
+        <h2>The user-facing problem</h2>
+        <p>After 5.3.1, packaged installs were finally anchored to <code>~/.nexo</code> again, but the runtime still had an honesty problem: some packaged core scripts and hook shims could be discovered through the same filesystem bucket used for personal scripts. That makes the product feel unreliable because the user cannot easily tell what belongs to the public runtime and what belongs to their own operator layer.</p>
+
+        <h2>What 5.3.2 changes</h2>
+        <ul>
+            <li><strong>Runtime core-artifacts manifest.</strong> Packaged installs now persist which top-level runtime scripts and hooks are shipped as product artifacts. The personal script registry reads that manifest, so a file can be classified as core even if it physically lives under <code>~/.nexo/scripts</code>.</li>
+            <li><strong>Heartbeat hooks are promoted into core.</strong> The Claude Code heartbeat wrappers now live under the managed hooks surface. <code>nexo update</code> rewrites managed client configs to those core hook paths and removes the retired legacy wrappers from the personal runtime bucket.</li>
+            <li><strong>Stale public surface is removed.</strong> A public LaunchAgent template that referenced a non-packaged GitHub-monitor script is removed instead of being quietly treated as “maybe core later.” If something is not actually packaged core, it should not pretend to be.</li>
+        </ul>
+
+        <h2>Why this matters</h2>
+        <p>The difference is operational, not cosmetic. A user can install NEXO from npm, keep years of their own data in <code>~/.nexo</code>, work on the source repo separately if they want to, and still use <code>nexo update</code> without the packaged product surface bleeding into their personal automation bucket. The runtime remains replaceable; the data remains durable; the ownership boundary is explicit.</p>
+
+        <h2>Client nuance stays honest</h2>
+        <p>Claude Code still has the deepest hook surface, so it is where heartbeat and protocol hooks are managed most tightly. Codex and Claude Desktop share the same brain and supported runtime surfaces, but this release does not fake hook parity where the client does not provide it. Product surface stays shared; hook depth stays client-specific.</p>
+
+        <h2>Validation</h2>
+        <p>This release is backed by dedicated regression coverage for runtime core-artifacts manifests, packaged-update cleanup of retired heartbeat files, client-sync hook rewrites, and the personal-script classification rules. The real runtime audit now also yields zero collisions between the personal bucket and the public core product surface after the new manifest is applied.</p>
+
+        <h2>Upgrade</h2>
+        <p>If you want the exact release record, open the <a href="/changelog/#v532">5.3.2 changelog section</a>. If you are already installed, the intended path is simply:</p>
+        <p><code>npm install -g nexo-brain@5.3.2</code><br><code>nexo update</code></p>
+        <p>Your data stays in <code>~/.nexo</code>. The runtime stays replaceable. The product surface and your own runtime layer stop pretending to be the same thing.</p>
+    </div>
+</section>
+
+<footer>
+    <div class="container">
+        <div class="footer-content">
+            <div class="footer-left">
+                Created by <strong>Francisco Cerd&agrave; Puigserver</strong> &amp; <strong>NEXO</strong> (Claude Opus) &bull; Built by <a href="https://www.wazion.com">WAzion</a> &bull; AGPL-3.0 License &bull; &copy; 2026
+            </div>
+            <div class="footer-links">
+                <a href="https://github.com/wazionapps/nexo">GitHub</a>
+                <a href="https://x.com/NEXOBRAIN">X / Twitter</a>
+                <a href="https://github.com/sponsors/wazionapps">Sponsor</a>
+                <a href="/docs/">Docs</a>
+                <a href="/compare/">Compare</a>
+                <a href="/blog/">Blog</a>
+                <a href="https://www.npmjs.com/package/nexo-brain">npm</a>
+                <a href="https://github.com/wazionapps/nexo/releases">Releases</a>
+            </div>
+            <div style="text-align:center;margin-top:12px;color:#6b7280;font-size:12px;">Last updated: April 2026</div>
+        </div>
+    </div>
+</footer>
+
+</body>
+</html>

--- a/changelog/index.html
+++ b/changelog/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Changelog — NEXO Brain</title>
-    <meta name="description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.3.1 normalizes packaged npm installs so nexo update stays anchored to ~/.nexo, refreshes packaged artifacts after upgrade, and avoids repo-only drift in user runtimes.">
+    <meta name="description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.3.2 hardens the runtime boundary for packaged users by separating core runtime artifacts from personal scripts and migrating legacy heartbeat wrappers into managed hooks.">
     <meta name="robots" content="index, follow">
     <link rel="canonical" href="https://nexo-brain.com/changelog/">
 
@@ -12,7 +12,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://nexo-brain.com/changelog/">
     <meta property="og:title" content="Changelog — NEXO Brain">
-    <meta property="og:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.3.1 normalizes packaged npm installs so nexo update stays anchored to ~/.nexo, refreshes packaged artifacts after upgrade, and avoids repo-only drift in user runtimes.">
+    <meta property="og:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.3.2 hardens the runtime boundary for packaged users by separating core runtime artifacts from personal scripts and migrating legacy heartbeat wrappers into managed hooks.">
     <meta property="og:image" content="https://nexo-brain.com/assets/og/og-changelog.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -20,7 +20,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Changelog — NEXO Brain">
-    <meta name="twitter:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.3.1 normalizes packaged npm installs so nexo update stays anchored to ~/.nexo, refreshes packaged artifacts after upgrade, and avoids repo-only drift in user runtimes.">
+    <meta name="twitter:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.3.2 hardens the runtime boundary for packaged users by separating core runtime artifacts from personal scripts and migrating legacy heartbeat wrappers into managed hooks.">
     <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-changelog.png">
 
     <script type="application/ld+json">
@@ -28,7 +28,7 @@
         "@context": "https://schema.org",
         "@type": "CollectionPage",
         "name": "Changelog — NEXO Brain",
-        "description": "Full version history for NEXO Brain cognitive runtime. Latest release: v5.3.1 normalizes packaged npm installs so nexo update stays anchored to ~/.nexo, refreshes packaged artifacts after upgrade, and avoids repo-only drift in user runtimes.",
+        "description": "Full version history for NEXO Brain cognitive runtime. Latest release: v5.3.2 hardens the runtime boundary for packaged users by separating core runtime artifacts from personal scripts and migrating legacy heartbeat wrappers into managed hooks.",
         "url": "https://nexo-brain.com/changelog/",
         "isPartOf": {
             "@type": "WebSite",
@@ -87,12 +87,12 @@
                 <h1 class="section-title" style="font-size:clamp(32px,5vw,56px);">Changelog</h1>
                 <p class="section-subtitle">Every feature, fix, and improvement &mdash; from the beginning, with the same visual clarity as the rest of the site.</p>
                 <div class="page-chip-row">
-                    <span class="page-chip">v5.3.1 live</span>
-                    <span class="page-chip">Packaged runtime normalization</span>
-                    <span class="page-chip"><code>nexo update</code> now behaves like a normal npm user path</span>
+                    <span class="page-chip">v5.3.2 live</span>
+                    <span class="page-chip">Runtime boundary hardening</span>
+                    <span class="page-chip"><code>nexo scripts</code> now separates packaged core from personal runtime</span>
                 </div>
                 <div class="hero-actions" style="justify-content:flex-start;">
-                    <a href="#v531" class="btn btn-primary">Start with v5.3.1</a>
+                    <a href="#v532" class="btn btn-primary">Start with v5.3.2</a>
                     <a href="#v400" class="btn btn-secondary">See v4.0.0</a>
                     <a href="/evolution/" class="btn btn-secondary">See Evolution</a>
                 </div>
@@ -100,8 +100,8 @@
             <div class="page-visual">
                 <div class="page-stack">
                     <div class="page-stack-card">
-                        <strong>v5.3.1</strong>
-                        <span>Packaged runtime normalization: <code>nexo update</code> stays anchored to <code>~/.nexo</code>, refreshes packaged artifacts, and stops installed runtimes from inheriting repo-only drift.</span>
+                        <strong>v5.3.2</strong>
+                        <span>Runtime boundary hardening: packaged installs now track core runtime artifacts explicitly, keep them out of the personal bucket, and migrate legacy heartbeat wrappers into managed Claude Code hooks.</span>
                     </div>
                     <div class="page-stack-card">
                         <strong>v5.3.0</strong>
@@ -155,6 +155,29 @@
             <div>
                 <div id="changelog-page-meta" class="changelog-page-meta">Loading release pages…</div>
                 <div id="changelog-pager" class="changelog-pager" aria-label="Changelog pagination"></div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<!-- v5.3.2 runtime boundary hardening -->
+<section id="v532" class="section-compact" style="background:linear-gradient(135deg,#0b1120 0%,#7c3aed 55%,#ec4899 100%);">
+    <div class="container">
+        <div class="section-label">New in v5.3.2 <span style="opacity:.5;font-weight:400;">&mdash; April 12, 2026</span></div>
+        <h2 class="section-title">Runtime Boundary Hardening &amp; Honest Core vs Personal Separation</h2>
+        <p class="section-subtitle">
+            A trust-boundary patch for packaged users. NEXO now persists which scripts and hooks belong to the packaged core runtime, stops mixing them into the personal-script bucket, migrates the legacy Claude Code heartbeat wrappers into managed core hooks, and removes a stale public LaunchAgent template that was not backed by packaged core code.
+        </p>
+        <div class="cognitive-group">
+            <div class="cognitive-grid" style="grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:16px;">
+                <div class="cognitive-card">
+                    <h3>Personal means personal again</h3>
+                    <p>Packaged installs now write a runtime core-artifacts manifest and the personal script registry reads it. If a file was shipped by the product, it is classified as core instead of being mixed into the operator's own script bucket just because it happens to live under <code>~/.nexo/scripts</code>.</p>
+                </div>
+                <div class="cognitive-card">
+                    <h3>Heartbeat hooks are now real core hooks</h3>
+                    <p>The remaining Claude Code heartbeat wrappers are shipped under the managed hooks surface. <code>nexo update</code> rewrites managed client configs to those hook paths and removes the retired legacy wrappers from <code>NEXO_HOME/scripts</code>.</p>
+                </div>
             </div>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents</title>
-    <meta name="description" content="Libre/open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.1 normalizes packaged npm installs so nexo update stays anchored to ~/.nexo, refreshes packaged bootstrap and client artifacts after upgrade, avoids repo-only drift in installed runtimes, and keeps personal scripts on the canonical packaged path.">
+    <meta name="description" content="Libre/open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.2 hardens the runtime boundary for normal npm users: core runtime artifacts are tracked explicitly, personal scripts stop mixing with packaged core files, and nexo update migrates legacy heartbeat wrappers into managed core hooks.">
     <meta name="keywords" content="AI memory, cognitive architecture, MCP, Claude Code, Codex, Claude Desktop, agent memory, vector search, AI agents, shared brain, open source">
     <meta name="author" content="WAzion">
     <meta name="robots" content="index, follow">
@@ -14,7 +14,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://nexo-brain.com">
     <meta property="og:title" content="NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents">
-    <meta property="og:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.1 normalizes packaged npm installs so nexo update stays anchored to ~/.nexo, refreshes packaged bootstrap and client artifacts after upgrade, avoids repo-only drift in installed runtimes, and keeps personal scripts on the canonical packaged path.">
+    <meta property="og:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.2 hardens the runtime boundary for normal npm users: core runtime artifacts are tracked explicitly, personal scripts stop mixing with packaged core files, and nexo update migrates legacy heartbeat wrappers into managed core hooks.">
     <meta property="og:image" content="https://nexo-brain.com/assets/og/og-home.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -22,7 +22,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents">
-    <meta name="twitter:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.1 normalizes packaged npm installs so nexo update stays anchored to ~/.nexo, refreshes packaged bootstrap and client artifacts after upgrade, avoids repo-only drift in installed runtimes, and keeps personal scripts on the canonical packaged path.">
+    <meta name="twitter:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.2 hardens the runtime boundary for normal npm users: core runtime artifacts are tracked explicitly, personal scripts stop mixing with packaged core files, and nexo update migrates legacy heartbeat wrappers into managed core hooks.">
     <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-home.png">
 
     <!-- Google Analytics (GA4) -->
@@ -46,12 +46,12 @@
         "@context": "https://schema.org",
         "@type": "SoftwareApplication",
         "name": "NEXO Brain",
-        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.1 normalizes packaged npm installs so nexo update stays anchored to ~/.nexo, refreshes packaged bootstrap and client artifacts after upgrade, avoids repo-only drift in installed runtimes, and keeps personal scripts on the canonical packaged path.",
+        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.2 hardens the runtime boundary for normal npm users: core runtime artifacts are tracked explicitly, personal scripts stop mixing with packaged core files, and nexo update migrates legacy heartbeat wrappers into managed core hooks.",
         "applicationCategory": "DeveloperApplication",
         "operatingSystem": "macOS, Linux, Windows",
         "url": "https://nexo-brain.com",
         "downloadUrl": "https://www.npmjs.com/package/nexo-brain",
-        "softwareVersion": "5.3.1",
+        "softwareVersion": "5.3.2",
         "license": "https://www.gnu.org/licenses/agpl-3.0",
         "author": {
             "@type": "Organization",
@@ -88,7 +88,7 @@
         "@type": "WebSite",
         "name": "NEXO Brain",
         "url": "https://nexo-brain.com",
-        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.1 normalizes packaged npm installs so nexo update stays anchored to ~/.nexo, refreshes packaged bootstrap and client artifacts after upgrade, avoids repo-only drift in installed runtimes, and keeps personal scripts on the canonical packaged path.",
+        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.2 hardens the runtime boundary for normal npm users: core runtime artifacts are tracked explicitly, personal scripts stop mixing with packaged core files, and nexo update migrates legacy heartbeat wrappers into managed core hooks.",
         "publisher": {
             "@type": "Organization",
             "name": "WAzion",
@@ -697,7 +697,7 @@
     <div class="container">
         <div class="hero-badge fade-up">
             <span class="dot"></span>
-            <span id="version-badge">v5.3.1</span> &mdash; Packaged runtime normalization so <code>nexo update</code> stays anchored to <code>~/.nexo</code>, refreshes packaged artifacts, and behaves like a normal npm install
+            <span id="version-badge">v5.3.2</span> &mdash; Runtime boundary hardening so packaged core stays distinct from personal scripts and <code>nexo update</code> migrates legacy heartbeat wrappers into managed hooks
         </div>
         <div class="fade-up" style="display:flex;gap:8px;justify-content:center;margin-bottom:12px;">
             <img src="https://img.shields.io/npm/v/nexo-brain?color=7C3AED&label=npm" alt="npm version">
@@ -1156,9 +1156,9 @@
 
         <div class="release-evolution-grid">
             <div class="release-evolution-card">
-                <div class="release-evolution-version">v5.3.1</div>
-                <h3>Packaged npm installs finally behave like packaged npm installs</h3>
-                <p><code>nexo update</code> now keeps installed runtimes anchored to <code>~/.nexo</code>, refreshes packaged bootstrap and client artifacts after upgrade, skips repo-only release drift inside user installs, and keeps personal scripts on the canonical packaged path instead of falling back to legacy <code>~/claude</code> assumptions.</p>
+                <div class="release-evolution-version">v5.3.2</div>
+                <h3>Core product surface and personal runtime are now explicit</h3>
+                <p>Packaged installs now persist which scripts and hooks are core runtime artifacts, <code>nexo scripts</code> stops mixing those into the personal bucket, and <code>nexo update</code> migrates the last legacy Claude Code heartbeat wrappers into managed core hooks.</p>
             </div>
             <div class="release-evolution-card">
                 <div class="release-evolution-version">v5.1.0</div>

--- a/llms.txt
+++ b/llms.txt
@@ -1,9 +1,10 @@
 # NEXO Brain
 
-> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.3.1).
+> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.3.2).
 
 NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. It adds a local shared brain across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, smarter retrieval defaults, long-horizon overnight analysis, and 150+ MCP tools.
 
+v5.3.2: runtime boundary hardening — packaged installs track core runtime artifacts, `nexo scripts` stops mixing core with personal, and `nexo update` migrates legacy heartbeat wrappers into managed core hooks
 v5.3.1: packaged runtime normalization — `nexo update` keeps normal npm installs anchored to `~/.nexo` and refreshes packaged artifacts cleanly
 v5.3.0: nexo uninstall — stops crons, removes runtime, preserves user data for clean reinstall
 v5.2.1: fix deep-sleep datetime crash in apply_findings.py; cortex_decide() auto-creates outcomes closing decision→verification loop


### PR DESCRIPTION
## Summary\n- update the homepage release badge and recent evolution card to v5.3.2\n- publish the v5.3.2 changelog section and release blog post\n- refresh website llms.txt for the runtime-boundary release\n\n## Validation\n- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 scripts/verify_release_readiness.py --ci --website-root /tmp/nexo-site-v532