### PR TITLE
site(v5.3.3): publish doctor inventory alignment

### DIFF
--- a/.well-known/llms.txt
+++ b/.well-known/llms.txt
@@ -1,9 +1,10 @@
 # NEXO Brain
 
-> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.3.2).
+> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.3.3).
 
 NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. It adds a local shared brain across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, smarter retrieval defaults, long-horizon overnight analysis, and 150+ MCP tools.
 
+v5.3.3: doctor inventory alignment — `nexo doctor` now recognizes the built-in `com.nexo.backup` LaunchAgent as a core auxiliary service on packaged installs
 v5.3.2: runtime boundary hardening — packaged installs track core runtime artifacts, `nexo scripts` stops mixing core with personal, and `nexo update` migrates legacy heartbeat wrappers into managed core hooks
 v5.3.1: packaged runtime normalization — `nexo update` keeps normal npm installs anchored to `~/.nexo` and refreshes packaged artifacts cleanly
 v5.3.0: nexo uninstall — stops crons, removes runtime, preserves user data for clean reinstall

--- a/blog/index.html
+++ b/blog/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Blog — NEXO Brain</title>
-    <meta name="description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, now including the v5.3.2 runtime-boundary release that makes core product surface and personal runtime behave like separate layers again.">
+    <meta name="description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, now including the v5.3.3 patch that makes packaged runtime doctor output match what the installer actually ships.">
     <meta name="robots" content="index, follow">
     <link rel="canonical" href="https://nexo-brain.com/blog/">
 
@@ -12,7 +12,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://nexo-brain.com/blog/">
     <meta property="og:title" content="Blog — NEXO Brain">
-    <meta property="og:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, now including the v5.3.2 runtime-boundary release that makes core product surface and personal runtime behave like separate layers again.">
+    <meta property="og:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, now including the v5.3.3 patch that makes packaged runtime doctor output match what the installer actually ships.">
     <meta property="og:image" content="https://nexo-brain.com/assets/og/og-blog.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -20,7 +20,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Blog — NEXO Brain">
-    <meta name="twitter:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, now including the v5.3.2 runtime-boundary release that makes core product surface and personal runtime behave like separate layers again.">
+    <meta name="twitter:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, now including the v5.3.3 patch that makes packaged runtime doctor output match what the installer actually ships.">
     <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-blog.png">
 
     <script type="application/ld+json">
@@ -28,7 +28,7 @@
         "@context": "https://schema.org",
         "@type": "CollectionPage",
         "name": "Blog — NEXO Brain",
-        "description": "Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, now including the v5.3.2 runtime-boundary release that makes core product surface and personal runtime behave like separate layers again.",
+        "description": "Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, now including the v5.3.3 patch that makes packaged runtime doctor output match what the installer actually ships.",
         "url": "https://nexo-brain.com/blog/",
         "isPartOf": {
             "@type": "WebSite",
@@ -134,7 +134,7 @@
                     <span class="page-chip">Competitive analysis</span>
                 </div>
                 <div class="hero-actions" style="justify-content:flex-start;">
-                    <a href="/blog/nexo-5-3-2-runtime-boundary-hardening/" class="btn btn-primary">Read latest release</a>
+                    <a href="/blog/nexo-5-3-3-doctor-inventory-alignment/" class="btn btn-primary">Read latest release</a>
                     <a href="/changelog/" class="btn btn-secondary">Latest release notes</a>
                     <a href="/evolution/" class="btn btn-secondary">See Evolution</a>
                 </div>
@@ -143,22 +143,22 @@
                 <div class="section-label">Latest release</div>
                 <div class="blog-featured-meta">
                     <span class="compare-chip">April 12, 2026</span>
-                    <span class="compare-chip">Runtime boundary hardening</span>
+                    <span class="compare-chip">Doctor inventory alignment</span>
                 </div>
-                <h2>NEXO 5.3.2: Runtime Boundary Hardening for Real Shared-Brain Installs</h2>
-                <p>NEXO 5.3.2 finishes the packaging cleanup by making the boundary explicit: packaged core scripts/hooks are tracked as product artifacts, <code>nexo scripts</code> stops mixing them into the personal bucket, and <code>nexo update</code> migrates the last legacy heartbeat wrappers into managed core hooks.</p>
+                <h2>NEXO 5.3.3: Doctor Inventory Alignment for Clean Packaged Installs</h2>
+                <p>NEXO 5.3.3 removes the last misleading packaged-runtime warning: the built-in hourly backup helper is now inventoried as core, so <code>nexo doctor</code> stops flagging a clean npm install as if it had an unexplained legacy LaunchAgent.</p>
                 <div class="hero-actions" style="justify-content:flex-start;margin-bottom:18px;">
-                    <a href="/blog/nexo-5-3-2-runtime-boundary-hardening/" class="btn btn-primary">Open article</a>
-                    <a href="/changelog/#v532" class="btn btn-secondary">Open changelog</a>
+                    <a href="/blog/nexo-5-3-3-doctor-inventory-alignment/" class="btn btn-primary">Open article</a>
+                    <a href="/changelog/#v533" class="btn btn-secondary">Open changelog</a>
                 </div>
                 <div class="blog-mini-stack">
                     <div class="blog-mini-card">
                         <strong>Companion view</strong>
-                        <span><a href="/changelog/#v532">The 5.3.2 changelog section</a></span>
+                        <span><a href="/changelog/#v533">The 5.3.3 changelog section</a></span>
                     </div>
                     <div class="blog-mini-card">
                         <strong>Previous release</strong>
-                        <span><a href="/blog/nexo-5-3-1-packaged-runtime-normalization/">NEXO 5.3.1: Packaged Runtime Normalization for Real npm Users</a>.</span>
+                        <span><a href="/blog/nexo-5-3-2-runtime-boundary-hardening/">NEXO 5.3.2: Runtime Boundary Hardening for Real Shared-Brain Installs</a>.</span>
                     </div>
                 </div>
             </div>
@@ -170,6 +170,13 @@
 <section class="section-flush-top">
     <div class="container">
         <div class="blog-grid">
+
+            <div class="blog-card">
+                <div class="blog-card-date">April 12, 2026</div>
+                <h2><a href="/blog/nexo-5-3-3-doctor-inventory-alignment/">NEXO 5.3.3: Doctor Inventory Alignment for Clean Packaged Installs</a></h2>
+                <p>A small packaging honesty patch: the installer already shipped the built-in backup LaunchAgent as core, and now <code>nexo doctor</code> recognizes that same inventory instead of flagging a clean runtime as unknown.</p>
+                <a href="/blog/nexo-5-3-3-doctor-inventory-alignment/" class="read-more">Read article <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14"/><path d="M12 5l7 7-7 7"/></svg></a>
+            </div>
 
             <div class="blog-card">
                 <div class="blog-card-date">April 12, 2026</div>

--- a/blog/nexo-5-3-3-doctor-inventory-alignment/index.html
+++ b/blog/nexo-5-3-3-doctor-inventory-alignment/index.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <title>NEXO 5.3.3: Doctor Inventory Alignment for Clean Packaged Installs</title>
+    <meta name="description" content="NEXO 5.3.3 closes the last packaged-runtime doctor mismatch: the installer already ships the built-in backup LaunchAgent as core, and now nexo doctor inventories it the same way.">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://nexo-brain.com/blog/nexo-5-3-3-doctor-inventory-alignment/">
+
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://nexo-brain.com/blog/nexo-5-3-3-doctor-inventory-alignment/">
+    <meta property="og:title" content="NEXO 5.3.3: Doctor Inventory Alignment for Clean Packaged Installs">
+    <meta property="og:description" content="A small but important packaging honesty patch: clean npm installs no longer show a false unknown LaunchAgent warning for the built-in backup helper.">
+    <meta property="og:image" content="https://nexo-brain.com/assets/og/og-blog.png">
+    <meta property="article:published_time" content="2026-04-12">
+    <meta property="article:author" content="Francisco Cerda Puigserver">
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="NEXO 5.3.3: Doctor Inventory Alignment for Clean Packaged Installs">
+    <meta name="twitter:description" content="The packaged installer and runtime doctor now agree that the built-in hourly backup helper is core.">
+    <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-blog.png">
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-1LNEMCJMS7"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-1LNEMCJMS7');
+    </script>
+
+    <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicon-32.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
+    <link rel="stylesheet" href="/assets/style.css">
+
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "NEXO 5.3.3: Doctor Inventory Alignment for Clean Packaged Installs",
+        "description": "NEXO 5.3.3 closes the last packaged-runtime doctor mismatch: the installer already ships the built-in backup LaunchAgent as core, and now nexo doctor inventories it the same way.",
+        "datePublished": "2026-04-12",
+        "dateModified": "2026-04-12",
+        "author": {
+            "@type": "Person",
+            "name": "Francisco Cerda Puigserver"
+        },
+        "publisher": {
+            "@type": "Organization",
+            "name": "WAzion",
+            "url": "https://www.wazion.com"
+        },
+        "mainEntityOfPage": {
+            "@type": "WebPage",
+            "@id": "https://nexo-brain.com/blog/nexo-5-3-3-doctor-inventory-alignment/"
+        },
+        "url": "https://nexo-brain.com/blog/nexo-5-3-3-doctor-inventory-alignment/",
+        "image": "https://nexo-brain.com/assets/nexo-brain-infographic-v5.png",
+        "keywords": ["NEXO 5.3.3", "nexo doctor", "LaunchAgent", "packaged runtime", "backup helper", "~/.nexo"]
+    }
+    </script>
+
+    <style>
+        .article-header { padding-top: 128px; padding-bottom: 40px; text-align: center; }
+        .article-meta { font-size: 14px; color: var(--text-muted); margin-bottom: 16px; }
+        .article-body {
+            max-width: 720px; margin: 0 auto; padding: 0 24px 80px;
+            font-size: 17px; line-height: 1.8; color: var(--text);
+        }
+        .article-body h2 { font-size: 28px; font-weight: 700; margin: 48px 0 16px; letter-spacing: -0.01em; }
+        .article-body p { margin-bottom: 20px; color: var(--text-muted); }
+        .article-body strong { color: var(--text); }
+        .article-body a { color: var(--purple-light); }
+        .article-body a:hover { color: var(--pink); }
+        .article-body code {
+            font-family: 'SF Mono', 'Fira Code', monospace;
+            font-size: 14px; color: var(--pink);
+            background: rgba(236, 72, 153, 0.1);
+            padding: 2px 8px; border-radius: 4px;
+        }
+        .article-back {
+            display: inline-flex; align-items: center; gap: 6px;
+            font-size: 14px; font-weight: 600; color: var(--text-muted);
+            margin-bottom: 24px;
+        }
+        .article-back:hover { color: var(--purple-light); }
+        .article-visual { margin: 32px 0 40px; text-align: center; }
+        .article-visual img {
+            max-width: 100%;
+            border-radius: 16px;
+            border: 1px solid var(--dark-border);
+            box-shadow: 0 8px 32px rgba(37,99,235,0.18);
+        }
+    </style>
+</head>
+<body>
+
+<nav>
+    <div class="container">
+        <a href="/" class="nav-logo">
+            <img src="/assets/logo-64.png" alt="NEXO Brain" class="logo-image">
+            <span class="logo-text">NEXO Brain</span>
+        </a>
+        <button class="mobile-menu-toggle" aria-label="Toggle navigation" onclick="toggleMobileMenu()">
+            <span></span><span></span><span></span>
+        </button>
+        <div class="nav-links">
+            <a href="/">Home</a>
+            <a href="/features/">Features</a>
+            <a href="/evolution/">Evolution</a>
+            <a href="/compare/">Compare</a>
+            <a href="/blog/">Blog</a>
+            <a href="/changelog/">Changelog</a>
+            <a href="/docs/">Docs</a>
+            <a href="https://github.com/wazionapps/nexo" class="nav-cta">GitHub</a>
+        </div>
+    </div>
+</nav>
+
+<section class="article-header">
+    <div class="container">
+        <a href="/blog/" class="article-back">← Back to blog</a>
+        <div class="article-meta">April 12, 2026 · Patch release · Packaged runtime / doctor</div>
+        <h1 class="section-title" style="font-size:clamp(28px,4.5vw,48px);max-width:920px;margin:0 auto 16px;">NEXO 5.3.3: Doctor Inventory Alignment for Clean Packaged Installs</h1>
+        <p class="section-subtitle" style="max-width:760px;margin:0 auto;">5.3.2 fixed the runtime boundary. 5.3.3 closes the last honesty gap on top of that: a clean npm install should not look suspicious to <code>nexo doctor</code> just because the product itself shipped a backup helper.</p>
+    </div>
+</section>
+
+<section>
+    <div class="article-body">
+        <div class="article-visual">
+            <img src="/assets/nexo-brain-infographic-v5.png" alt="NEXO Brain 5.3.3 release">
+        </div>
+
+        <p><strong>5.3.3 is a packaging truthfulness patch.</strong> It does not add a new cognitive subsystem. It removes a contradiction between two product surfaces that should have agreed all along: the packaged installer and runtime doctor.</p>
+
+        <h2>The mismatch</h2>
+        <p>NEXO already shipped an hourly backup helper as part of the packaged runtime. The installer treated <code>com.nexo.backup</code> as a built-in auxiliary LaunchAgent. But runtime doctor did not inventory that same helper as core, which meant a clean npm install could still show a false “Unknown com.nexo LaunchAgents” warning.</p>
+
+        <h2>What 5.3.3 changes</h2>
+        <p>Runtime doctor now recognizes the built-in backup LaunchAgent as part of the core auxiliary inventory. That means the packaged installer, the runtime filesystem, and <code>nexo doctor</code> now describe the same system instead of pulling in different directions.</p>
+
+        <h2>Why this matters</h2>
+        <p>Small inventory mismatches create trust erosion. If a user installs from npm, keeps their own data in <code>~/.nexo</code>, and runs doctor on a healthy runtime, the tool should not imply there is a ghost legacy process when the process was actually shipped by the product. Packaging cleanup is only credible when diagnostics tell the same story.</p>
+
+        <h2>Relationship to 5.3.2</h2>
+        <p>The boundary fix from <a href="/blog/nexo-5-3-2-runtime-boundary-hardening/">5.3.2</a> remains the bigger change: packaged core scripts and hooks are tracked as product artifacts, the personal bucket stops absorbing them by accident, and legacy heartbeat wrappers move into managed core hooks. Version 5.3.3 is the follow-through that makes doctor reflect that cleaned-up packaged surface honestly.</p>
+
+        <h2>Upgrade</h2>
+        <p>Open the <a href="/changelog/#v533">5.3.3 changelog section</a> for the exact release note. If you are already installed, the intended path stays simple:</p>
+        <p><code>npm install -g nexo-brain@5.3.3</code><br><code>nexo update</code></p>
+        <p>Your data stays in <code>~/.nexo</code>. The runtime stays replaceable. Now the packaged installer and runtime doctor agree about the built-in backup surface too.</p>
+    </div>
+</section>
+
+<footer>
+    <div class="container">
+        <div class="footer-content">
+            <div class="footer-left">
+                Created by <strong>Francisco Cerd&agrave; Puigserver</strong> &amp; <strong>NEXO</strong> (Claude Opus) &bull; Built by <a href="https://www.wazion.com">WAzion</a> &bull; AGPL-3.0 License &bull; &copy; 2026
+            </div>
+            <div class="footer-links">
+                <a href="https://github.com/wazionapps/nexo">GitHub</a>
+                <a href="https://x.com/NEXOBRAIN">X / Twitter</a>
+                <a href="https://github.com/sponsors/wazionapps">Sponsor</a>
+                <a href="/docs/">Docs</a>
+                <a href="/compare/">Compare</a>
+                <a href="/blog/">Blog</a>
+                <a href="https://www.npmjs.com/package/nexo-brain">npm</a>
+                <a href="https://github.com/wazionapps/nexo/releases">Releases</a>
+            </div>
+            <div style="text-align:center;margin-top:12px;color:#6b7280;font-size:12px;">Last updated: April 2026</div>
+        </div>
+    </div>
+</footer>
+
+</body>
+</html>

--- a/changelog/index.html
+++ b/changelog/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Changelog — NEXO Brain</title>
-    <meta name="description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.3.2 hardens the runtime boundary for packaged users by separating core runtime artifacts from personal scripts and migrating legacy heartbeat wrappers into managed hooks.">
+    <meta name="description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.3.3 aligns runtime doctor with the packaged installer by recognizing the built-in backup LaunchAgent as core.">
     <meta name="robots" content="index, follow">
     <link rel="canonical" href="https://nexo-brain.com/changelog/">
 
@@ -12,7 +12,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://nexo-brain.com/changelog/">
     <meta property="og:title" content="Changelog — NEXO Brain">
-    <meta property="og:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.3.2 hardens the runtime boundary for packaged users by separating core runtime artifacts from personal scripts and migrating legacy heartbeat wrappers into managed hooks.">
+    <meta property="og:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.3.3 aligns runtime doctor with the packaged installer by recognizing the built-in backup LaunchAgent as core.">
     <meta property="og:image" content="https://nexo-brain.com/assets/og/og-changelog.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -20,7 +20,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Changelog — NEXO Brain">
-    <meta name="twitter:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.3.2 hardens the runtime boundary for packaged users by separating core runtime artifacts from personal scripts and migrating legacy heartbeat wrappers into managed hooks.">
+    <meta name="twitter:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.3.3 aligns runtime doctor with the packaged installer by recognizing the built-in backup LaunchAgent as core.">
     <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-changelog.png">
 
     <script type="application/ld+json">
@@ -28,7 +28,7 @@
         "@context": "https://schema.org",
         "@type": "CollectionPage",
         "name": "Changelog — NEXO Brain",
-        "description": "Full version history for NEXO Brain cognitive runtime. Latest release: v5.3.2 hardens the runtime boundary for packaged users by separating core runtime artifacts from personal scripts and migrating legacy heartbeat wrappers into managed hooks.",
+        "description": "Full version history for NEXO Brain cognitive runtime. Latest release: v5.3.3 aligns runtime doctor with the packaged installer by recognizing the built-in backup LaunchAgent as core.",
         "url": "https://nexo-brain.com/changelog/",
         "isPartOf": {
             "@type": "WebSite",
@@ -87,12 +87,12 @@
                 <h1 class="section-title" style="font-size:clamp(32px,5vw,56px);">Changelog</h1>
                 <p class="section-subtitle">Every feature, fix, and improvement &mdash; from the beginning, with the same visual clarity as the rest of the site.</p>
                 <div class="page-chip-row">
-                    <span class="page-chip">v5.3.2 live</span>
-                    <span class="page-chip">Runtime boundary hardening</span>
-                    <span class="page-chip"><code>nexo scripts</code> now separates packaged core from personal runtime</span>
+                    <span class="page-chip">v5.3.3 live</span>
+                    <span class="page-chip">Doctor inventory alignment</span>
+                    <span class="page-chip">Clean npm installs no longer show a false unknown backup LaunchAgent</span>
                 </div>
                 <div class="hero-actions" style="justify-content:flex-start;">
-                    <a href="#v532" class="btn btn-primary">Start with v5.3.2</a>
+                    <a href="#v533" class="btn btn-primary">Start with v5.3.3</a>
                     <a href="#v400" class="btn btn-secondary">See v4.0.0</a>
                     <a href="/evolution/" class="btn btn-secondary">See Evolution</a>
                 </div>
@@ -100,8 +100,8 @@
             <div class="page-visual">
                 <div class="page-stack">
                     <div class="page-stack-card">
-                        <strong>v5.3.2</strong>
-                        <span>Runtime boundary hardening: packaged installs now track core runtime artifacts explicitly, keep them out of the personal bucket, and migrate legacy heartbeat wrappers into managed Claude Code hooks.</span>
+                        <strong>v5.3.3</strong>
+                        <span>Doctor inventory alignment: the built-in backup LaunchAgent is now recognized as core, so clean packaged installs stop looking like they have an unexplained legacy plist.</span>
                     </div>
                     <div class="page-stack-card">
                         <strong>v5.3.0</strong>
@@ -155,6 +155,29 @@
             <div>
                 <div id="changelog-page-meta" class="changelog-page-meta">Loading release pages…</div>
                 <div id="changelog-pager" class="changelog-pager" aria-label="Changelog pagination"></div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<!-- v5.3.3 doctor inventory alignment -->
+<section id="v533" class="section-compact" style="background:linear-gradient(135deg,#0b1120 0%,#2563eb 45%,#06b6d4 100%);">
+    <div class="container">
+        <div class="section-label">New in v5.3.3 <span style="opacity:.5;font-weight:400;">&mdash; April 12, 2026</span></div>
+        <h2 class="section-title">Doctor Inventory Alignment for Clean Packaged Installs</h2>
+        <p class="section-subtitle">
+            A small but important packaging honesty patch. NEXO already shipped an hourly built-in backup helper as part of the packaged runtime. Now <code>nexo doctor</code> inventories that helper as core too, so clean npm installs stop surfacing a false “unknown LaunchAgent” warning.
+        </p>
+        <div class="cognitive-group">
+            <div class="cognitive-grid" style="grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:16px;">
+                <div class="cognitive-card">
+                    <h3>Installer and doctor now agree</h3>
+                    <p>The packaged installer has treated <code>com.nexo.backup</code> as a core auxiliary LaunchAgent. Runtime doctor now uses that same inventory, instead of acting as if the built-in hourly DB backup helper appeared from nowhere.</p>
+                </div>
+                <div class="cognitive-card">
+                    <h3>No more false dirty-runtime signal</h3>
+                    <p>This removes the last misleading warning from the packaged cleanup sequence. Users can install from npm, keep their data in <code>~/.nexo</code>, and run <code>nexo doctor</code> without seeing a fake “unknown LaunchAgent” on an otherwise healthy runtime.</p>
+                </div>
             </div>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents</title>
-    <meta name="description" content="Libre/open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.2 hardens the runtime boundary for normal npm users: core runtime artifacts are tracked explicitly, personal scripts stop mixing with packaged core files, and nexo update migrates legacy heartbeat wrappers into managed core hooks.">
+    <meta name="description" content="Libre/open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.3 closes the last packaged-runtime doctor mismatch by recognizing the built-in backup LaunchAgent as core, on top of the 5.3.2 runtime-boundary hardening for normal npm users.">
     <meta name="keywords" content="AI memory, cognitive architecture, MCP, Claude Code, Codex, Claude Desktop, agent memory, vector search, AI agents, shared brain, open source">
     <meta name="author" content="WAzion">
     <meta name="robots" content="index, follow">
@@ -14,7 +14,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://nexo-brain.com">
     <meta property="og:title" content="NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents">
-    <meta property="og:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.2 hardens the runtime boundary for normal npm users: core runtime artifacts are tracked explicitly, personal scripts stop mixing with packaged core files, and nexo update migrates legacy heartbeat wrappers into managed core hooks.">
+    <meta property="og:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.3 closes the last packaged-runtime doctor mismatch by recognizing the built-in backup LaunchAgent as core, on top of the 5.3.2 runtime-boundary hardening for normal npm users.">
     <meta property="og:image" content="https://nexo-brain.com/assets/og/og-home.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -22,7 +22,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents">
-    <meta name="twitter:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.2 hardens the runtime boundary for normal npm users: core runtime artifacts are tracked explicitly, personal scripts stop mixing with packaged core files, and nexo update migrates legacy heartbeat wrappers into managed core hooks.">
+    <meta name="twitter:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.3 closes the last packaged-runtime doctor mismatch by recognizing the built-in backup LaunchAgent as core, on top of the 5.3.2 runtime-boundary hardening for normal npm users.">
     <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-home.png">
 
     <!-- Google Analytics (GA4) -->
@@ -46,12 +46,12 @@
         "@context": "https://schema.org",
         "@type": "SoftwareApplication",
         "name": "NEXO Brain",
-        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.2 hardens the runtime boundary for normal npm users: core runtime artifacts are tracked explicitly, personal scripts stop mixing with packaged core files, and nexo update migrates legacy heartbeat wrappers into managed core hooks.",
+        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.3 closes the last packaged-runtime doctor mismatch by recognizing the built-in backup LaunchAgent as core, on top of the 5.3.2 runtime-boundary hardening for normal npm users.",
         "applicationCategory": "DeveloperApplication",
         "operatingSystem": "macOS, Linux, Windows",
         "url": "https://nexo-brain.com",
         "downloadUrl": "https://www.npmjs.com/package/nexo-brain",
-        "softwareVersion": "5.3.2",
+        "softwareVersion": "5.3.3",
         "license": "https://www.gnu.org/licenses/agpl-3.0",
         "author": {
             "@type": "Organization",
@@ -88,7 +88,7 @@
         "@type": "WebSite",
         "name": "NEXO Brain",
         "url": "https://nexo-brain.com",
-        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.2 hardens the runtime boundary for normal npm users: core runtime artifacts are tracked explicitly, personal scripts stop mixing with packaged core files, and nexo update migrates legacy heartbeat wrappers into managed core hooks.",
+        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.3 closes the last packaged-runtime doctor mismatch by recognizing the built-in backup LaunchAgent as core, on top of the 5.3.2 runtime-boundary hardening for normal npm users.",
         "publisher": {
             "@type": "Organization",
             "name": "WAzion",
@@ -697,7 +697,7 @@
     <div class="container">
         <div class="hero-badge fade-up">
             <span class="dot"></span>
-            <span id="version-badge">v5.3.2</span> &mdash; Runtime boundary hardening so packaged core stays distinct from personal scripts and <code>nexo update</code> migrates legacy heartbeat wrappers into managed hooks
+            <span id="version-badge">v5.3.3</span> &mdash; Doctor inventory now recognizes the built-in backup LaunchAgent as core, completing the packaged runtime cleanup started in <code>v5.3.2</code>
         </div>
         <div class="fade-up" style="display:flex;gap:8px;justify-content:center;margin-bottom:12px;">
             <img src="https://img.shields.io/npm/v/nexo-brain?color=7C3AED&label=npm" alt="npm version">
@@ -1156,9 +1156,9 @@
 
         <div class="release-evolution-grid">
             <div class="release-evolution-card">
-                <div class="release-evolution-version">v5.3.2</div>
-                <h3>Core product surface and personal runtime are now explicit</h3>
-                <p>Packaged installs now persist which scripts and hooks are core runtime artifacts, <code>nexo scripts</code> stops mixing those into the personal bucket, and <code>nexo update</code> migrates the last legacy Claude Code heartbeat wrappers into managed core hooks.</p>
+                <div class="release-evolution-version">v5.3.3</div>
+                <h3>Packaged runtime and doctor now agree on what is core</h3>
+                <p>The last packaged-runtime doctor mismatch is gone: the built-in hourly backup helper is now inventoried as a core LaunchAgent, so a clean npm install no longer looks “mysteriously dirty” to <code>nexo doctor</code>. The 5.3.2 runtime-boundary separation remains the foundation underneath it.</p>
             </div>
             <div class="release-evolution-card">
                 <div class="release-evolution-version">v5.1.0</div>

--- a/llms.txt
+++ b/llms.txt
@@ -1,9 +1,10 @@
 # NEXO Brain
 
-> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.3.2).
+> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.3.3).
 
 NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. It adds a local shared brain across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, smarter retrieval defaults, long-horizon overnight analysis, and 150+ MCP tools.
 
+v5.3.3: doctor inventory alignment — `nexo doctor` now recognizes the built-in `com.nexo.backup` LaunchAgent as a core auxiliary service on packaged installs
 v5.3.2: runtime boundary hardening — packaged installs track core runtime artifacts, `nexo scripts` stops mixing core with personal, and `nexo update` migrates legacy heartbeat wrappers into managed core hooks
 v5.3.1: packaged runtime normalization — `nexo update` keeps normal npm installs anchored to `~/.nexo` and refreshes packaged artifacts cleanly
 v5.3.0: nexo uninstall — stops crons, removes runtime, preserves user data for clean reinstall


### PR DESCRIPTION
## Summary
- publish the 5.3.3 homepage/changelog/blog refresh
- add the 5.3.3 blog post for doctor inventory alignment
- sync public llms.txt metadata to 5.3.3

## Verification
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 scripts/verify_release_readiness.py --ci --website-root /tmp/nexo-site-v533