### PR TITLE
release(v5.3.4): close legacy core alias leaks

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.3.3",
+  "version": "5.3.4",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [5.3.4] - 2026-04-12
+
+### Core/personal runtime boundary cleanup + version visibility
+
+- `nexo scripts` now keeps legacy hook aliases (`nexo-postcompact.sh`,
+  `nexo-memory-precompact.sh`, `nexo-memory-stop.sh`,
+  `nexo-session-briefing.sh`) out of the personal bucket on packaged
+  installs.
+- `nexo update` now removes those retired aliases from `NEXO_HOME/scripts/`
+  when the canonical hook already exists in `NEXO_HOME/hooks/`.
+- `nexo` and `nexo chat` now show a lightweight version status line with the
+  installed runtime version and the latest published npm version.
+- Added regression coverage for alias cleanup and the CLI version-status
+  banner.
+
 ## [5.3.3] - 2026-04-12
 
 ### Doctor inventory alignment

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 
 [Watch the overview video](https://nexo-brain.com/watch/) · [Watch on YouTube](https://www.youtube.com/watch?v=i2lkGhKyVqI) · [Open the infographic](https://nexo-brain.com/assets/nexo-brain-infographic-v5.png)
 
+Version `5.3.4` closes the last packaged-runtime core/personal leak from the hook migration work: legacy hook aliases stay out of the personal bucket, `nexo update` removes those retired aliases when the canonical hooks already exist, and both `nexo` and `nexo chat` now show latest vs installed version at a glance.
+
 Start here:
 - [5-minute quickstart](docs/quickstart-5-minutes.md)
 - [Workflow quickstart](docs/workflows-quickstart.md)

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 5.3.3
+version: 5.3.4
 metadata:
   openclaw:
     requires:

--- a/llms.txt
+++ b/llms.txt
@@ -4,6 +4,7 @@
 
 NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. It adds a local shared brain across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, smarter retrieval defaults, long-horizon overnight analysis, and 150+ MCP tools.
 
+v5.3.4: runtime boundary cleanup + version visibility — legacy hook aliases stay out of the personal bucket, `nexo update` removes retired aliases, and `nexo` / `nexo chat` show latest vs installed version
 v5.3.3: doctor inventory alignment — `nexo doctor` now recognizes the built-in `com.nexo.backup` LaunchAgent as a core auxiliary service on packaged installs
 v5.3.2: runtime boundary hardening — packaged installs track core runtime artifacts, `nexo scripts` stops mixing core with personal, and `nexo update` migrates legacy heartbeat wrappers into managed core hooks
 v5.3.1: packaged runtime normalization — `nexo update` keeps normal npm installs anchored to `~/.nexo` and refreshes packaged artifacts cleanly

--- a/openclaw-plugin/package-lock.json
+++ b/openclaw-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "5.0.3",
+  "version": "5.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wazionapps/openclaw-memory-nexo-brain",
-      "version": "5.0.3",
+      "version": "5.3.4",
       "license": "AGPL-3.0",
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "5.3.3",
+  "version": "5.3.4",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.3.3" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.3.4" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.3.3",
+  "version": "5.3.4",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/src/auto_update.py
+++ b/src/auto_update.py
@@ -364,6 +364,12 @@ def _cleanup_retired_runtime_files():
         NEXO_HOME / "scripts" / "heartbeat-user-msg.sh",
         NEXO_HOME / "hooks" / "heartbeat-guard.sh",
     ]
+    conditional_retired = [
+        (NEXO_HOME / "scripts" / "nexo-postcompact.sh", NEXO_HOME / "hooks" / "post-compact.sh"),
+        (NEXO_HOME / "scripts" / "nexo-memory-precompact.sh", NEXO_HOME / "hooks" / "pre-compact.sh"),
+        (NEXO_HOME / "scripts" / "nexo-memory-stop.sh", NEXO_HOME / "hooks" / "session-stop.sh"),
+        (NEXO_HOME / "scripts" / "nexo-session-briefing.sh", NEXO_HOME / "hooks" / "session-start.sh"),
+    ]
     for target in retired:
         try:
             if target.exists():
@@ -375,6 +381,13 @@ def _cleanup_retired_runtime_files():
                 _log(f"Removed retired runtime file: {target.name}")
         except Exception as e:
             _log(f"Retired runtime cleanup warning ({target.name}): {e}")
+    for target, canonical in conditional_retired:
+        try:
+            if target.exists() and canonical.exists():
+                target.unlink()
+                _log(f"Removed retired runtime alias: {target.name} (canonical: {canonical.name})")
+        except Exception as e:
+            _log(f"Retired runtime alias cleanup warning ({target.name}): {e}")
 
 
 def _sync_crons():

--- a/src/cli.py
+++ b/src/cli.py
@@ -38,6 +38,7 @@ import os
 import shutil
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 from runtime_home import export_resolved_nexo_home
@@ -49,6 +50,8 @@ TERMINAL_CLIENT_LABELS = {
     "codex": "Codex",
 }
 TERMINAL_CLIENT_ORDER = ("claude_code", "codex")
+VERSION_STATUS_CACHE = NEXO_HOME / "config" / "cli-version-status.json"
+LATEST_NPM_PACKAGE = "nexo-brain"
 
 
 def _get_version() -> str:
@@ -66,6 +69,67 @@ def _get_version() -> str:
         except Exception:
             continue
     return "?"
+
+
+def _load_latest_version_cache(max_age_seconds: int = 6 * 3600) -> str | None:
+    try:
+        payload = json.loads(VERSION_STATUS_CACHE.read_text())
+    except Exception:
+        return None
+    version = str(payload.get("latest", "")).strip()
+    checked_at = float(payload.get("checked_at", 0) or 0)
+    if not version:
+        return None
+    if checked_at and (time.time() - checked_at) > max_age_seconds:
+        return None
+    return version
+
+
+def _save_latest_version_cache(version: str) -> None:
+    VERSION_STATUS_CACHE.parent.mkdir(parents=True, exist_ok=True)
+    VERSION_STATUS_CACHE.write_text(json.dumps({
+        "latest": version,
+        "checked_at": time.time(),
+    }))
+
+
+def _fetch_latest_version(timeout_seconds: int = 2) -> str | None:
+    try:
+        result = subprocess.run(
+            ["npm", "view", LATEST_NPM_PACKAGE, "version"],
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    latest = result.stdout.strip()
+    if not latest:
+        return None
+    try:
+        _save_latest_version_cache(latest)
+    except Exception:
+        pass
+    return latest
+
+
+def _should_refresh_latest_version() -> bool:
+    try:
+        return sys.stdout.isatty() or sys.stderr.isatty()
+    except Exception:
+        return False
+
+
+def _version_status_line() -> str:
+    installed = _get_version()
+    latest = _load_latest_version_cache()
+    if latest is None and _should_refresh_latest_version():
+        latest = _fetch_latest_version()
+    if latest:
+        return f"NEXO Latest: v{latest} | Installed: v{installed}"
+    return f"NEXO Installed: v{installed}"
 
 # Ensure src/ is on path for imports
 if str(NEXO_CODE) not in sys.path:
@@ -1011,6 +1075,7 @@ def _prompt_for_terminal_client(
 def _chat(args):
     target = args.path or "."
     selected_client = getattr(args, "client", None)
+    print(f"[NEXO] {_version_status_line()}", file=sys.stderr)
 
     try:
         from auto_update import startup_preflight
@@ -1499,6 +1564,7 @@ def _uninstall(args):
 def _print_help():
     v = _get_version()
     print(f"""NEXO Runtime CLI v{v}
+{_version_status_line()}
 
 Commands:
   nexo chat [path] [--client claude_code|codex]      Launch a NEXO terminal client

--- a/src/script_registry.py
+++ b/src/script_registry.py
@@ -50,6 +50,10 @@ _LEGACY_CORE_RUNTIME_FILES = {
     "heartbeat-enforcement.py",
     "heartbeat-posttool.sh",
     "heartbeat-user-msg.sh",
+    "nexo-memory-precompact.sh",
+    "nexo-memory-stop.sh",
+    "nexo-postcompact.sh",
+    "nexo-session-briefing.sh",
 }
 
 # Forbidden patterns — direct DB access from personal scripts

--- a/tests/test_cli_scripts.py
+++ b/tests/test_cli_scripts.py
@@ -73,6 +73,20 @@ def test_doctor_prints_progress_message(nexo_home):
     assert "NEXO Doctor" in result.stdout
 
 
+def test_help_prints_version_status_from_cache(nexo_home):
+    (nexo_home / "config").mkdir(exist_ok=True)
+    (nexo_home / "config" / "cli-version-status.json").write_text(json.dumps({
+        "latest": "9.9.10",
+        "checked_at": 4102444800,
+    }))
+    (nexo_home / "version.json").write_text(json.dumps({"version": "9.9.9"}))
+
+    result = _run_cli(nexo_home)
+
+    assert result.returncode == 0
+    assert "NEXO Latest: v9.9.10 | Installed: v9.9.9" in result.stdout
+
+
 class TestScriptsList:
     def test_empty_list(self, nexo_home):
         result = _run_cli(nexo_home, "scripts", "list")
@@ -197,6 +211,7 @@ class TestRuntimeUpdate:
             "NEXO_HOME": str(runtime_home),
             "NEXO_CODE": str(runtime_home),
             "HOME": str(tmp_path),
+            "PYTHONPATH": str(runtime_home),
         }
         result = subprocess.run(
             [sys.executable, CLI_PY, "update", "--json"],
@@ -228,6 +243,7 @@ class TestRuntimeUpdate:
         current_src = Path(os.path.dirname(__file__)).parent / "src"
         (runtime_home / "cli.py").write_text((current_src / "cli.py").read_text())
         (runtime_home / "auto_update.py").write_text((current_src / "auto_update.py").read_text())
+        (runtime_home / "runtime_home.py").write_text((current_src / "runtime_home.py").read_text())
         (runtime_home / "runtime_power.py").write_text(
             "def ensure_power_policy_choice(**kwargs):\n"
             "    return {'policy': 'disabled', 'prompted': False}\n\n"
@@ -302,6 +318,7 @@ class TestRuntimeUpdate:
             "NEXO_HOME": str(runtime_home),
             "NEXO_CODE": str(runtime_home),
             "HOME": str(tmp_path),
+            "PYTHONPATH": str(runtime_home),
         }
         result = subprocess.run(
             [sys.executable, str(runtime_home / "cli.py"), "update", "--json"],
@@ -393,6 +410,7 @@ class TestRuntimeUpdate:
             "NEXO_HOME": str(runtime_home),
             "NEXO_CODE": str(runtime_home),
             "HOME": str(tmp_path),
+            "PYTHONPATH": str(runtime_home),
         }
         result = subprocess.run(
             [sys.executable, CLI_PY, "update"],
@@ -415,6 +433,9 @@ class TestRuntimeUpdate:
         src_update = Path(os.path.dirname(__file__)).parent / "src" / "plugins" / "update.py"
         update_copy = plugins_dir / "update.py"
         update_copy.write_text(src_update.read_text())
+        (runtime_home / "runtime_home.py").write_text(
+            (Path(os.path.dirname(__file__)).parent / "src" / "runtime_home.py").read_text()
+        )
 
         probe = (
             "import importlib.util, json, pathlib; "
@@ -429,6 +450,7 @@ class TestRuntimeUpdate:
             "NEXO_HOME": str(runtime_home),
             "NEXO_CODE": str(runtime_home),
             "HOME": str(tmp_path),
+            "PYTHONPATH": str(runtime_home),
         }
         result = subprocess.run(
             [sys.executable, "-c", probe],
@@ -504,11 +526,45 @@ class TestChatCommand:
             capture_output=True, text=True, timeout=30, env=env,
         )
         assert result.returncode == 0
+        assert "[NEXO] NEXO " in result.stderr
         payload = json.loads(out_file.read_text())
         assert payload["argv"][:3] == ["--model", "claude-opus-4-6[1m]", "--dangerously-skip-permissions"]
         assert "nexo_startup" in payload["argv"][-1]
         assert "nexo_heartbeat" in payload["argv"][-1]
         assert payload["cwd"] == str(workspace.resolve())
+
+    def test_chat_prints_version_status_from_cache(self, nexo_home, tmp_path):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        fake_claude = tmp_path / "claude"
+        out_file = tmp_path / "claude-invocation.json"
+        fake_claude.write_text(
+            "#!/usr/bin/env python3\n"
+            "import json, sys\n"
+            f"open({json.dumps(str(out_file))}, 'w').write(json.dumps(sys.argv[1:]))\n"
+        )
+        fake_claude.chmod(0o755)
+        (nexo_home / "config").mkdir(exist_ok=True)
+        (nexo_home / "config" / "cli-version-status.json").write_text(json.dumps({
+            "latest": "9.9.10",
+            "checked_at": 4102444800,
+        }))
+        (nexo_home / "version.json").write_text(json.dumps({"version": "9.9.9"}))
+
+        env = {
+            **os.environ,
+            "NEXO_HOME": str(nexo_home),
+            "NEXO_CODE": os.path.join(os.path.dirname(__file__), "..", "src"),
+            "HOME": str(nexo_home),
+            "CLAUDE_BIN": str(fake_claude),
+        }
+        result = subprocess.run(
+            [sys.executable, CLI_PY, "chat", str(workspace)],
+            capture_output=True, text=True, timeout=30, env=env,
+        )
+
+        assert result.returncode == 0
+        assert "[NEXO] NEXO Latest: v9.9.10 | Installed: v9.9.9" in result.stderr
 
     def test_chat_uses_configured_codex_client(self, nexo_home, tmp_path):
         workspace = tmp_path / "workspace"

--- a/tests/test_script_registry.py
+++ b/tests/test_script_registry.py
@@ -1,4 +1,5 @@
 """Tests for script_registry — metadata parsing, runtime detection, doctor validation."""
+import json
 import os
 import stat
 import sys
@@ -42,6 +43,17 @@ def scripts_dir(tmp_path, monkeypatch):
     crons_dir = nexo_home / "crons"
     crons_dir.mkdir()
     (crons_dir / "manifest.json").write_text('{"crons":[{"id":"immune","script":"scripts/nexo-immune.py"}]}')
+
+    config_dir = nexo_home / "config"
+    config_dir.mkdir()
+    (config_dir / "runtime-core-artifacts.json").write_text(json.dumps({
+        "script_names": ["nexo-update.sh"],
+        "hook_names": ["post-compact.sh"],
+    }))
+
+    hooks_dir = nexo_home / "hooks"
+    hooks_dir.mkdir()
+    (hooks_dir / "post-compact.sh").write_text("#!/bin/bash\necho hook\n")
 
     monkeypatch.setenv("NEXO_HOME", str(nexo_home))
     monkeypatch.setenv("HOME", str(nexo_home))
@@ -236,6 +248,20 @@ class TestCoreFiltering:
         assert "my-backup" in names
         assert "nexo-immune" in names
 
+    def test_runtime_core_artifacts_mark_non_cron_core_scripts(self, scripts_dir):
+        (scripts_dir / "nexo-update.sh").write_text("#!/bin/bash\necho update\n")
+
+        entries = {entry["path"].split("/")[-1]: entry for entry in classify_scripts_dir()["entries"]}
+        assert entries["nexo-update.sh"]["classification"] == "core"
+        assert entries["nexo-update.sh"]["core"] is True
+
+    def test_legacy_hook_aliases_are_not_personal(self, scripts_dir):
+        (scripts_dir / "nexo-postcompact.sh").write_text("#!/bin/bash\necho legacy post compact\n")
+
+        entries = {entry["path"].split("/")[-1]: entry for entry in classify_scripts_dir()["entries"]}
+        assert entries["nexo-postcompact.sh"]["classification"] == "core"
+        assert entries["nexo-postcompact.sh"]["core"] is True
+
     def test_non_script_artifacts_ignored(self, scripts_dir):
         (scripts_dir / "notes.csv").write_text("a,b,c\n")
         (scripts_dir / "debug.log").write_text("hello\n")
@@ -262,7 +288,7 @@ class TestCoreFiltering:
 
     def test_runtime_core_manifest_marks_packaged_runtime_files_as_core(self, scripts_dir):
         config_dir = scripts_dir.parent / "config"
-        config_dir.mkdir()
+        config_dir.mkdir(exist_ok=True)
         (config_dir / "runtime-core-artifacts.json").write_text(
             '{"script_names":["nexo-catchup.py"],"hook_names":["capture-tool-logs.sh","heartbeat-posttool.sh"]}\n'
         )


### PR DESCRIPTION
## Summary
- keep legacy hook aliases out of the packaged personal-scripts bucket
- remove retired hook alias wrappers during nexo update when canonical hooks already exist
- show latest vs installed version in nexo and nexo chat
- bump Claude plugin, OpenClaw plugin, ClawHub skill, changelog, README, and llms surfaces to 5.3.4

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_script_registry.py tests/test_cli_scripts.py
- python3 -m py_compile src/cli.py src/script_registry.py src/auto_update.py
- cd openclaw-plugin && npm install && npm run build && npm test