### PR TITLE
v5.3.12: centralize model selection

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.3.11",
+  "version": "5.3.12",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [5.3.12] - 2026-04-13
+
+### Centralized model selection
+
+- All automation profiles, task backends, and Codex defaults now inherit the
+  user's configured model instead of hardcoding third-party model strings.
+  The `fast` profile no longer defaults to Codex — it uses the user's backend
+  and model.
+- Added `resolve_user_model()` to `client_preferences` so scripts can query
+  the single source of truth instead of hardcoding a model name.
+- README updated to reflect the one-model-everywhere design.
+
 ## [5.3.11] - 2026-04-13
 
 ### Protocol + Cortex contract hardening

--- a/README.md
+++ b/README.md
@@ -821,9 +821,7 @@ If you want the shell or Python wrappers instead of raw MCP tools:
 - [docs/reference-verticals.md](docs/reference-verticals.md)
 - [compare/README.md](compare/README.md)
 
-Recommended defaults:
-- Claude Code: `Opus 4.6 with 1M context`
-- Codex: `gpt-5.4` with `xhigh` reasoning
+The model you pick during install is used everywhere — interactive sessions, automation scripts, and all task profiles.  Change it once in your preferences and every part of the system follows.  Default: `Opus 4.6 with 1M context`.
 
 Or use the shell alias created during install (e.g. `atlas`), which now runs `nexo chat .` so it opens the terminal client you pick for that session, with the last-used option shown first.
 
@@ -904,7 +902,7 @@ The Doctor system reads existing health artifacts (immune, watchdog, self-audit)
 - **macOS or Linux** (Windows via [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
 - **Node.js 18+** (for the installer)
 - **Claude Code is the primary recommended client.** It remains the most mature NEXO path: native hooks, the most battle-tested automation contract, and the clearest parity with historical production behavior.
-- **Recommended profiles:** Claude Code + `Opus 4.6 with 1M context`; Codex + `gpt-5.4` with `xhigh` reasoning if you prefer Codex as your terminal or automation backend.
+- **Model:** You pick your model during install and every component uses it.  Default is `Opus 4.6 with 1M context`.  Scripts and automation profiles read from a single preference — no hardcoded model strings.
 - Python 3, Homebrew, and the selected required client/backend can be installed automatically when NEXO has a supported installer path for that dependency.
 
 ## Architecture
@@ -1021,7 +1019,7 @@ When Claude Desktop is installed, `nexo-brain`, `nexo update`, and `nexo clients
 
 ### Codex
 
-When Codex CLI is available, `nexo-brain`, `nexo update`, and `nexo clients sync` register the same `nexo` MCP server via `codex mcp add`, so Codex uses the same local memory store as Claude Code and Claude Desktop. If selected during install, `nexo chat` can open Codex directly and background automation can also run through Codex. Interactive `nexo chat` launches use Codex's aggressive no-confirmation mode so the session does not stall on repetitive approval prompts. The current recommended Codex profile is `gpt-5.4` with `xhigh` reasoning. Runtime Doctor also audits recent Codex sessions for NEXO startup markers and conditioned-file protocol discipline so parity drift does not hide behind the lack of native Claude-style hooks.
+When Codex CLI is available, `nexo-brain`, `nexo update`, and `nexo clients sync` register the same `nexo` MCP server via `codex mcp add`, so Codex uses the same local memory store as Claude Code and Claude Desktop. If selected during install, `nexo chat` can open Codex directly and background automation can also run through Codex. Interactive `nexo chat` launches use Codex's aggressive no-confirmation mode so the session does not stall on repetitive approval prompts. Codex uses the same model you configured during install — no separate model override is needed. Runtime Doctor also audits recent Codex sessions for NEXO startup markers and conditioned-file protocol discipline so parity drift does not hide behind the lack of native Claude-style hooks.
 
 ### Cursor
 

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 5.3.11
+version: 5.3.12
 metadata:
   openclaw:
     requires:

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "5.3.11",
-  "description": "OpenClaw native memory plugin powered by NEXO Brain — Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
+  "version": "5.3.12",
+  "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",
   "exports": "./dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.3.11" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.3.12" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.3.11",
+  "version": "5.3.12",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/scripts/verify_claude_code_mcp.py
+++ b/scripts/verify_claude_code_mcp.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from client_sync import _claude_code_mcp_path, _claude_code_settings_path  # noqa: E402
+from runtime_home import legacy_nexo_home, managed_nexo_home, resolve_nexo_home, user_home  # noqa: E402
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    return json.loads(path.read_text())
+
+
+def _normalize(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _normalize(val) for key, val in sorted(value.items())}
+    if isinstance(value, list):
+        return [_normalize(item) for item in value]
+    if isinstance(value, str) and value.startswith("~"):
+        return str(Path(value).expanduser())
+    return value
+
+
+def _server_command(config: dict[str, Any] | None) -> str:
+    if not isinstance(config, dict):
+        return ""
+    parts = [str(config.get("command", "")).strip()]
+    parts.extend(str(arg).strip() for arg in (config.get("args") or []))
+    return " ".join(part for part in parts if part)
+
+
+def _parse_claude_mcp_list(output: str) -> dict[str, dict[str, str]]:
+    servers: dict[str, dict[str, str]] = {}
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("Checking MCP server health"):
+            continue
+        if ": " not in line or " - " not in line:
+            continue
+        name, rest = line.split(": ", 1)
+        command, status = rest.rsplit(" - ", 1)
+        servers[name.strip()] = {
+            "command": command.strip(),
+            "status": status.strip(),
+            "raw": line,
+        }
+    return servers
+
+
+def _walk_strings(value: Any) -> list[str]:
+    if isinstance(value, dict):
+        strings: list[str] = []
+        for item in value.values():
+            strings.extend(_walk_strings(item))
+        return strings
+    if isinstance(value, list):
+        strings: list[str] = []
+        for item in value:
+            strings.extend(_walk_strings(item))
+        return strings
+    if isinstance(value, str):
+        return [value]
+    return []
+
+
+def _is_same_file(left: dict[str, Any] | None, right: dict[str, Any] | None) -> bool:
+    return _normalize(left or {}) == _normalize(right or {})
+
+
+def _find_workspace_file(start: Path, relative_path: str) -> Path | None:
+    start = start.resolve()
+    for current in [start, *start.parents]:
+        candidate = current / relative_path
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _run_claude_mcp_list() -> tuple[int, str, str]:
+    try:
+        proc = subprocess.run(
+            ["claude", "mcp", "list"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        return proc.returncode, proc.stdout, proc.stderr
+    except FileNotFoundError:
+        return 127, "", "claude command not found"
+    except subprocess.TimeoutExpired as exc:
+        return 124, exc.stdout or "", "claude mcp list timed out"
+
+
+def inspect_claude_code_mcp(
+    *,
+    server_name: str = "nexo",
+    home: Path | None = None,
+    workspace: Path | None = None,
+    cli_output: str | None = None,
+    cli_returncode: int = 0,
+    cli_stderr: str = "",
+) -> dict[str, Any]:
+    home = (home or user_home()).expanduser()
+    workspace = (workspace or Path.cwd()).expanduser()
+    managed_home = managed_nexo_home(home=home)
+    legacy_home = legacy_nexo_home(home=home)
+    root_path = _claude_code_mcp_path(home)
+    settings_path = _claude_code_settings_path(home)
+
+    root_payload = _load_json(root_path)
+    settings_payload = _load_json(settings_path)
+    root_server = (root_payload.get("mcpServers") or {}).get(server_name)
+    settings_server = (settings_payload.get("mcpServers") or {}).get(server_name)
+
+    workspace_mcp_path = _find_workspace_file(workspace, ".mcp.json")
+    workspace_server = None
+    if workspace_mcp_path:
+        workspace_payload = _load_json(workspace_mcp_path)
+        workspace_server = (workspace_payload.get("mcpServers") or {}).get(server_name)
+
+    if cli_output is None:
+        cli_returncode, cli_output, cli_stderr = _run_claude_mcp_list()
+
+    cli_servers = _parse_claude_mcp_list(cli_output)
+    cli_server = cli_servers.get(server_name)
+
+    global_config = root_server or settings_server or {}
+    active_source_label = "root"
+    active_source_path = str(root_path)
+    active_source_config = root_server
+    candidate_sources = []
+    if workspace_server:
+        candidate_sources.append(("workspace", str(workspace_mcp_path), workspace_server))
+    if root_server:
+        candidate_sources.append(("root", str(root_path), root_server))
+    if settings_server:
+        candidate_sources.append(("settings", str(settings_path), settings_server))
+    if cli_server:
+        for label, path, config in candidate_sources:
+            if _server_command(config) == cli_server["command"]:
+                active_source_label = label
+                active_source_path = path
+                active_source_config = config
+                break
+
+    global_home_raw = str((global_config.get("env") or {}).get("NEXO_HOME", managed_home))
+    global_code_raw = str((global_config.get("env") or {}).get("NEXO_CODE", ""))
+    resolved_home = resolve_nexo_home(global_home_raw)
+    active_db = resolved_home / "data" / "nexo.db"
+    legacy_db_candidates = [
+        legacy_home / "data" / "nexo.db",
+        legacy_home / "brain" / "nexo.db",
+        resolved_home / "brain" / "nexo.db",
+    ]
+    server_path = None
+    if isinstance(global_config, dict):
+        args = global_config.get("args") or []
+        if args:
+            server_path = Path(str(args[0])).expanduser()
+
+    issues: list[str] = []
+    warnings: list[str] = []
+    notes: list[str] = []
+
+    if not root_server and settings_server:
+        issues.append(
+            f"{root_path} no define mcpServers.{server_name}, pero {settings_path} sí. "
+            "Claude Code 2.1.x lee el config raíz para MCP user-scoped."
+        )
+    elif not root_server:
+        issues.append(f"{root_path} no define mcpServers.{server_name}.")
+
+    if root_server and settings_server and not _is_same_file(root_server, settings_server):
+        issues.append(
+            f"{root_path} y {settings_path} tienen {server_name} distinto. "
+            f"El root es la fuente de verdad y settings.json está desincronizado."
+        )
+
+    if workspace_server and root_server and not _is_same_file(workspace_server, root_server):
+        if active_source_label == "workspace":
+            issues.append(
+                f"El CLI está cargando {server_name} desde {workspace_mcp_path}, no desde {root_path}. "
+                "Antes de culpar al server global, revisa el attach local del workspace."
+            )
+        else:
+            issues.append(
+                f"{workspace_mcp_path} define {server_name} distinto al root global. "
+                "Antes de culpar al server, confirma si el workspace está adjuntando otro MCP."
+            )
+    elif workspace_server:
+        notes.append(f"Workspace local detectado: {workspace_mcp_path}")
+
+    if cli_returncode != 0:
+        issues.append(
+            f"`claude mcp list` falló con rc={cli_returncode}: {(cli_stderr or cli_output).strip() or 'sin detalle'}"
+        )
+    elif not cli_server:
+        issues.append(
+            f"`claude mcp list` no reporta {server_name}; el CLI activo no está cargando ese server."
+        )
+    else:
+        expected = _server_command(active_source_config or global_config)
+        if expected and cli_server["command"] != expected:
+            issues.append(
+                f"`claude mcp list` carga `{cli_server['command']}`, pero {active_source_path} apunta a `{expected}`."
+            )
+        if "Connected" not in cli_server["status"]:
+            issues.append(
+                f"`claude mcp list` ve {server_name} pero no conecta: {cli_server['status']}."
+            )
+
+    legacy_tokens = [str(legacy_home), "~/claude", f"{home}/claude"]
+    seen_strings = _walk_strings(root_server) + _walk_strings(settings_server) + _walk_strings(workspace_server)
+    if cli_server:
+        seen_strings.append(cli_server["command"])
+    legacy_hits = sorted({value for value in seen_strings for token in legacy_tokens if token and token in value})
+    if legacy_hits:
+        issues.append("Rutas legacy detectadas en la configuración activa: " + "; ".join(legacy_hits))
+
+    if global_home_raw:
+        expanded_home = Path(global_home_raw).expanduser()
+        if expanded_home == legacy_home or resolved_home == legacy_home:
+            issues.append(
+                f"NEXO_HOME apunta a legacy `{legacy_home}`. El home gestionado actual es `{managed_home}`."
+            )
+
+    if server_path and not server_path.exists():
+        issues.append(f"server.py no existe en la ruta configurada: {server_path}")
+
+    if isinstance(global_config, dict):
+        command = str(global_config.get("command", "")).strip()
+        if command.startswith("/") and not Path(command).exists():
+            issues.append(f"El binario configurado no existe: {command}")
+
+    if global_code_raw:
+        expanded_code = Path(global_code_raw).expanduser()
+        if expanded_code == legacy_home:
+            issues.append(
+                f"NEXO_CODE sigue apuntando a legacy `{legacy_home}` en vez del runtime o repo real."
+            )
+
+    if not active_db.exists():
+        issues.append(f"La DB activa esperada no existe: {active_db}")
+
+    stale_legacy_dbs = [path for path in legacy_db_candidates if path.exists() and path != active_db]
+    for path in stale_legacy_dbs:
+        warnings.append(f"DB legacy presente pero no activa: {path}")
+
+    if resolved_home == managed_home and active_db.exists():
+        notes.append(f"NEXO_HOME resuelto correctamente a {resolved_home}")
+    if cli_server:
+        notes.append(f"`claude mcp list` reporta: {cli_server['raw']}")
+
+    return {
+        "ok": not issues,
+        "server_name": server_name,
+        "root_path": str(root_path),
+        "settings_path": str(settings_path),
+        "workspace_mcp_path": str(workspace_mcp_path) if workspace_mcp_path else "",
+        "active_source_label": active_source_label,
+        "active_source_path": active_source_path,
+        "managed_home": str(managed_home),
+        "legacy_home": str(legacy_home),
+        "resolved_home": str(resolved_home),
+        "active_db": str(active_db),
+        "root_server": root_server,
+        "settings_server": settings_server,
+        "workspace_server": workspace_server,
+        "cli_server": cli_server,
+        "issues": issues,
+        "warnings": warnings,
+        "notes": notes,
+    }
+
+
+def _print_human(report: dict[str, Any]) -> None:
+    status = "OK" if report["ok"] else "FAIL"
+    print(f"[claude-code-mcp] {status}")
+    print(f"source_of_truth: {report['root_path']}")
+    print(f"settings_mirror: {report['settings_path']}")
+    if report["workspace_mcp_path"]:
+        print(f"workspace_mcp: {report['workspace_mcp_path']}")
+    print(f"active_source: {report['active_source_label']} -> {report['active_source_path']}")
+    print(f"resolved_nexo_home: {report['resolved_home']}")
+    print(f"active_db: {report['active_db']}")
+    if report["issues"]:
+        print("issues:")
+        for item in report["issues"]:
+            print(f"- {item}")
+    if report["warnings"]:
+        print("warnings:")
+        for item in report["warnings"]:
+            print(f"- {item}")
+    if report["notes"]:
+        print("notes:")
+        for item in report["notes"]:
+            print(f"- {item}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Diagnostica qué MCP carga realmente Claude Code para evitar culpar al server antes de leer la configuración efectiva."
+    )
+    parser.add_argument("--server", default="nexo", help="Nombre del server MCP a comprobar (default: nexo)")
+    parser.add_argument("--workspace", default="", help="Workspace a revisar para detectar .mcp.json local (default: cwd)")
+    parser.add_argument("--json", action="store_true", help="Imprime el informe en JSON")
+    args = parser.parse_args(argv)
+
+    report = inspect_claude_code_mcp(
+        server_name=args.server,
+        workspace=Path(args.workspace).expanduser() if args.workspace else Path.cwd(),
+    )
+    if args.json:
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+    else:
+        _print_human(report)
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_release_readiness.py
+++ b/scripts/verify_release_readiness.py
@@ -12,8 +12,13 @@ import argparse
 import json
 import os
 import re
+import shutil
+import sqlite3
 import subprocess
 import sys
+import urllib.error
+import urllib.parse
+import urllib.request
 from pathlib import Path
 
 
@@ -35,12 +40,60 @@ def _run(cmd: list[str], *, env: dict[str, str] | None = None) -> None:
         raise SystemExit(result.returncode)
 
 
-def _package_version() -> str:
-    payload = json.loads(PACKAGE_JSON.read_text())
+def _package_manifest() -> dict:
+    payload = json.loads(PACKAGE_JSON.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise SystemExit("[release-readiness] package.json must contain a JSON object")
+    return payload
+
+
+def _package_version(payload: dict | None = None) -> str:
+    payload = payload or _package_manifest()
     version = str(payload.get("version", "") or "").strip()
     if not version:
         raise SystemExit("[release-readiness] package.json missing version")
     return version
+
+
+def _package_name(payload: dict | None = None) -> str:
+    payload = payload or _package_manifest()
+    name = str(payload.get("name", "") or "").strip()
+    if not name:
+        raise SystemExit("[release-readiness] package.json missing package name")
+    return name
+
+
+def _resolve_repository_slug(payload: dict | None = None) -> str:
+    payload = payload or _package_manifest()
+    repository = payload.get("repository")
+    if isinstance(repository, dict):
+        raw = str(repository.get("url", "") or "").strip()
+    else:
+        raw = str(repository or "").strip()
+    match = re.search(r"github\.com[:/](?P<slug>[^/]+/[^/.]+?)(?:\.git)?$", raw)
+    if not match:
+        raise SystemExit(f"[release-readiness] cannot resolve GitHub repository slug from {raw!r}")
+    return match.group("slug")
+
+
+def _fetch_json(url: str, *, label: str) -> dict:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "nexo-release-readiness",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        raise SystemExit(f"[release-readiness] {label} HTTP {exc.code}: {url}") from exc
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"[release-readiness] {label} request failed: {exc.reason}") from exc
+    if not isinstance(payload, dict):
+        raise SystemExit(f"[release-readiness] {label} must return a JSON object")
+    return payload
 
 
 def _resolve_nexo_home(explicit_home: str = "") -> Path:
@@ -93,6 +146,36 @@ def _check_website(version: str, website_root: Path) -> None:
     if missing:
         raise SystemExit("[release-readiness] website drift:\n- " + "\n- ".join(missing))
     print(f"[release-readiness] website OK ({website_root})")
+
+
+def _check_github_release(version: str, repository_slug: str) -> None:
+    payload = _fetch_json(
+        f"https://api.github.com/repos/{repository_slug}/releases/tags/v{version}",
+        label="github release",
+    )
+    tag_name = str(payload.get("tag_name", "") or "").strip()
+    if tag_name != f"v{version}":
+        raise SystemExit(
+            f"[release-readiness] GitHub release tag {tag_name!r} != expected v{version}"
+        )
+    html_url = str(payload.get("html_url", "") or "").strip()
+    if not html_url:
+        raise SystemExit("[release-readiness] GitHub release missing html_url")
+    print(f"[release-readiness] github release OK ({html_url})")
+
+
+def _check_npm_package(version: str, package_name: str) -> None:
+    encoded_name = urllib.parse.quote(package_name, safe="@/")
+    payload = _fetch_json(
+        f"https://registry.npmjs.org/{encoded_name}/latest",
+        label="npm registry",
+    )
+    live_version = str(payload.get("version", "") or "").strip()
+    if live_version != version:
+        raise SystemExit(
+            f"[release-readiness] npm latest version {live_version!r} != package.json {version}"
+        )
+    print(f"[release-readiness] npm registry OK ({package_name}@{live_version})")
 
 
 def _load_contract(contract_path: Path) -> dict:
@@ -203,7 +286,7 @@ def _run_runtime_doctor(nexo_home: Path) -> None:
             "-c",
             (
                 "from doctor.orchestrator import run_doctor; "
-                "report = run_doctor(tier='runtime', fix=False); "
+                "report = run_doctor(tier='runtime', fix=False, plane='installation_live'); "
                 "import sys; "
                 "bad = [c for c in report.checks if c.status in ('degraded','critical')]; "
                 "print(f'runtime doctor: {report.overall_status} ({len(bad)} issues)'); "
@@ -212,6 +295,68 @@ def _run_runtime_doctor(nexo_home: Path) -> None:
         ],
         env=env,
     )
+
+
+def _run_runtime_update(nexo_home: Path) -> None:
+    node_bin = shutil.which("node")
+    if not node_bin:
+        raise SystemExit("[release-readiness] node is required to run `nexo update`")
+    env = os.environ.copy()
+    env["NEXO_HOME"] = str(nexo_home)
+    env["NEXO_CODE"] = str(ROOT / "src")
+    print(f"[release-readiness] runtime update home: {nexo_home}")
+    _run([node_bin, str(ROOT / "bin" / "nexo.js"), "update"], env=env)
+
+
+def _check_protocol_closeout(nexo_home: Path, task_id: str) -> None:
+    db_path = nexo_home / "data" / "nexo.db"
+    if not db_path.is_file():
+        raise SystemExit(f"[release-readiness] runtime DB missing for protocol closeout: {db_path}")
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        task = conn.execute(
+            """
+            SELECT task_id, status, must_verify, close_evidence, must_change_log, change_log_id
+            FROM protocol_tasks
+            WHERE task_id = ?
+            """,
+            (task_id,),
+        ).fetchone()
+        if task is None:
+            raise SystemExit(f"[release-readiness] protocol task not found: {task_id}")
+        if str(task["status"] or "").strip() != "done":
+            raise SystemExit(
+                f"[release-readiness] protocol task {task_id} must be closed as 'done', found {task['status']!r}"
+            )
+        if int(task["must_verify"] or 0) and not str(task["close_evidence"] or "").strip():
+            raise SystemExit(
+                f"[release-readiness] protocol task {task_id} is missing close_evidence"
+            )
+        change_log_id = task["change_log_id"]
+        if int(task["must_change_log"] or 0) and not change_log_id:
+            raise SystemExit(
+                f"[release-readiness] protocol task {task_id} is missing change_log_id"
+            )
+        if change_log_id:
+            change = conn.execute(
+                "SELECT id, what_changed, why, verify FROM change_log WHERE id = ?",
+                (change_log_id,),
+            ).fetchone()
+            if change is None:
+                raise SystemExit(
+                    f"[release-readiness] change_log row {change_log_id} missing for task {task_id}"
+                )
+            if not str(change["what_changed"] or "").strip() or not str(change["why"] or "").strip():
+                raise SystemExit(
+                    f"[release-readiness] change_log row {change_log_id} is missing what_changed/why"
+                )
+        print(
+            f"[release-readiness] protocol closeout OK ({task_id}, change_log_id={change_log_id or 'none'})"
+        )
+    finally:
+        conn.close()
 
 
 def main() -> int:
@@ -241,9 +386,26 @@ def main() -> int:
         action="store_true",
         help="Fail if any gate in the provided contract is not marked complete.",
     )
+    parser.add_argument(
+        "--final-closeout",
+        action="store_true",
+        help="Run the final post-publish closeout gate: GitHub Release, npm, runtime update/doctor, and protocol closeout.",
+    )
+    parser.add_argument(
+        "--protocol-task-id",
+        default="",
+        help="Protocol task to verify for change_log/task_close evidence during final closeout.",
+    )
     args = parser.parse_args()
 
-    version = _package_version()
+    if args.final_closeout and args.ci:
+        raise SystemExit("[release-readiness] --final-closeout requires a live runtime; do not combine it with --ci")
+    if args.final_closeout and not args.protocol_task_id.strip():
+        raise SystemExit("[release-readiness] --final-closeout requires --protocol-task-id")
+
+    manifest = _package_manifest()
+    version = _package_version(manifest)
+    package_name = _package_name(manifest)
     nexo_home = _resolve_nexo_home(args.nexo_home)
     website_root = Path(args.website_root).expanduser()
     _check_changelog(version)
@@ -257,8 +419,15 @@ def main() -> int:
             website_root=website_root,
             require_complete=args.require_contract_complete,
         )
+    if args.final_closeout:
+        _check_github_release(version, _resolve_repository_slug(manifest))
+        _check_npm_package(version, package_name)
     if not args.ci:
+        if args.final_closeout:
+            _run_runtime_update(nexo_home)
         _run_runtime_doctor(nexo_home)
+    if args.final_closeout:
+        _check_protocol_closeout(nexo_home, args.protocol_task_id.strip())
     print("[release-readiness] OK")
     return 0
 

--- a/src/agent_runner.py
+++ b/src/agent_runner.py
@@ -509,6 +509,8 @@ def _build_codex_prompt(
         "If that tool is unavailable, call `nexo_guard_check(...)` and `nexo_cortex_check(...)` first.\n"
         "- For long multi-step or cross-session work, call `nexo_workflow_open(...)` and keep it updated with "
         "`nexo_workflow_update(...)` so resume/replay use durable state instead of guesswork.\n"
+        "- Before diagnosing NEXO, explicitly fix the plane first: `product_public`, `runtime_personal`, `installation_live`, `database_real`, or `cooperator`. "
+        "Do not mix planes inside the same diagnosis.\n"
         "- If a target file has conditioned learnings or blocking guard rules, review them before any read/edit/delete step, and acknowledge guard before any edit/delete step.\n"
         "- Do not claim done without explicit verification evidence. Close with `nexo_task_close(...)`; if unavailable, capture the change log and state the evidence explicitly.\n"
         "- When a correction changes the canonical rule, capture or supersede the learning instead of leaving contradictory active rules behind."

--- a/src/auto_update.py
+++ b/src/auto_update.py
@@ -36,11 +36,114 @@ TEMPLATE_FILE = REPO_DIR / "templates" / "CLAUDE.md.template"
 
 CHECK_COOLDOWN_SECONDS = 3600  # 1 hour
 GIT_TIMEOUT_SECONDS = 4  # stay well under the 5s total budget
+CRITICAL_BACKUP_TABLES = ("learnings", "session_diary", "guard_checks", "protocol_debt")
 
 
 def _log(msg: str):
     """Log to stderr with prefix."""
     print(f"[NEXO auto-update] {msg}", file=sys.stderr)
+
+
+def _critical_table_count(db_path: Path, table: str) -> int | None:
+    """Return COUNT(*) for a critical table when it exists, otherwise None."""
+    import sqlite3
+
+    conn = None
+    try:
+        conn = sqlite3.connect(str(db_path))
+        exists = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name = ?",
+            (table,),
+        ).fetchone()
+        if not exists:
+            return None
+        row = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()
+        return int(row[0]) if row else 0
+    except Exception:
+        return None
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+
+def _find_primary_db_path() -> Path | None:
+    """Return the main nexo.db path if present."""
+    for candidate in (DATA_DIR / "nexo.db", NEXO_HOME / "nexo.db", SRC_DIR / "nexo.db"):
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _validate_db_backup(source_db: Path, backup_db: Path) -> dict:
+    """Check that a backup preserves non-empty critical tables from the source DB."""
+    report = {
+        "ok": True,
+        "source_db": str(source_db),
+        "backup_db": str(backup_db),
+        "source_counts": {},
+        "backup_counts": {},
+        "regressions": [],
+        "errors": [],
+    }
+    if not source_db.is_file():
+        report["ok"] = False
+        report["errors"].append(f"source db missing: {source_db}")
+        return report
+    if not backup_db.is_file():
+        report["ok"] = False
+        report["errors"].append(f"backup db missing: {backup_db}")
+        return report
+
+    for table in CRITICAL_BACKUP_TABLES:
+        source_count = _critical_table_count(source_db, table)
+        backup_count = _critical_table_count(backup_db, table)
+        report["source_counts"][table] = source_count
+        report["backup_counts"][table] = backup_count
+
+        if source_count is None:
+            continue
+        if backup_count is None:
+            report["regressions"].append({
+                "table": table,
+                "source": source_count,
+                "backup": None,
+                "reason": "missing_in_backup",
+            })
+            continue
+        if source_count > 0 and backup_count == 0:
+            report["regressions"].append({
+                "table": table,
+                "source": source_count,
+                "backup": backup_count,
+                "reason": "critical_rows_lost",
+            })
+
+    if report["regressions"] or report["errors"]:
+        report["ok"] = False
+    return report
+
+
+def _create_validated_db_backup() -> tuple[str | None, dict | None]:
+    """Create a DB backup and validate that critical tables still contain data."""
+    backup_dir = _backup_dbs()
+    if not backup_dir:
+        return None, None
+
+    source_db = _find_primary_db_path()
+    if source_db is None:
+        return backup_dir, None
+
+    report = _validate_db_backup(source_db, Path(backup_dir) / source_db.name)
+    if not report["ok"]:
+        details = ", ".join(
+            f"{item['table']} {item['source']}->{item['backup']}"
+            for item in report["regressions"]
+        ) or "; ".join(report["errors"])
+        _log(f"DB backup validation failed: {details}")
+    return backup_dir, report
 
 
 def _read_last_check() -> dict:
@@ -677,6 +780,11 @@ def _check_git_updates() -> str | None:
     if rc != 0:
         return None
 
+    db_backup_dir, backup_report = _create_validated_db_backup()
+    if backup_report is not None and not backup_report["ok"]:
+        _log("Skipping auto-update because the validated pre-update DB backup is not trustworthy.")
+        return None
+
     rc, pull_out, pull_err = _git("pull", "--ff-only")
     if rc != 0:
         _log(f"git pull --ff-only failed: {pull_err}")
@@ -684,9 +792,6 @@ def _check_git_updates() -> str | None:
 
     new_version = _read_package_version()
     new_req_hash = _requirements_hash()
-
-    # Backup databases before any changes that might run migrations
-    db_backup_dir = _backup_dbs()
 
     # Reinstall pip deps if requirements.txt content changed (not just version)
     if old_req_hash != new_req_hash:
@@ -2057,7 +2162,14 @@ def manual_sync_update(*, interactive: bool = False, allow_source_pull: bool = T
             pulled = True
 
     _emit_progress(progress_fn, "Creating runtime backups...")
-    db_backup_dir = _backup_dbs()
+    db_backup_dir, backup_report = _create_validated_db_backup()
+    if backup_report is not None and not backup_report["ok"]:
+        return {
+            "ok": False,
+            "mode": "sync",
+            "error": "DB backup validation failed before runtime sync.",
+            "backup_dir": db_backup_dir,
+        }
     tree_backup_dir = _backup_runtime_tree(NEXO_HOME)
     sync_result = {"ok": False, "mode": "sync", "pulled_source": pulled, "backup_dir": db_backup_dir, "tree_backup": tree_backup_dir}
     try:

--- a/src/cli.py
+++ b/src/cli.py
@@ -26,7 +26,7 @@ Entry points:
   nexo skills evolution [--json]
   nexo clients sync [--json]
   nexo contributor status|on|off [--json]
-  nexo doctor [--tier boot|runtime|deep|all] [--json] [--fix]
+  nexo doctor [--tier boot|runtime|deep|all] [--plane runtime_personal|installation_live|database_real] [--json] [--fix]
   nexo uninstall [--dry-run] [--delete-data] [--json]
 """
 from __future__ import annotations
@@ -1210,7 +1210,7 @@ def _doctor(args):
     init_db()
     tier_label = getattr(args, "tier", "boot") or "boot"
     print(f"[NEXO] Inspecting {tier_label} diagnostics... please wait.", file=sys.stderr, flush=True)
-    report = run_doctor(tier=args.tier, fix=args.fix)
+    report = run_doctor(tier=args.tier, fix=args.fix, plane=getattr(args, "plane", ""))
     output = format_report(report, fmt="json" if args.json else "text")
     print(output)
 
@@ -1749,6 +1749,12 @@ def main():
     doctor_parser = sub.add_parser("doctor", help="Unified diagnostics")
     doctor_parser.add_argument("--tier", default="boot", choices=["boot", "runtime", "deep", "all"],
                                help="Diagnostic tier (default: boot)")
+    doctor_parser.add_argument(
+        "--plane",
+        default="",
+        choices=["", "runtime_personal", "installation_live", "database_real", "product_public", "cooperator"],
+        help="Diagnostic plane. Doctor only runs on runtime_personal, installation_live, or database_real.",
+    )
     doctor_parser.add_argument("--json", action="store_true", help="JSON output")
     doctor_parser.add_argument("--fix", action="store_true", help="Apply deterministic fixes")
 

--- a/src/client_preferences.py
+++ b/src/client_preferences.py
@@ -48,10 +48,13 @@ INSTALL_PREFERENCE_KEYS = {
 }
 DEFAULT_CLAUDE_CODE_MODEL = "claude-opus-4-6[1m]"
 DEFAULT_CLAUDE_CODE_REASONING_EFFORT = ""
-DEFAULT_CODEX_MODEL = "gpt-5.4"
-DEFAULT_CODEX_REASONING_EFFORT = "xhigh"
-DEFAULT_FAST_MODEL = "gpt-5.4-mini"
-DEFAULT_FAST_REASONING_EFFORT = "medium"
+# Codex/fast defaults: fall back to the user's configured model, not a hardcoded
+# third-party model.  The user picks their model once at install time; every
+# profile and backend should honour that choice.
+DEFAULT_CODEX_MODEL = DEFAULT_CLAUDE_CODE_MODEL
+DEFAULT_CODEX_REASONING_EFFORT = ""
+DEFAULT_FAST_MODEL = DEFAULT_CLAUDE_CODE_MODEL
+DEFAULT_FAST_REASONING_EFFORT = ""
 
 
 def _user_home() -> Path:
@@ -260,9 +263,9 @@ def default_automation_task_profiles() -> dict[str, dict[str, str]]:
             "reasoning_effort": "",
         },
         "fast": {
-            "backend": CLIENT_CODEX,
-            "model": DEFAULT_FAST_MODEL,
-            "reasoning_effort": DEFAULT_FAST_REASONING_EFFORT,
+            "backend": "",
+            "model": "",
+            "reasoning_effort": "",
         },
         "balanced": {
             "backend": "",
@@ -521,6 +524,22 @@ def resolve_terminal_client(requested: str | None = None, *, preferences: dict |
         normalized["default_terminal_client"],
         interactive_clients=normalized["interactive_clients"],
     )
+
+
+def resolve_user_model(preferences: dict | None = None) -> str:
+    """Return the single model the user has configured.
+
+    Scripts and automation tasks should call this instead of hardcoding a model
+    string.  The value comes from the user's ``client_runtime_profiles`` for
+    their ``default_terminal_client`` (usually ``claude_code``).
+    """
+    normalized = preferences or load_client_preferences()
+    client = normalize_default_terminal_client(
+        normalized["default_terminal_client"],
+        interactive_clients=normalized["interactive_clients"],
+    )
+    profile = resolve_client_runtime_profile(client, preferences=normalized)
+    return profile["model"]
 
 
 def resolve_automation_backend(preferences: dict | None = None) -> str:

--- a/src/client_sync.py
+++ b/src/client_sync.py
@@ -61,9 +61,10 @@ except Exception:
         }
 
     def resolve_client_runtime_profile(client: str, preferences: dict | None = None) -> dict:
+        _default_model = "claude-opus-4-6[1m]"
         defaults = {
-            "claude_code": {"model": "claude-opus-4-6[1m]", "reasoning_effort": ""},
-            "codex": {"model": "gpt-5.4", "reasoning_effort": "xhigh"},
+            "claude_code": {"model": _default_model, "reasoning_effort": ""},
+            "codex": {"model": _default_model, "reasoning_effort": ""},
         }
         return dict(defaults.get(client, {}))
 

--- a/src/doctor/orchestrator.py
+++ b/src/doctor/orchestrator.py
@@ -6,6 +6,7 @@ import time
 import traceback
 
 from doctor.models import DoctorCheck, DoctorReport
+from doctor.planes import diagnostic_plane_preflight
 from doctor.providers.boot import run_boot_checks
 from doctor.providers.runtime import run_runtime_checks
 from doctor.providers.deep import run_deep_checks
@@ -22,12 +23,13 @@ _TIER_ORDER = ["boot", "runtime", "deep"]
 VALID_TIERS = frozenset(_TIER_ORDER) | {"all"}
 
 
-def run_doctor(tier: str = "boot", fix: bool = False) -> DoctorReport:
+def run_doctor(tier: str = "boot", fix: bool = False, plane: str = "") -> DoctorReport:
     """Run diagnostic checks for the specified tier(s).
 
     Args:
         tier: "boot", "runtime", "deep", or "all"
         fix: If True, apply deterministic fixes where possible
+        plane: Explicit diagnostic plane — runtime_personal, installation_live, or database_real
     """
     report = DoctorReport(overall_status="healthy")
     start = time.monotonic()
@@ -40,6 +42,13 @@ def run_doctor(tier: str = "boot", fix: bool = False) -> DoctorReport:
             severity="error",
             summary=f"Unknown tier '{tier}' — valid options: {', '.join(sorted(VALID_TIERS))}",
         ))
+        report.compute_status()
+        report.duration_ms = int((time.monotonic() - start) * 1000)
+        return report
+
+    _, preflight = diagnostic_plane_preflight(plane)
+    if preflight is not None:
+        report.add(preflight)
         report.compute_status()
         report.duration_ms = int((time.monotonic() - start) * 1000)
         return report

--- a/src/doctor/planes.py
+++ b/src/doctor/planes.py
@@ -1,0 +1,87 @@
+"""Diagnostic plane preflight for NEXO Doctor."""
+
+from __future__ import annotations
+
+from doctor.models import DoctorCheck
+
+VALID_DIAGNOSTIC_PLANES = {
+    "product_public": {
+        "label": "producto público",
+        "use": "release contracts, artefactos publicados, compare/, docs y surfaces públicas del repo",
+    },
+    "runtime_personal": {
+        "label": "runtime personal",
+        "use": "~/.nexo, scripts personales, followups, reminders y hábitos operativos del operador",
+    },
+    "installation_live": {
+        "label": "instalación viva",
+        "use": "runtime instalado, hooks activos, clientes conectados, cron sync y parity de la instalación local",
+    },
+    "database_real": {
+        "label": "BD real",
+        "use": "SQLite/MySQL reales, filas, schema, deudas, sesiones y evidencia persistida",
+    },
+    "cooperator": {
+        "label": "co-operador",
+        "use": "comportamiento del agente, protocolo, comunicación y decisiones del asistente",
+    },
+}
+
+DOCTOR_COMPATIBLE_PLANES = {"runtime_personal", "installation_live", "database_real"}
+
+
+def normalize_diagnostic_plane(plane: str = "") -> str:
+    clean = (plane or "").strip().lower().replace("-", "_").replace(" ", "_")
+    return clean if clean in VALID_DIAGNOSTIC_PLANES else ""
+
+
+def diagnostic_plane_choices() -> list[str]:
+    return sorted(VALID_DIAGNOSTIC_PLANES)
+
+
+def diagnostic_plane_preflight(plane: str = "") -> tuple[str, DoctorCheck | None]:
+    clean_plane = normalize_diagnostic_plane(plane)
+    if not clean_plane:
+        options = ", ".join(diagnostic_plane_choices())
+        return "", DoctorCheck(
+            id="orchestrator.diagnostic_plane_required",
+            tier="orchestrator",
+            status="critical",
+            severity="error",
+            summary="El diagnóstico está bloqueado hasta fijar explícitamente el plano",
+            evidence=[
+                f"planes válidos: {options}",
+                "Usa `runtime_personal` para ~/.nexo y hábitos del runtime; `installation_live` para hooks/clientes/instalación; `database_real` para filas y schema reales.",
+            ],
+            repair_plan=[
+                "Repite `nexo_doctor` o `nexo doctor` con `plane='runtime_personal'`, `plane='installation_live'` o `plane='database_real'`.",
+                "Si el problema pertenece a producto público o al co-operador, usa el surface correcto en vez de NEXO Doctor.",
+            ],
+            escalation_prompt=(
+                "NEXO mezcló planos en diagnósticos anteriores. El doctor no debe correr hasta que se elija "
+                "explícitamente si el problema está en producto público, runtime personal, instalación viva, BD real o co-operador."
+            ),
+        )
+
+    if clean_plane not in DOCTOR_COMPATIBLE_PLANES:
+        plane_info = VALID_DIAGNOSTIC_PLANES[clean_plane]
+        return clean_plane, DoctorCheck(
+            id="orchestrator.diagnostic_plane_mismatch",
+            tier="orchestrator",
+            status="degraded",
+            severity="warn",
+            summary=f"NEXO Doctor no es la superficie correcta para el plano {plane_info['label']}",
+            evidence=[
+                f"plane: {clean_plane}",
+                f"este plano se diagnostica mejor desde: {plane_info['use']}",
+            ],
+            repair_plan=[
+                "Si quieres diagnosticar runtime/instalación/BD, vuelve a lanzar el doctor con el plano correcto.",
+                "Si el problema es del producto público o del co-operador, usa release checks, repo checks o herramientas de protocolo/sesión en vez de Doctor.",
+            ],
+            escalation_prompt=(
+                "El plano elegido no corresponde al runtime doctor. Cambia de plano o de herramienta antes de seguir para no mezclar diagnóstico técnico con producto o comportamiento del agente."
+            ),
+        )
+
+    return clean_plane, None

--- a/src/hook_guardrails.py
+++ b/src/hook_guardrails.py
@@ -14,6 +14,21 @@ from protocol_settings import get_protocol_strictness
 READ_LIKE_TOOLS = {"Read"}
 WRITE_LIKE_TOOLS = {"Edit", "MultiEdit", "Write"}
 DELETE_LIKE_TOOLS = {"Delete"}
+NON_TRIVIAL_PROTOCOL_TOOLS = {"Read", "Bash", "Grep", "Glob", "Edit", "MultiEdit", "Write", "Delete"}
+PROTOCOL_SKIP_TOOLS = {
+    "nexo_startup",
+    "nexo_smart_startup",
+    "nexo_stop",
+    "nexo_heartbeat",
+    "nexo_task_open",
+    "nexo_task_close",
+    "nexo_workflow_open",
+    "nexo_workflow_update",
+    "nexo_guard_check",
+    "nexo_guard_file_check",
+    "nexo_rules_check",
+}
+ACTION_TASK_TYPES = {"edit", "execute", "delegate"}
 NEXO_CODE_ROOT = Path(os.environ.get("NEXO_CODE", str(Path(__file__).resolve().parent))).expanduser().resolve()
 LIVE_REPO_ROOT = NEXO_CODE_ROOT.parent if NEXO_CODE_ROOT.name == "src" else NEXO_CODE_ROOT
 PUBLIC_REPO_DIRS = {
@@ -48,6 +63,11 @@ def _operation_kind(tool_name: str) -> str:
     if tool_name in DELETE_LIKE_TOOLS:
         return "delete"
     return "other"
+
+
+def _short_tool_name(tool_name: str) -> str:
+    clean = str(tool_name or "").strip()
+    return clean.rsplit("__", 1)[-1] if "__" in clean else clean
 
 
 def _normalize_file_path(path: str) -> str:
@@ -154,7 +174,8 @@ def _resolve_nexo_sid(conn, external_session_id: str) -> str:
 def _find_open_task_for_file(conn, sid: str, filepath: str) -> dict | None:
     target = _normalize_file_path(filepath)
     rows = conn.execute(
-        """SELECT task_id, files, guard_has_blocking
+        """SELECT task_id, files, guard_has_blocking, task_type, plan, unknowns,
+                  verification_step, opened_with_guard, must_change_log, must_verify
            FROM protocol_tasks
            WHERE session_id = ? AND status = 'open'
            ORDER BY opened_at DESC""",
@@ -173,7 +194,8 @@ def _find_open_task_for_file(conn, sid: str, filepath: str) -> dict | None:
 
 def _find_any_open_task(conn, sid: str) -> dict | None:
     row = conn.execute(
-        """SELECT task_id, files, guard_has_blocking
+        """SELECT task_id, files, guard_has_blocking, task_type, plan, unknowns,
+                  verification_step, opened_with_guard, must_change_log, must_verify
            FROM protocol_tasks
            WHERE session_id = ? AND status = 'open'
            ORDER BY opened_at DESC
@@ -181,6 +203,26 @@ def _find_any_open_task(conn, sid: str) -> dict | None:
         (sid,),
     ).fetchone()
     return dict(row) if row else None
+
+
+def _find_any_open_workflow(conn, sid: str) -> dict | None:
+    row = conn.execute(
+        """SELECT run_id, protocol_task_id, current_step_key
+           FROM workflow_runs
+           WHERE session_id = ? AND status IN ('open', 'running', 'blocked', 'waiting_approval')
+           ORDER BY updated_at DESC, run_id DESC
+           LIMIT 1""",
+        (sid,),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def _session_has_guard_check(conn, sid: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM guard_checks WHERE session_id = ? LIMIT 1",
+        (sid,),
+    ).fetchone()
+    return bool(row)
 
 
 def _find_open_debt(conn, *, session_id: str, task_id: str, debt_type: str, file_token: str) -> dict | None:
@@ -239,6 +281,98 @@ def _ensure_protocol_debt(
         task_id=task_id,
         evidence=evidence,
     )
+
+
+def _task_list_field(task: dict | None, key: str) -> list:
+    if not task:
+        return []
+    try:
+        parsed = json.loads(task.get(key) or "[]")
+    except Exception:
+        return []
+    return parsed if isinstance(parsed, list) else []
+
+
+def _task_needs_workflow(task: dict | None) -> bool:
+    if not task:
+        return False
+    if str(task.get("task_type") or "").strip() not in ACTION_TASK_TYPES:
+        return False
+    if len(_task_list_field(task, "plan")) > 1:
+        return True
+    if len(_task_list_field(task, "unknowns")) > 0:
+        return True
+    if len(_task_list_field(task, "files")) > 1:
+        return True
+    return bool(str(task.get("verification_step") or "").strip())
+
+
+def _append_protocol_warning(warnings: list[dict], message: str) -> None:
+    clean = (message or "").strip()
+    if not clean:
+        return
+    if any((item.get("message") or "").strip() == clean for item in warnings):
+        return
+    warnings.append({"message": clean})
+
+
+def _collect_protocol_warnings(conn, *, sid: str, tool_name: str) -> list[dict]:
+    short_name = _short_tool_name(tool_name)
+    if short_name in PROTOCOL_SKIP_TOOLS or short_name not in NON_TRIVIAL_PROTOCOL_TOOLS:
+        return []
+
+    warnings: list[dict] = []
+    if not sid:
+        _append_protocol_warning(
+            warnings,
+            "Trabajo no trivial detectado antes de `nexo_startup(...)`. Arranca NEXO, abre `nexo_task_open(...)`, y si esto va a durar varias fases abre también `nexo_workflow_open(...)` antes de seguir.",
+        )
+        return warnings
+
+    task = _find_any_open_task(conn, sid)
+    has_guard = _session_has_guard_check(conn, sid)
+    if not task:
+        guard_note = (
+            " Ejecuta `nexo_guard_check(...)` antes de leer código condicionado o compartido."
+            if short_name in {"Read", "Bash", "Grep", "Glob"} and not has_guard
+            else ""
+        )
+        _append_protocol_warning(
+            warnings,
+            "Trabajo no trivial detectado sin `nexo_task_open(...)`. Ábrelo ahora y, si esto va a cruzar varios pasos o mensajes, añade `nexo_workflow_open(...)`." + guard_note,
+        )
+        _append_protocol_warning(
+            warnings,
+            "Recordatorio protocolario: mantén `nexo_heartbeat(...)` al día y no cierres en optimista; si hay cambios reales, registra `nexo_change_log(...)` o cierra con `nexo_task_close(...)` más evidencia.",
+        )
+        return warnings
+
+    task_id = str(task.get("task_id") or "").strip()
+    if str(task.get("task_type") or "").strip() in ACTION_TASK_TYPES and not (task.get("opened_with_guard") or has_guard):
+        _append_protocol_warning(
+            warnings,
+            f"La tarea {task_id} está activa sin guard visible. Ejecuta `nexo_guard_check(...)` antes de tocar código condicionado o compartido.",
+        )
+
+    workflow = _find_any_open_workflow(conn, sid)
+    if _task_needs_workflow(task) and not workflow:
+        _append_protocol_warning(
+            warnings,
+            f"La tarea {task_id} ya tiene pinta de multi-step y sigue sin `nexo_workflow_open(...)`. Ábrelo para que checkpoints, resume y replay no dependan de memoria implícita.",
+        )
+
+    if str(task.get("task_type") or "").strip() in ACTION_TASK_TYPES and short_name in {"Bash", "Edit", "MultiEdit", "Write", "Delete"}:
+        change_note = (
+            " Si editas de verdad y no vas a usar `nexo_task_close(...)` inmediatamente, captura `nexo_change_log(...)`."
+            if task.get("must_change_log")
+            else ""
+        )
+        _append_protocol_warning(
+            warnings,
+            f"Recordatorio protocolario para {task_id}: mantén `nexo_heartbeat(...)` al día y ciérrala con `nexo_task_close(...)` más evidencia antes de decir que está resuelta.{change_note}",
+        )
+
+    return warnings
 
 
 def _collect_automation_live_repo_blocks(
@@ -429,21 +563,20 @@ def process_pre_tool_event(payload: dict) -> dict:
 def process_tool_event(payload: dict) -> dict:
     tool_name = str(payload.get("tool_name", "")).strip()
     op = _operation_kind(tool_name)
-    if op == "other":
-        return {"ok": True, "skipped": True, "reason": "tool not monitored"}
-
     tool_input = payload.get("tool_input")
     files = _extract_touched_files(tool_input)
-    if not files:
-        return {"ok": True, "skipped": True, "reason": "no touched files found"}
-
     conn = get_db()
     sid = _resolve_nexo_sid(conn, str(payload.get("session_id", "")))
-    if not sid:
+    warnings = _collect_protocol_warnings(conn, sid=sid, tool_name=tool_name)
+
+    if op == "other" and not warnings:
+        return {"ok": True, "skipped": True, "reason": "tool not monitored"}
+    if not files and op in {"read", "write", "delete"} and not warnings:
+        return {"ok": True, "skipped": True, "reason": "no touched files found"}
+    if not sid and not warnings:
         return {"ok": True, "skipped": True, "reason": "session not mapped to nexo"}
 
-    conditioned = _load_conditioned_learnings(conn, files)
-    warnings: list[dict] = []
+    conditioned = _load_conditioned_learnings(conn, files) if sid else {}
     violations: list[dict] = []
 
     for filepath in files:
@@ -545,6 +678,9 @@ def format_hook_message(result: dict) -> str:
         return ""
     lines = ["NEXO DISCIPLINE:"]
     for item in result.get("warnings", []):
+        if item.get("message") and not item.get("learning_ids"):
+            lines.append(f"- PROTOCOL REMINDER: {item['message']}")
+            continue
         if item.get("debt_id"):
             lines.append(
                 f"- REVIEW FILE RULES: {item['file']} -> learnings {item['learning_ids']}. "

--- a/src/plugins/doctor.py
+++ b/src/plugins/doctor.py
@@ -11,13 +11,14 @@ if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
 
 
-def handle_doctor(tier: str = "boot", fix: bool = False, output: str = "text") -> str:
+def handle_doctor(tier: str = "boot", fix: bool = False, output: str = "text", plane: str = "") -> str:
     """Unified diagnostic report for boot/runtime/deep health.
 
     Args:
         tier: Diagnostic tier — boot, runtime, deep, or all (default: boot)
         fix: Apply deterministic fixes (default: False)
         output: Output format — text or json (default: text)
+        plane: Diagnostic plane — runtime_personal, installation_live, or database_real
     """
     from doctor.orchestrator import run_doctor
     from doctor.formatters import format_report
@@ -27,7 +28,7 @@ def handle_doctor(tier: str = "boot", fix: bool = False, output: str = "text") -
     if output not in ("text", "json"):
         return f"Invalid output '{output}'. Use: text, json"
 
-    report = run_doctor(tier=tier, fix=fix)
+    report = run_doctor(tier=tier, fix=fix, plane=plane)
     return format_report(report, fmt=output)
 
 

--- a/src/plugins/schedule.py
+++ b/src/plugins/schedule.py
@@ -20,6 +20,9 @@ from script_registry import (
     get_declared_schedule,
 )
 
+LEGACY_BACKUP_CRON_ID = "backup"
+LEGACY_BACKUP_SUMMARY = "legacy backup file evidence"
+
 
 def handle_schedule_status(hours: int = 24, cron_id: str = '') -> str:
     """Show cron execution status — what ran, what failed, durations.
@@ -30,6 +33,8 @@ def handle_schedule_status(hours: int = 24, cron_id: str = '') -> str:
     """
     if cron_id:
         runs = cron_runs_recent(hours, cron_id)
+        if cron_id == LEGACY_BACKUP_CRON_ID:
+            runs = _select_backup_runs(runs, hours)
         if not runs:
             return f"No runs for '{cron_id}' in the last {hours}h."
         schedule_meta = get_personal_script_schedule(cron_id) or {}
@@ -53,7 +58,7 @@ def handle_schedule_status(hours: int = 24, cron_id: str = '') -> str:
         return "\n".join(lines)
 
     # Summary view — one line per cron
-    summary = cron_runs_summary(hours)
+    summary = _merge_legacy_summaries(cron_runs_summary(hours), hours)
     if not summary:
         return f"No cron executions recorded in the last {hours}h."
 
@@ -80,6 +85,119 @@ def handle_schedule_status(hours: int = 24, cron_id: str = '') -> str:
         lines.append(f"  {status} {s['cron_id']}: {rate}, {dur}{summary_txt}{suffix}")
 
     return "\n".join(lines)
+
+
+def _select_backup_runs(db_runs: list[dict], hours: int) -> list[dict]:
+    legacy_runs = _legacy_backup_runs(hours)
+    if _prefer_legacy_over_db(db_runs, legacy_runs):
+        return legacy_runs
+    return db_runs
+
+
+def _merge_legacy_summaries(summary_rows: list[dict], hours: int) -> list[dict]:
+    rows = [dict(row) for row in (summary_rows or [])]
+    legacy_summary = _legacy_backup_summary(hours)
+    if not legacy_summary:
+        return rows
+    by_cron_id = {row["cron_id"]: row for row in rows}
+    existing = by_cron_id.get(LEGACY_BACKUP_CRON_ID)
+    if _prefer_legacy_summary(existing, legacy_summary):
+        by_cron_id[LEGACY_BACKUP_CRON_ID] = legacy_summary
+    return sorted(
+        by_cron_id.values(),
+        key=lambda row: row.get("last_run") or "",
+        reverse=True,
+    )
+
+
+def _prefer_legacy_over_db(db_runs: list[dict], legacy_runs: list[dict]) -> bool:
+    if not legacy_runs:
+        return False
+    if not db_runs:
+        return True
+    latest_db = _parse_db_timestamp(db_runs[0].get("started_at"))
+    latest_legacy = _parse_db_timestamp(legacy_runs[0].get("started_at"))
+    if latest_legacy is None:
+        return False
+    if latest_db is None:
+        return True
+    return latest_legacy > latest_db
+
+
+def _prefer_legacy_summary(existing: dict | None, legacy: dict) -> bool:
+    if not legacy:
+        return False
+    if not existing:
+        return True
+    latest_existing = _parse_db_timestamp(existing.get("last_run"))
+    latest_legacy = _parse_db_timestamp(legacy.get("last_run"))
+    if latest_legacy is None:
+        return False
+    if latest_existing is None:
+        return True
+    return latest_legacy > latest_existing
+
+
+def _legacy_backup_summary(hours: int) -> dict | None:
+    runs = _legacy_backup_runs(hours)
+    if not runs:
+        return None
+    return _build_summary_from_runs(LEGACY_BACKUP_CRON_ID, runs)
+
+
+def _legacy_backup_runs(hours: int) -> list[dict]:
+    nexo_home = Path(os.environ.get("NEXO_HOME", str(Path.home() / ".nexo")))
+    backup_dir = nexo_home / "backups"
+    if not backup_dir.exists():
+        return []
+    cutoff = _now_utc().timestamp() - (hours * 3600)
+    runs: list[dict] = []
+    for backup_file in backup_dir.glob("nexo-*.db"):
+        try:
+            stat = backup_file.stat()
+        except OSError:
+            continue
+        if stat.st_mtime < cutoff:
+            continue
+        started = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).replace(microsecond=0)
+        started_at = started.strftime("%Y-%m-%d %H:%M:%S")
+        runs.append(
+            {
+                "cron_id": LEGACY_BACKUP_CRON_ID,
+                "started_at": started_at,
+                "ended_at": started_at,
+                "exit_code": 0,
+                "summary": LEGACY_BACKUP_SUMMARY,
+                "error": "",
+                "duration_secs": 1.0,
+            }
+        )
+    runs.sort(key=lambda row: row["started_at"], reverse=True)
+    return runs
+
+
+def _build_summary_from_runs(cron_id: str, runs: list[dict]) -> dict:
+    completed_runs = [
+        row for row in runs if row.get("exit_code") is not None and row.get("ended_at")
+    ]
+    duration_values = [
+        float(row["duration_secs"])
+        for row in completed_runs
+        if row.get("duration_secs") is not None
+    ]
+    return {
+        "cron_id": cron_id,
+        "total_runs": len(runs),
+        "succeeded": sum(1 for row in completed_runs if row.get("exit_code") == 0),
+        "completed_runs": len(completed_runs),
+        "failed": sum(1 for row in completed_runs if row.get("exit_code") not in (None, 0)),
+        "open_runs": len(runs) - len(completed_runs),
+        "avg_duration": round(sum(duration_values) / len(duration_values), 1) if duration_values else None,
+        "last_run": runs[0].get("started_at"),
+        "last_exit_code": runs[0].get("exit_code"),
+        "last_ended_at": runs[0].get("ended_at"),
+        "last_summary": next((row.get("summary") for row in runs if row.get("summary")), ""),
+    }
 
 
 def _summary_has_warning(summary: str = "") -> bool:

--- a/src/runtime_power.py
+++ b/src/runtime_power.py
@@ -67,8 +67,9 @@ MACOS_FDA_PROBE_PATHS = (
 )
 DEFAULT_CLAUDE_CODE_MODEL = "claude-opus-4-6[1m]"
 DEFAULT_CLAUDE_CODE_REASONING_EFFORT = ""
-DEFAULT_CODEX_MODEL = "gpt-5.4"
-DEFAULT_CODEX_REASONING_EFFORT = "xhigh"
+# Codex defaults mirror the user's primary model — no hardcoded third-party models.
+DEFAULT_CODEX_MODEL = DEFAULT_CLAUDE_CODE_MODEL
+DEFAULT_CODEX_REASONING_EFFORT = ""
 
 
 def _schedule_defaults() -> dict:

--- a/src/scripts/nexo-cortex-cycle.py
+++ b/src/scripts/nexo-cortex-cycle.py
@@ -18,9 +18,9 @@ What this script does (idempotent and best-effort):
 3. Detects degradation signals on the 7-day window. The criteria are
    intentionally conservative to avoid false alarms on small samples:
      a. recommendation_accept_rate < 50% AND total_evaluations >= 10
-     b. linked_outcome_success_rate < 50% AND linked_outcomes_total >= 5
+     b. linked_outcome_success_rate < 50% AND linked_outcomes_resolved >= 5
      c. override_success_rate > recommended_success_rate by >= 20pp
-        AND linked_outcomes_total >= 5
+        AND linked_outcomes_resolved >= 5
 4. Opens (or refreshes) NF-CORTEX-QUALITY-DROP followup with the offending
    metrics when degradation is detected. Idempotent: if a non-PENDING /
    resolved followup of the same id already exists, it is updated in
@@ -96,6 +96,13 @@ def detect_quality_signals(summary: dict) -> list[dict]:
     total = int(summary.get("total_evaluations") or 0)
     accept_rate = float(summary.get("recommendation_accept_rate") or 0.0)
     linked_total = int(summary.get("linked_outcomes_total") or 0)
+    linked_met = int(summary.get("linked_outcomes_met") or 0)
+    linked_missed = int(summary.get("linked_outcomes_missed") or 0)
+    linked_pending = int(summary.get("linked_outcomes_pending") or 0)
+    linked_resolved = linked_met + linked_missed
+    if linked_resolved <= 0 and linked_total > 0:
+        # Older callers may omit the met/missed counters; fall back to total minus pending.
+        linked_resolved = max(0, linked_total - linked_pending)
     linked_success = float(summary.get("linked_outcome_success_rate") or 0.0)
     recommended_success = float(summary.get("recommended_success_rate") or 0.0)
     override_success = float(summary.get("override_success_rate") or 0.0)
@@ -114,21 +121,25 @@ def detect_quality_signals(summary: dict) -> list[dict]:
             ),
         })
 
-    if linked_total >= LINKED_MIN_SAMPLE and linked_success < LINKED_SUCCESS_FLOOR:
+    linked_scope = f"{linked_resolved} resolved linked outcomes"
+    if linked_pending > 0:
+        linked_scope += f" ({linked_total} total, {linked_pending} pending)"
+
+    if linked_resolved >= LINKED_MIN_SAMPLE and linked_success < LINKED_SUCCESS_FLOOR:
         signals.append({
             "kind": "linked_success",
             "severity": "warn",
             "metric_value": linked_success,
             "threshold": LINKED_SUCCESS_FLOOR,
-            "sample_size": linked_total,
+            "sample_size": linked_resolved,
             "message": (
                 f"Cortex linked-outcome success rate {linked_success:.1f}% on "
-                f"{linked_total} linked outcomes is below the "
+                f"{linked_scope} is below the "
                 f"{LINKED_SUCCESS_FLOOR:.0f}% floor."
             ),
         })
 
-    if linked_total >= LINKED_MIN_SAMPLE:
+    if linked_resolved >= LINKED_MIN_SAMPLE:
         gap = override_success - recommended_success
         if gap >= OVERRIDE_GAP_THRESHOLD:
             signals.append({
@@ -136,12 +147,12 @@ def detect_quality_signals(summary: dict) -> list[dict]:
                 "severity": "error",
                 "metric_value": gap,
                 "threshold": OVERRIDE_GAP_THRESHOLD,
-                "sample_size": linked_total,
+                "sample_size": linked_resolved,
                 "message": (
                     f"Cortex overrides outperform recommendations by {gap:.1f}pp "
                     f"(override {override_success:.1f}% vs recommended "
-                    f"{recommended_success:.1f}% on {linked_total} linked "
-                    "outcomes). The recommender is mis-ranking choices."
+                    f"{recommended_success:.1f}% on {linked_scope}). The "
+                    "recommender is mis-ranking choices."
                 ),
             })
 
@@ -171,14 +182,36 @@ def _upsert_quality_followup(signals: list[dict]) -> str:
     resolved, a fresh row is inserted with the same id (REPLACE) so the
     new degradation pattern is visible.
     """
-    if not signals:
-        return "no_signal"
-
     try:
-        from db import get_followup, get_db
+        from db import complete_followup, get_followup, get_db
     except Exception as e:
         _log(f"WARN: cannot import db helpers: {e}")
         return "skipped_no_db"
+
+    try:
+        existing = get_followup(FOLLOWUP_ID)
+    except Exception as e:
+        _log(f"WARN: get_followup raised: {e}")
+        existing = None
+
+    if not signals:
+        if not existing:
+            return "no_signal"
+        status = str(existing.get("status") or "").upper()
+        if status.startswith("COMPLETED") or status in {"DELETED", "ARCHIVED", "BLOCKED", "WAITING", "CANCELLED"}:
+            return "no_signal"
+        try:
+            complete_followup(
+                FOLLOWUP_ID,
+                result=(
+                    "Auto-resolved by cortex-cycle: no active degradation signals in the "
+                    "current 7d window."
+                ),
+            )
+        except Exception as e:
+            _log(f"WARN: failed to close followup: {e}")
+            return "failed_close"
+        return "closed"
 
     summary_lines = ["Cortex continuous validation found quality degradation:"]
     for sig in signals:
@@ -196,12 +229,6 @@ def _upsert_quality_followup(signals: list[dict]) -> str:
         "created_at FROM cortex_evaluations ORDER BY id DESC LIMIT 20"
     )
     now_epoch = datetime.now().timestamp()
-
-    try:
-        existing = get_followup(FOLLOWUP_ID)
-    except Exception as e:
-        _log(f"WARN: get_followup raised: {e}")
-        existing = None
 
     try:
         conn = get_db()
@@ -255,8 +282,8 @@ def run() -> int:
             f"signals={len(signals)}"
         )
 
-    if signals:
-        action = _upsert_quality_followup(signals)
+    action = _upsert_quality_followup(signals)
+    if signals or action not in {"no_signal"}:
         _log(f"Cortex cycle: followup {FOLLOWUP_ID} {action} ({len(signals)} signal(s))")
 
     return 0

--- a/src/scripts/nexo-daily-self-audit.py
+++ b/src/scripts/nexo-daily-self-audit.py
@@ -479,6 +479,43 @@ def _upsert_workflow_goal_inline(conn: sqlite3.Connection, *, area: str, sample_
 
     columns = _table_columns(conn, "workflow_goals")
     signature = _topic_signature(sample_goal)
+    goal_id = f"WG-AUDIT-{hashlib.sha1(f'{area}:{signature or sample_goal}'.encode('utf-8'), usedforsecurity=False).hexdigest()[:8].upper()}"
+
+    def _write_goal(existing_row: sqlite3.Row, *, reactivated: bool) -> dict:
+        updates: dict[str, object] = {}
+        if "title" in columns:
+            updates["title"] = sample_goal[:140]
+        if "objective" in columns:
+            updates["objective"] = objective
+        if "priority" in columns:
+            updates["priority"] = "high"
+        if "owner" in columns:
+            updates["owner"] = AUDIT_GOAL_OWNER
+        if "next_action" in columns:
+            updates["next_action"] = next_action
+        if "success_signal" in columns:
+            updates["success_signal"] = success_signal
+        if "shared_state" in columns:
+            updates["shared_state"] = json.dumps({"area": area, "signature": signature, "source": "self-audit"})
+        if reactivated and "status" in columns:
+            updates["status"] = "active"
+        if reactivated and "blocker_reason" in columns:
+            updates["blocker_reason"] = ""
+        if reactivated and "closed_at" in columns:
+            updates["closed_at"] = None
+        if "updated_at" in columns:
+            updates["updated_at"] = now_iso
+        assignments = ", ".join(f"{column} = ?" for column in updates)
+        conn.execute(
+            f"UPDATE workflow_goals SET {assignments} WHERE goal_id = ?",
+            [updates[column] for column in updates] + [existing_row["goal_id"]],
+        )
+        return {
+            "ok": True,
+            "action": "reactivated" if reactivated else "updated",
+            "goal_id": str(existing_row["goal_id"]),
+        }
+
     rows = conn.execute(
         """SELECT * FROM workflow_goals
            WHERE status NOT IN ('completed', 'cancelled', 'abandoned')
@@ -499,31 +536,21 @@ def _upsert_workflow_goal_inline(conn: sqlite3.Connection, *, area: str, sample_
     next_action = AUDIT_GOAL_NEXT_ACTION
     success_signal = "The theme stops resurfacing in unresolved protocol tasks."
     now_iso = datetime.now().isoformat(timespec="seconds")
-    if existing:
-        updates: dict[str, object] = {}
-        if "title" in columns:
-            updates["title"] = sample_goal[:140]
-        if "objective" in columns:
-            updates["objective"] = objective
-        if "priority" in columns:
-            updates["priority"] = "high"
-        if "owner" in columns:
-            updates["owner"] = AUDIT_GOAL_OWNER
-        if "next_action" in columns:
-            updates["next_action"] = next_action
-        if "success_signal" in columns:
-            updates["success_signal"] = success_signal
-        if "updated_at" in columns:
-            updates["updated_at"] = now_iso
-        assignments = ", ".join(f"{column} = ?" for column in updates)
-        conn.execute(
-            f"UPDATE workflow_goals SET {assignments} WHERE goal_id = ?",
-            [updates[column] for column in updates] + [existing["goal_id"]],
+    exact = conn.execute(
+        "SELECT * FROM workflow_goals WHERE goal_id = ? LIMIT 1",
+        (goal_id,),
+    ).fetchone()
+    if exact is not None:
+        exact_status = str(exact["status"] or "").lower()
+        return _write_goal(
+            exact,
+            reactivated=exact_status in {"completed", "cancelled", "abandoned"},
         )
-        return {"ok": True, "action": "updated", "goal_id": str(existing["goal_id"])}
+
+    if existing:
+        return _write_goal(existing, reactivated=False)
 
     # Content fingerprint, not security-sensitive.
-    goal_id = f"WG-AUDIT-{hashlib.sha1(f'{area}:{signature or sample_goal}'.encode('utf-8'), usedforsecurity=False).hexdigest()[:8].upper()}"
     values: dict[str, object] = {"goal_id": goal_id}
     if "session_id" in columns:
         values["session_id"] = ""

--- a/src/scripts/rehydrate_learnings_from_archive.py
+++ b/src/scripts/rehydrate_learnings_from_archive.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""Rehydrate archived markdown learnings back into the NEXO learnings table.
+
+The original Evolution #5 incident found an empty learnings table while the
+historical archive still existed as markdown grouped by domain. This helper
+parses the archive format used in those files:
+
+- markdown tables with `Error | Solucion`
+- dated sections with bullet/numbered operational learnings
+
+Dry-run is the default. Pass `--apply` to insert missing learnings.
+"""
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_SRC = Path(__file__).resolve().parents[1]
+if str(REPO_SRC) not in sys.path:
+    sys.path.insert(0, str(REPO_SRC))
+
+from db import create_learning, get_db, init_db  # noqa: E402
+from runtime_home import export_resolved_nexo_home  # noqa: E402
+
+NEXO_HOME = export_resolved_nexo_home()
+TABLE_HEADER_TITLES = {"error", "problema", "issue"}
+DEFAULT_ARCHIVE_DIRS = (
+    NEXO_HOME / "claude" / "operations" / "archive" / "learnings",
+    Path.home() / "claude" / "operations" / "archive" / "learnings",
+    Path.home() / ".claude" / "operations" / "archive" / "learnings",
+)
+
+
+@dataclass(frozen=True)
+class LearningCandidate:
+    category: str
+    title: str
+    content: str
+    reasoning: str
+    prevention: str
+    status: str = "active"
+
+
+def _strip_markdown(text: str) -> str:
+    text = text.replace("**", "").replace("__", "")
+    text = text.replace("~~", "")
+    text = re.sub(r"`([^`]*)`", r"\1", text)
+    text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
+    text = re.sub(r"\s+", " ", text).strip(" |")
+    return text.strip()
+
+
+def _derive_title(text: str) -> str:
+    first_sentence = re.split(r"(?<=[.!?])\s+", text, maxsplit=1)[0].strip()
+    if not first_sentence:
+        first_sentence = text.strip()
+    return first_sentence[:180].rstrip(" .")
+
+
+def _derive_prevention(text: str) -> str:
+    match = re.search(r"(Regla:\s*.*|SIEMPRE\s+.*|NUNCA\s+.*)", text, flags=re.IGNORECASE)
+    if match:
+        return match.group(1).strip()
+    return text[:500].strip()
+
+
+def _candidate_reasoning(path: Path, section: str) -> str:
+    section_note = f" [{section}]" if section and section != path.stem else ""
+    return f"Rehydrated from markdown archive {path.name}{section_note}"
+
+
+def _parse_table_row(path: Path, section: str, line: str) -> LearningCandidate | None:
+    parts = [_strip_markdown(cell) for cell in line.strip().strip("|").split("|")]
+    if len(parts) < 2:
+        return None
+    title, prevention = parts[0], parts[1]
+    if title.lower() in TABLE_HEADER_TITLES or set(title) <= {"-"}:
+        return None
+    if not title or not prevention:
+        return None
+    status = "superseded" if "obsoleto" in prevention.lower() or "obsoleto" in title.lower() else "active"
+    content = f"{title}. {prevention}"
+    return LearningCandidate(
+        category=path.stem,
+        title=title,
+        content=content,
+        reasoning=_candidate_reasoning(path, section),
+        prevention=prevention,
+        status=status,
+    )
+
+
+def _consume_bullet_block(lines: list[str], start: int) -> tuple[str, int]:
+    pieces = [re.sub(r"^([-*]|\d+\.)\s+", "", lines[start].strip())]
+    idx = start + 1
+    while idx < len(lines):
+        stripped = lines[idx].strip()
+        if not stripped:
+            break
+        if stripped.startswith("## ") or stripped.startswith("|"):
+            break
+        if re.match(r"^([-*]|\d+\.)\s+", stripped):
+            break
+        pieces.append(stripped)
+        idx += 1
+    return _strip_markdown(" ".join(pieces)), idx
+
+
+def _parse_bullet(path: Path, section: str, text: str) -> LearningCandidate | None:
+    if len(text) < 12:
+        return None
+    title = _derive_title(text)
+    prevention = _derive_prevention(text)
+    status = "superseded" if "obsoleto" in text.lower() else "active"
+    return LearningCandidate(
+        category=path.stem,
+        title=title,
+        content=text,
+        reasoning=_candidate_reasoning(path, section),
+        prevention=prevention,
+        status=status,
+    )
+
+
+def parse_archive_file(path: Path) -> list[LearningCandidate]:
+    lines = path.read_text(encoding="utf-8", errors="ignore").splitlines()
+    section = path.stem
+    results: list[LearningCandidate] = []
+    idx = 0
+    while idx < len(lines):
+        stripped = lines[idx].strip()
+        if stripped.startswith("## "):
+            section = _strip_markdown(stripped[3:])
+            idx += 1
+            continue
+        if stripped.startswith("|") and not re.match(r"^\|\s*-", stripped):
+            row = _parse_table_row(path, section, stripped)
+            if row is not None:
+                results.append(row)
+            idx += 1
+            continue
+        if re.match(r"^([-*]|\d+\.)\s+", stripped):
+            block, next_idx = _consume_bullet_block(lines, idx)
+            row = _parse_bullet(path, section, block)
+            if row is not None:
+                results.append(row)
+            idx = next_idx
+            continue
+        idx += 1
+    return results
+
+
+def parse_archive_dir(archive_dir: Path) -> list[LearningCandidate]:
+    candidates: list[LearningCandidate] = []
+    for path in sorted(archive_dir.glob("*.md")):
+        candidates.extend(parse_archive_file(path))
+
+    deduped: list[LearningCandidate] = []
+    seen: set[tuple[str, str]] = set()
+    for item in candidates:
+        key = (item.category.lower(), item.title.lower())
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(item)
+    return deduped
+
+
+def resolve_archive_dir(explicit: str = "") -> Path:
+    if explicit:
+        path = Path(explicit).expanduser()
+        if not path.is_dir():
+            raise FileNotFoundError(f"archive dir not found: {path}")
+        return path
+    for candidate in DEFAULT_ARCHIVE_DIRS:
+        if candidate.is_dir():
+            return candidate
+    raise FileNotFoundError(
+        "No learnings archive found. Tried: "
+        + ", ".join(str(path) for path in DEFAULT_ARCHIVE_DIRS)
+    )
+
+
+def apply_candidates(candidates: list[LearningCandidate], *, apply: bool) -> dict:
+    init_db()
+    conn = get_db()
+    existing = {
+        (row[0].lower(), row[1].lower())
+        for row in conn.execute("SELECT category, title FROM learnings").fetchall()
+    }
+    inserted = 0
+    skipped = 0
+    for item in candidates:
+        key = (item.category.lower(), item.title.lower())
+        if key in existing:
+            skipped += 1
+            continue
+        if apply:
+            create_learning(
+                item.category,
+                item.title,
+                item.content,
+                reasoning=item.reasoning,
+                prevention=item.prevention,
+                status=item.status,
+            )
+        existing.add(key)
+        inserted += 1
+    return {
+        "parsed": len(candidates),
+        "inserted": inserted,
+        "skipped_existing": skipped,
+        "mode": "apply" if apply else "dry-run",
+    }
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--archive-dir", default="", help="Override archive directory")
+    parser.add_argument("--apply", action="store_true", help="Insert parsed learnings into the DB")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    try:
+        archive_dir = resolve_archive_dir(args.archive_dir)
+    except FileNotFoundError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    candidates = parse_archive_dir(archive_dir)
+    summary = apply_candidates(candidates, apply=args.apply)
+    print(
+        f"{summary['mode']}: archive={archive_dir} parsed={summary['parsed']} "
+        f"inserted={summary['inserted']} skipped_existing={summary['skipped_existing']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/server.py
+++ b/src/server.py
@@ -202,6 +202,8 @@ mcp = FastMCP(
         "- **Workflow runtime (MANDATORY for long multi-step or cross-session work):** open `nexo_goal_open(...)` when the objective must survive sessions, then `nexo_workflow_open(...)`, "
         "update meaningful checkpoints with `nexo_workflow_update(...)`, then use `nexo_workflow_resume(...)` / "
         "`nexo_workflow_replay(...)` instead of restarting blindly.\n"
+        "- **Diagnostic plane (MANDATORY before diagnosing NEXO):** fix the plane explicitly first — `product_public`, `runtime_personal`, `installation_live`, `database_real`, or `cooperator`. "
+        "Do not mix product, runtime, install, DB, and agent-behavior explanations in the same diagnosis.\n"
         "- **Guard (MANDATORY before ANY code edit):** `nexo_guard_check(files='...', area='...')` BEFORE editing code. "
         "No exceptions. Blocking rules→resolve first. `nexo_track(sid=SID, paths=[...])` before shared files\n"
         "- **Skills (MANDATORY before multi-step tasks):** `nexo_skill_match(task)` to find reusable procedures. "

--- a/src/skills/run-nexo-core-fix-cycle/guide.md
+++ b/src/skills/run-nexo-core-fix-cycle/guide.md
@@ -1,0 +1,17 @@
+# Run NEXO Core Fix Cycle
+
+Usa esta skill cuando haya que implementar y verificar un grupo pequeño de fixes del core de NEXO sin improvisar el plano ni repetir siempre la misma fase de descubrimiento y test.
+
+## Steps
+1. Fija primero el plano: repo público `nexo`, runtime instalado `~/.nexo` y claims/documentación pública. No mezcles esos tres mundos.
+2. Abre `nexo_task_open(...)` y `nexo_workflow_open(...)` antes de tocar código. Si el fix es de acción, pasa también por `nexo_cortex_decide(...)`.
+3. Ejecuta la skill con `areas` ajustadas al fix. El helper te devuelve el mapa de archivos y corre la batería de tests focalizada para `protocol`, `plane`, `guard`, `cortex` y/o `release`.
+4. Implementa el cambio mínimo defendible solo en la superficie correcta. Si el problema es producto, se arregla en el repo; no en `~/.nexo`.
+5. Reejecuta la skill para revalidar el clúster exacto de tests tocado por el fix.
+6. Cierra con `nexo_task_close(...)` y evidencia real. Si hubo edición real, deja `change_log` y captura learning si cambió una regla canónica.
+
+## Gotchas
+- No uses diary, workflow text o intuición como sustituto de git/tests/runtime reales.
+- Si el fix toca doctor o claims públicos, fija el `plane` explícito antes de ejecutar diagnósticos.
+- Si el fix toca release o runtime update, usa la vía oficial (`nexo update`, doctor, skill de release final) y no scripts laterales.
+- Si el helper no encuentra un área, añade la superficie nueva de forma explícita en la skill en vez de seguir repitiendo grep manual disperso.

--- a/src/skills/run-nexo-core-fix-cycle/script.py
+++ b/src/skills/run-nexo-core-fix-cycle/script.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+AREA_MAP = {
+    "protocol": {
+        "files": [
+            "src/plugins/protocol.py",
+            "src/db/_protocol.py",
+            "src/db/__init__.py",
+            "tests/test_protocol.py",
+        ],
+        "tests": [
+            "tests/test_protocol.py",
+        ],
+    },
+    "plane": {
+        "files": [
+            "src/doctor/orchestrator.py",
+            "src/plugins/doctor.py",
+            "src/server.py",
+            "tests/test_doctor.py",
+        ],
+        "tests": [
+            "tests/test_doctor.py",
+        ],
+    },
+    "guard": {
+        "files": [
+            "src/hook_guardrails.py",
+            "tests/test_hook_guardrails.py",
+        ],
+        "tests": [
+            "tests/test_hook_guardrails.py",
+        ],
+    },
+    "cortex": {
+        "files": [
+            "src/plugins/cortex.py",
+            "tests/test_cortex_decisions.py",
+        ],
+        "tests": [
+            "tests/test_cortex_decisions.py",
+        ],
+    },
+    "release": {
+        "files": [
+            "scripts/verify_release_readiness.py",
+            "src/skills/run-release-final-audit/script.py",
+            "tests/test_verify_release_readiness.py",
+            "tests/test_release_readiness_baseline.py",
+        ],
+        "tests": [
+            "tests/test_verify_release_readiness.py",
+            "tests/test_release_readiness_baseline.py",
+        ],
+    },
+}
+
+
+def _is_repo_root(candidate: Path) -> bool:
+    return (
+        (candidate / "package.json").is_file()
+        and (candidate / "src" / "server.py").is_file()
+        and (candidate / "tests").is_dir()
+    )
+
+
+def _normalize_candidate(raw: str | Path) -> Path:
+    candidate = Path(raw).expanduser().resolve()
+    if candidate.is_file():
+        candidate = candidate.parent
+    if candidate.name == "src" and (candidate / "server.py").is_file():
+        candidate = candidate.parent
+    return candidate
+
+
+def _resolve_repo_root_from_atlas() -> Path | None:
+    homes = []
+    env_home = os.environ.get("NEXO_HOME", "").strip()
+    if env_home:
+        homes.append(Path(env_home).expanduser())
+    homes.extend((Path.home() / ".nexo", Path.home() / "claude"))
+
+    seen = set()
+    for home in homes:
+        key = str(home)
+        if key in seen:
+            continue
+        seen.add(key)
+        atlas_path = home / "brain" / "project-atlas.json"
+        if not atlas_path.is_file():
+            continue
+        try:
+            payload = json.loads(atlas_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            continue
+        nexo = payload.get("nexo") if isinstance(payload, dict) else None
+        locations = nexo.get("locations") if isinstance(nexo, dict) else None
+        source = locations.get("mcp_server", "") if isinstance(locations, dict) else ""
+        if not isinstance(source, str) or not source.strip():
+            continue
+        candidate = _normalize_candidate(source)
+        if _is_repo_root(candidate):
+            return candidate
+    return None
+
+
+def _resolve_repo_root(explicit_root: str = "") -> Path:
+    if explicit_root.strip():
+        candidate = _normalize_candidate(explicit_root)
+        if _is_repo_root(candidate):
+            return candidate
+
+    env_code = os.environ.get("NEXO_CODE", "").strip()
+    if env_code:
+        candidate = _normalize_candidate(env_code)
+        if _is_repo_root(candidate):
+            return candidate
+
+    cwd = Path.cwd().resolve()
+    for candidate in (cwd, *cwd.parents):
+        if _is_repo_root(candidate):
+            return candidate
+
+    atlas_repo = _resolve_repo_root_from_atlas()
+    if atlas_repo is not None:
+        return atlas_repo
+
+    script_root = Path(__file__).resolve().parents[3]
+    if _is_repo_root(script_root):
+        return script_root
+    return script_root
+
+
+def _parse_bool(raw: str, default: bool) -> bool:
+    text = (raw or "").strip().lower()
+    if not text:
+        return default
+    if text in {"1", "true", "yes", "on"}:
+        return True
+    if text in {"0", "false", "no", "off"}:
+        return False
+    raise SystemExit(f"[core-fix-cycle] invalid boolean: {raw}")
+
+
+def _normalize_areas(raw: str) -> list[str]:
+    text = (raw or "protocol,plane").replace("+", ",")
+    parts = [item.strip().lower() for item in text.split(",") if item.strip()]
+    if not parts:
+        return ["protocol", "plane"]
+    unknown = [item for item in parts if item not in AREA_MAP]
+    if unknown:
+        raise SystemExit(
+            f"[core-fix-cycle] unknown area(s): {', '.join(unknown)}. Expected one of: {', '.join(sorted(AREA_MAP))}"
+        )
+    seen = set()
+    ordered = []
+    for item in parts:
+        if item in seen:
+            continue
+        seen.add(item)
+        ordered.append(item)
+    return ordered
+
+
+def _env(root: Path, nexo_home: str) -> dict[str, str]:
+    env = os.environ.copy()
+    src_path = str(root / "src")
+    existing_pythonpath = env.get("PYTHONPATH", "").strip()
+    env["PYTHONPATH"] = (
+        f"{src_path}{os.pathsep}{existing_pythonpath}" if existing_pythonpath else src_path
+    )
+    env["NEXO_CODE"] = src_path
+    env["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
+    if nexo_home.strip():
+        env["NEXO_HOME"] = str(Path(nexo_home).expanduser())
+    return env
+
+
+def _command_succeeds(cmd: list[str], *, env: dict[str, str], root: Path) -> bool:
+    result = subprocess.run(
+        cmd,
+        cwd=root,
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return result.returncode == 0
+
+
+def _resolve_python(root: Path, env: dict[str, str]) -> str:
+    candidates = []
+    override = os.environ.get("NEXO_RELEASE_PYTHON", "").strip()
+    if override:
+        candidates.append(override)
+
+    for name in ("python3", "python"):
+        path = shutil.which(name)
+        if path:
+            candidates.append(path)
+
+    candidates.append(sys.executable)
+
+    seen = set()
+    for candidate in candidates:
+        if not candidate or candidate in seen:
+            continue
+        seen.add(candidate)
+        if _command_succeeds([candidate, "-m", "pytest", "--version"], env=env, root=root):
+            return candidate
+
+    raise SystemExit(
+        "[core-fix-cycle] no Python interpreter with pytest available. "
+        "Set NEXO_RELEASE_PYTHON or install pytest in the active runtime."
+    )
+
+
+def _run(cmd: list[str], *, env: dict[str, str], root: Path) -> None:
+    print(f"[core-fix-cycle] $ {' '.join(cmd)}")
+    result = subprocess.run(cmd, cwd=root, env=env)
+    if result.returncode != 0:
+        raise SystemExit(result.returncode)
+
+
+def main() -> int:
+    areas = _normalize_areas(sys.argv[1] if len(sys.argv) > 1 else "protocol,plane")
+    run_tests = _parse_bool(sys.argv[2] if len(sys.argv) > 2 else "true", True)
+    repo_root = _resolve_repo_root(sys.argv[3] if len(sys.argv) > 3 else "")
+    nexo_home = sys.argv[4] if len(sys.argv) > 4 else ""
+    env = _env(repo_root, nexo_home)
+
+    files: list[str] = []
+    tests: list[str] = []
+    for area in areas:
+        for path in AREA_MAP[area]["files"]:
+            if path not in files:
+                files.append(path)
+        for path in AREA_MAP[area]["tests"]:
+            if path not in tests:
+                tests.append(path)
+
+    print(f"[core-fix-cycle] repo_root={repo_root}")
+    print(f"[core-fix-cycle] areas={','.join(areas)}")
+    print("[core-fix-cycle] file-map:")
+    for path in files:
+        label = "OK" if (repo_root / path).exists() else "missing"
+        print(f"[core-fix-cycle]   - {path} [{label}]")
+
+    if not run_tests:
+        print("[core-fix-cycle] tests skipped")
+        print("[core-fix-cycle] OK")
+        return 0
+
+    existing_tests = [path for path in tests if (repo_root / path).is_file()]
+    if not existing_tests:
+        print("[core-fix-cycle] no tests found for selected areas")
+        print("[core-fix-cycle] OK")
+        return 0
+
+    python_bin = _resolve_python(repo_root, env)
+    print(f"[core-fix-cycle] python={python_bin}")
+    _run([python_bin, "-m", "pytest", "-q", *existing_tests], env=env, root=repo_root)
+    print("[core-fix-cycle] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/skills/run-nexo-core-fix-cycle/skill.json
+++ b/src/skills/run-nexo-core-fix-cycle/skill.json
@@ -1,0 +1,58 @@
+{
+  "id": "SK-RUN-NEXO-CORE-FIX-CYCLE",
+  "name": "Run NEXO Core Fix Cycle",
+  "description": "Mapea las superficies core impactadas y ejecuta la verificación focalizada para ciclos pequeños de fixes de NEXO sin mezclar repo público, runtime y claims no verificados.",
+  "level": "published",
+  "mode": "hybrid",
+  "source_kind": "core",
+  "execution_level": "read-only",
+  "approval_required": false,
+  "tags": [
+    "nexo",
+    "core",
+    "fix",
+    "protocol",
+    "plane",
+    "verification"
+  ],
+  "trigger_patterns": [
+    "dos fixes core nexo",
+    "core fix cycle",
+    "enforcement protocolario",
+    "plano antes del diagnostico",
+    "ciclo fix core nexo"
+  ],
+  "params_schema": {
+    "areas": {
+      "type": "string",
+      "required": false,
+      "default": "protocol,plane"
+    },
+    "run_tests": {
+      "type": "boolean",
+      "required": false,
+      "default": true
+    },
+    "repo_root": {
+      "type": "string",
+      "required": false,
+      "default": ""
+    },
+    "nexo_home": {
+      "type": "string",
+      "required": false,
+      "default": ""
+    }
+  },
+  "command_template": {
+    "argv": [
+      "{{file_path}}",
+      "{{areas}}",
+      "{{run_tests}}",
+      "{{repo_root}}",
+      "{{nexo_home}}"
+    ]
+  },
+  "executable_entry": "script.py",
+  "stable_after_uses": 5
+}

--- a/src/skills/run-release-final-audit/guide.md
+++ b/src/skills/run-release-final-audit/guide.md
@@ -1,14 +1,16 @@
 # Run Release Final Audit
 
-Use this before the final release/publication package when you need a live check that smoke, release contract, changelog/version surfaces, client parity, and runtime doctor still align.
+Use this before claiming a release/publication is closed when you need a live check that smoke, release contract, public surfaces, runtime update/doctor, and protocol closeout still align.
 
 ## Steps
 1. Run the skill with defaults to audit the current package version. It auto-resolves `release-contracts/v{version}.json` and `scripts/run_vX_Y_smoke.py` when present.
 2. Keep `contract="auto"` and `require_contract_complete=true` for the real final gate. Set `contract="none"` only for pre-contract repo checks.
-3. Treat `ci=true` as repo-only. The last live audit should keep runtime doctor enabled.
+3. For the real post-publish closeout, set `final_closeout=true` and pass the release `protocol_task_id` so the audit also verifies GitHub Release, npm, `nexo update`, runtime doctor, `change_log`, and `task_close`.
+4. Treat `ci=true` as repo-only. The last live audit must stay outside CI because `final_closeout` expects a live runtime and a real closed task.
 
 ## Gotchas
 - A missing auto-resolved contract is a real blocker for the final release audit.
 - Smoke is version-line scoped. If no runner exists, the skill reports the skip explicitly instead of pretending it ran.
-- The script is read-only. It verifies readiness but does not bump versions, tag, publish, or update website worktrees.
+- The script is read-only except for the optional official `nexo update` step during `final_closeout`; it still does not bump versions, tag, publish, or edit website worktrees.
+- `final_closeout` is intentionally stricter than the repo-only readiness pass: it fails if the release task was not closed with evidence or if its `change_log` row is missing.
 - If the touched area includes bootstrap, startup, or public claims, finish with the manual watchpoints in `docs/client-parity-checklist.md`.

--- a/src/skills/run-release-final-audit/script.py
+++ b/src/skills/run-release-final-audit/script.py
@@ -194,12 +194,14 @@ def _looks_like_nexo_home(raw: str) -> bool:
     return (candidate / "skills-runtime").is_dir() or (candidate / "operations" / "tool-logs").is_dir()
 
 
-def _parse_optional_paths(argv: list[str]) -> tuple[str, str]:
-    if len(argv) > 6:
-        return argv[5], argv[6]
-    if len(argv) > 5:
-        return ("", argv[5]) if _looks_like_nexo_home(argv[5]) else (argv[5], "")
-    return "", ""
+def _parse_optional_args(argv: list[str]) -> tuple[str, str, str, str]:
+    website_root = argv[5] if len(argv) > 5 else ""
+    nexo_home = argv[6] if len(argv) > 6 else ""
+    final_closeout = argv[7] if len(argv) > 7 else ""
+    protocol_task_id = argv[8] if len(argv) > 8 else ""
+    if website_root and not nexo_home and _looks_like_nexo_home(website_root):
+        nexo_home, website_root = website_root, ""
+    return website_root, nexo_home, final_closeout, protocol_task_id
 
 
 def main() -> int:
@@ -207,7 +209,8 @@ def main() -> int:
     require_contract_complete = _parse_bool(sys.argv[2] if len(sys.argv) > 2 else "true", True)
     include_smoke = _parse_bool(sys.argv[3] if len(sys.argv) > 3 else "true", True)
     ci = _parse_bool(sys.argv[4] if len(sys.argv) > 4 else "false", False)
-    website_root, nexo_home = _parse_optional_paths(sys.argv)
+    website_root, nexo_home, final_closeout_raw, protocol_task_id = _parse_optional_args(sys.argv)
+    final_closeout = _parse_bool(final_closeout_raw, False)
 
     version = _package_version()
     contract_path = _resolve_contract(version, contract_arg)
@@ -216,8 +219,10 @@ def main() -> int:
 
     print(f"[release-final-audit] version={version}")
     print(f"[release-final-audit] contract={contract_path or 'none'}")
-    print(f"[release-final-audit] include_smoke={include_smoke} ci={ci}")
+    print(f"[release-final-audit] include_smoke={include_smoke} ci={ci} final_closeout={final_closeout}")
     print(f"[release-final-audit] python={python_bin}")
+    if final_closeout and protocol_task_id.strip():
+        print(f"[release-final-audit] protocol_task_id={protocol_task_id.strip()}")
 
     if include_smoke:
         smoke_runner = _resolve_smoke_runner(version)
@@ -240,6 +245,10 @@ def main() -> int:
             readiness_cmd.append("--require-contract-complete")
     elif require_contract_complete:
         print("[release-final-audit] require_contract_complete ignored because contract=none")
+    if final_closeout:
+        readiness_cmd.append("--final-closeout")
+        if protocol_task_id.strip():
+            readiness_cmd.extend(["--protocol-task-id", protocol_task_id.strip()])
 
     _run(readiness_cmd, env=env)
     print("[release-final-audit] OK")

--- a/src/skills/run-release-final-audit/skill.json
+++ b/src/skills/run-release-final-audit/skill.json
@@ -1,7 +1,7 @@
 {
   "id": "SK-RUN-RELEASE-FINAL-AUDIT",
   "name": "Run Release Final Audit",
-  "description": "Runs the final pre-release audit for NEXO: smoke when available, release-readiness checks, contract completeness, and consistency guardrails before a release/publication package.",
+  "description": "Runs the final release audit for NEXO: smoke when available, release-readiness checks, contract completeness, and optional closeout gates for GitHub Release, npm, runtime update/doctor, and protocol evidence.",
   "level": "published",
   "mode": "hybrid",
   "source_kind": "core",
@@ -12,6 +12,7 @@
     "final release audit",
     "release readiness audit",
     "pre-release audit",
+    "release closeout audit",
     "auditoria final release",
     "auditoria final publicacion",
     "seguridad reversibilidad consistencia"
@@ -37,6 +38,16 @@
       "required": false,
       "default": false
     },
+    "final_closeout": {
+      "type": "boolean",
+      "required": false,
+      "default": false
+    },
+    "protocol_task_id": {
+      "type": "string",
+      "required": false,
+      "default": ""
+    },
     "website_root": {
       "type": "string",
       "required": false,
@@ -56,7 +67,9 @@
       "{{include_smoke}}",
       "{{ci}}",
       "{{website_root}}",
-      "{{nexo_home}}"
+      "{{nexo_home}}",
+      "{{final_closeout}}",
+      "{{protocol_task_id}}"
     ]
   },
   "executable_entry": "script.py",

--- a/src/skills/run-runtime-doctor/script.py
+++ b/src/skills/run-runtime-doctor/script.py
@@ -12,7 +12,7 @@ def main() -> int:
         return 1
 
     cli_py = os.path.join(nexo_code, "cli.py")
-    cmd = [sys.executable, cli_py, "doctor", "--tier", tier, "--json"]
+    cmd = [sys.executable, cli_py, "doctor", "--tier", tier, "--plane", "runtime_personal", "--json"]
     result = subprocess.run(cmd, text=True)
     return result.returncode
 

--- a/tests/test_client_preferences.py
+++ b/tests/test_client_preferences.py
@@ -16,10 +16,10 @@ def test_normalize_client_preferences_preserves_old_defaults(tmp_path):
     assert prefs["automation_enabled"] is True
     assert prefs["automation_backend"] == "claude_code"
     assert prefs["client_runtime_profiles"]["claude_code"]["model"] == "claude-opus-4-6[1m]"
-    assert prefs["client_runtime_profiles"]["codex"]["model"] == "gpt-5.4"
-    assert prefs["client_runtime_profiles"]["codex"]["reasoning_effort"] == "xhigh"
-    assert prefs["automation_task_profiles"]["fast"]["backend"] == "codex"
-    assert prefs["automation_task_profiles"]["fast"]["model"] == "gpt-5.4-mini"
+    assert prefs["client_runtime_profiles"]["codex"]["model"] == "claude-opus-4-6[1m]"
+    assert prefs["client_runtime_profiles"]["codex"]["reasoning_effort"] == ""
+    assert prefs["automation_task_profiles"]["fast"]["backend"] == ""
+    assert prefs["automation_task_profiles"]["fast"]["model"] == ""
 
 
 def test_apply_client_preferences_forces_backend_none_when_automation_disabled():

--- a/tests/test_client_sync.py
+++ b/tests/test_client_sync.py
@@ -275,8 +275,8 @@ def test_sync_codex_uses_codex_cli_when_available(tmp_path, monkeypatch):
     assert "NEXO Shared Brain for Codex" in bootstrap_text
     config_path = home / ".codex" / "config.toml"
     config_text = config_path.read_text()
-    assert 'model = "gpt-5.4"' in config_text
-    assert 'model_reasoning_effort = "xhigh"' in config_text
+    assert 'model = "claude-opus-4-6[1m]"' in config_text
+    assert 'model_reasoning_effort = ""' in config_text
     assert "initial_messages = [{ role = \"system\"" in config_text
     assert "[nexo.codex]" in config_text
     assert "bootstrap_managed = true" in config_text

--- a/tests/test_cortex_cycle.py
+++ b/tests/test_cortex_cycle.py
@@ -95,6 +95,9 @@ class TestDetectQualitySignals:
             "total_evaluations": 40,
             "recommendation_accept_rate": 90.0,  # healthy
             "linked_outcomes_total": 8,
+            "linked_outcomes_met": 1,
+            "linked_outcomes_missed": 7,
+            "linked_outcomes_pending": 0,
             "linked_outcome_success_rate": 25.0,  # below floor
             "recommended_success_rate": 25.0,
             "override_success_rate": 0.0,
@@ -104,6 +107,24 @@ class TestDetectQualitySignals:
         assert "linked_success" in kinds
         assert "accept_rate" not in kinds  # accept rate is healthy
 
+    def test_linked_success_ignored_when_all_linked_outcomes_pending(
+        self, cortex_env, monkeypatch
+    ):
+        cycle = _load_cycle_module(monkeypatch, cortex_env)
+        summary = {
+            "total_evaluations": 40,
+            "recommendation_accept_rate": 90.0,
+            "linked_outcomes_total": 10,
+            "linked_outcomes_met": 0,
+            "linked_outcomes_missed": 0,
+            "linked_outcomes_pending": 10,
+            "linked_outcome_success_rate": 0.0,
+            "recommended_success_rate": 0.0,
+            "override_success_rate": 0.0,
+        }
+        signals = cycle.detect_quality_signals(summary)
+        assert all(s["kind"] != "linked_success" for s in signals)
+
     def test_override_gap_signal_when_overrides_outperform(
         self, cortex_env, monkeypatch
     ):
@@ -112,6 +133,9 @@ class TestDetectQualitySignals:
             "total_evaluations": 30,
             "recommendation_accept_rate": 70.0,
             "linked_outcomes_total": 10,
+            "linked_outcomes_met": 6,
+            "linked_outcomes_missed": 4,
+            "linked_outcomes_pending": 0,
             "linked_outcome_success_rate": 65.0,
             "recommended_success_rate": 50.0,
             "override_success_rate": 80.0,  # 30pp gap
@@ -131,6 +155,9 @@ class TestDetectQualitySignals:
             "total_evaluations": 30,
             "recommendation_accept_rate": 70.0,
             "linked_outcomes_total": 3,  # below LINKED_MIN_SAMPLE
+            "linked_outcomes_met": 2,
+            "linked_outcomes_missed": 1,
+            "linked_outcomes_pending": 0,
             "linked_outcome_success_rate": 50.0,
             "recommended_success_rate": 30.0,
             "override_success_rate": 80.0,
@@ -199,6 +226,9 @@ class TestPersistAndUpsert:
             "total_evaluations": 25,
             "recommendation_accept_rate": 88.0,
             "linked_outcomes_total": 10,
+            "linked_outcomes_met": 8,
+            "linked_outcomes_missed": 2,
+            "linked_outcomes_pending": 0,
             "linked_outcome_success_rate": 80.0,
             "recommended_success_rate": 82.0,
             "override_success_rate": 70.0,
@@ -234,6 +264,9 @@ class TestPersistAndUpsert:
             "total_evaluations": 30,
             "recommendation_accept_rate": 30.0,
             "linked_outcomes_total": 8,
+            "linked_outcomes_met": 2,
+            "linked_outcomes_missed": 6,
+            "linked_outcomes_pending": 0,
             "linked_outcome_success_rate": 25.0,
             "recommended_success_rate": 20.0,
             "override_success_rate": 80.0,
@@ -265,3 +298,42 @@ class TestPersistAndUpsert:
         ).fetchone()
         conn.close()
         assert rows[0] == 1
+
+    def test_run_with_pending_only_linked_outcomes_closes_existing_followup(
+        self, cortex_env, monkeypatch, isolated_db
+    ):
+        cycle = _load_cycle_module(monkeypatch, cortex_env)
+
+        pending_only = {
+            "days": 7,
+            "total_evaluations": 28,
+            "recommendation_accept_rate": 78.6,
+            "linked_outcomes_total": 10,
+            "linked_outcomes_met": 0,
+            "linked_outcomes_missed": 0,
+            "linked_outcomes_pending": 10,
+            "linked_outcome_success_rate": 0.0,
+            "recommended_success_rate": 0.0,
+            "override_success_rate": 0.0,
+        }
+
+        import db as nexo_db
+        monkeypatch.setattr(nexo_db, "cortex_evaluation_summary", lambda days=30: pending_only)
+
+        from db import create_followup, get_followup
+
+        create_followup(
+            cycle.FOLLOWUP_ID,
+            "Existing Cortex quality warning",
+            priority="high",
+        )
+
+        rc = cycle.run()
+        assert rc == 0
+
+        existing = get_followup(cycle.FOLLOWUP_ID)
+        assert existing is not None
+        assert str(existing["status"]).startswith("COMPLETED")
+
+        snapshot = json.loads((cortex_env / "operations" / "cortex-quality-latest.json").read_text())
+        assert snapshot["signals"] == []

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -2154,14 +2154,14 @@ class TestDeepChecks:
 class TestOrchestrator:
     def test_boot_tier(self, nexo_home):
         from doctor.orchestrator import run_doctor
-        report = run_doctor(tier="boot")
+        report = run_doctor(tier="boot", plane="installation_live")
         assert report.overall_status in ("healthy", "degraded", "critical")
         assert report.duration_ms >= 0
         assert len(report.checks) > 0
 
     def test_all_tiers(self, nexo_home):
         from doctor.orchestrator import run_doctor
-        report = run_doctor(tier="all")
+        report = run_doctor(tier="all", plane="installation_live")
         tiers = {c.tier for c in report.checks}
         assert "boot" in tiers
         assert "runtime" in tiers
@@ -2169,11 +2169,31 @@ class TestOrchestrator:
 
     def test_invalid_tier_returns_critical(self, nexo_home):
         from doctor.orchestrator import run_doctor
-        report = run_doctor(tier="nonexistent")
+        report = run_doctor(tier="nonexistent", plane="installation_live")
         assert report.overall_status == "critical"
         assert len(report.checks) == 1
         assert report.checks[0].id == "orchestrator.invalid_tier"
         assert "nonexistent" in report.checks[0].summary
+
+    def test_doctor_requires_explicit_plane(self, nexo_home):
+        from doctor.orchestrator import run_doctor
+
+        report = run_doctor(tier="boot")
+
+        assert report.overall_status == "critical"
+        assert len(report.checks) == 1
+        assert report.checks[0].id == "orchestrator.diagnostic_plane_required"
+        assert "plano" in report.checks[0].summary.lower()
+
+    def test_doctor_rejects_cooperator_plane(self, nexo_home):
+        from doctor.orchestrator import run_doctor
+
+        report = run_doctor(tier="boot", plane="cooperator")
+
+        assert report.overall_status == "degraded"
+        assert len(report.checks) == 1
+        assert report.checks[0].id == "orchestrator.diagnostic_plane_mismatch"
+        assert "co-operador" in report.checks[0].summary.lower()
 
     def test_tier_crash_is_caught_and_reported(self, nexo_home, monkeypatch):
         from doctor import orchestrator
@@ -2183,7 +2203,7 @@ class TestOrchestrator:
 
         monkeypatch.setitem(orchestrator._TIER_RUNNERS, "boot", exploding_runner)
 
-        report = orchestrator.run_doctor(tier="boot")
+        report = orchestrator.run_doctor(tier="boot", plane="installation_live")
         assert report.overall_status == "critical"
         crash_checks = [c for c in report.checks if c.id == "orchestrator.boot_crashed"]
         assert len(crash_checks) == 1
@@ -2198,7 +2218,7 @@ class TestOrchestrator:
 
         monkeypatch.setitem(orchestrator._TIER_RUNNERS, "runtime", exploding_runtime)
 
-        report = orchestrator.run_doctor(tier="all")
+        report = orchestrator.run_doctor(tier="all", plane="installation_live")
         tiers = {c.tier for c in report.checks}
         assert "boot" in tiers
         assert "deep" in tiers
@@ -2210,7 +2230,7 @@ class TestFormatters:
     def test_json_format(self, nexo_home):
         from doctor.orchestrator import run_doctor
         from doctor.formatters import format_report
-        report = run_doctor(tier="boot")
+        report = run_doctor(tier="boot", plane="installation_live")
         output = format_report(report, fmt="json")
         data = json.loads(output)
         assert "overall_status" in data
@@ -2219,7 +2239,7 @@ class TestFormatters:
     def test_text_format(self, nexo_home):
         from doctor.orchestrator import run_doctor
         from doctor.formatters import format_report
-        report = run_doctor(tier="boot")
+        report = run_doctor(tier="boot", plane="installation_live")
         output = format_report(report, fmt="text")
         assert "NEXO Doctor" in output
         assert "BOOT" in output

--- a/tests/test_file_migrations.py
+++ b/tests/test_file_migrations.py
@@ -194,3 +194,92 @@ def test_restore_dbs_handles_missing_gracefully(tmp_path, monkeypatch):
     row = verify.execute("SELECT x FROM t").fetchone()
     verify.close()
     assert row[0] == 42
+
+
+def test_validate_db_backup_detects_critical_table_regression(tmp_path):
+    """Critical source tables with rows must not become empty in the backup."""
+    import auto_update
+
+    source_db = tmp_path / "source.db"
+    backup_db = tmp_path / "backup.db"
+
+    src = sqlite3.connect(str(source_db))
+    src.execute("CREATE TABLE learnings (id INTEGER)")
+    src.execute("CREATE TABLE session_diary (id INTEGER)")
+    src.execute("CREATE TABLE guard_checks (id INTEGER)")
+    src.execute("CREATE TABLE protocol_debt (id INTEGER)")
+    src.execute("INSERT INTO learnings VALUES (1)")
+    src.execute("INSERT INTO session_diary VALUES (1)")
+    src.execute("INSERT INTO guard_checks VALUES (1)")
+    src.execute("INSERT INTO protocol_debt VALUES (1)")
+    src.commit()
+    src.close()
+
+    dst = sqlite3.connect(str(backup_db))
+    dst.execute("CREATE TABLE learnings (id INTEGER)")
+    dst.execute("CREATE TABLE session_diary (id INTEGER)")
+    dst.execute("CREATE TABLE guard_checks (id INTEGER)")
+    dst.execute("CREATE TABLE protocol_debt (id INTEGER)")
+    dst.commit()
+    dst.close()
+
+    report = auto_update._validate_db_backup(source_db, backup_db)
+
+    assert report["ok"] is False
+    tables = {item["table"] for item in report["regressions"]}
+    assert {"learnings", "session_diary", "guard_checks", "protocol_debt"} <= tables
+
+
+def test_validate_db_backup_accepts_non_empty_critical_tables(tmp_path):
+    """A valid backup must preserve non-empty critical tables."""
+    import auto_update
+
+    source_db = tmp_path / "source.db"
+    backup_db = tmp_path / "backup.db"
+
+    src = sqlite3.connect(str(source_db))
+    dst = sqlite3.connect(str(backup_db))
+    for conn in (src, dst):
+        conn.execute("CREATE TABLE learnings (id INTEGER)")
+        conn.execute("CREATE TABLE session_diary (id INTEGER)")
+        conn.execute("INSERT INTO learnings VALUES (1)")
+        conn.execute("INSERT INTO session_diary VALUES (1)")
+        conn.commit()
+    src.close()
+    dst.close()
+
+    report = auto_update._validate_db_backup(source_db, backup_db)
+
+    assert report["ok"] is True
+    assert report["regressions"] == []
+
+
+def test_check_git_updates_aborts_before_pull_when_backup_invalid(monkeypatch):
+    """Backup validation must gate the pull so bad snapshots never protect migrations."""
+    import auto_update
+
+    calls: list[tuple[str, ...]] = []
+
+    def _fake_git(*args):
+        calls.append(tuple(args))
+        if args == ("fetch", "--quiet"):
+            return 0, "", ""
+        if args == ("rev-parse", "HEAD"):
+            return 0, "local-head", ""
+        if args == ("rev-parse", "@{u}"):
+            return 0, "remote-head", ""
+        if args == ("merge-base", "HEAD", "@{u}"):
+            return 0, "local-head", ""
+        raise AssertionError(f"unexpected git call: {args}")
+
+    monkeypatch.setattr(auto_update, "_git", _fake_git)
+    monkeypatch.setattr(auto_update, "_read_package_version", lambda: "5.3.11")
+    monkeypatch.setattr(auto_update, "_requirements_hash", lambda: "same-hash")
+    monkeypatch.setattr(
+        auto_update,
+        "_create_validated_db_backup",
+        lambda: ("/tmp/pre-autoupdate", {"ok": False, "regressions": [{"table": "learnings", "source": 212, "backup": 0}]}),
+    )
+
+    assert auto_update._check_git_updates() is None
+    assert ("pull", "--ff-only") not in calls

--- a/tests/test_hook_guardrails.py
+++ b/tests/test_hook_guardrails.py
@@ -164,6 +164,68 @@ def test_process_tool_event_records_debt_when_writing_before_guard_ack(guardrail
     assert debt["severity"] == "error"
 
 
+def test_process_tool_event_warns_on_non_trivial_work_without_task_open(guardrail_env):
+    db, hook_guardrails = _reload_guardrail_stack()
+    db.init_db()
+    db.register_session(
+        "nexo-2009-3009",
+        "bash without task",
+        external_session_id="claude-bash-1",
+        session_client="claude_code",
+    )
+
+    result = hook_guardrails.process_tool_event(
+        {
+            "session_id": "claude-bash-1",
+            "tool_name": "Bash",
+            "tool_input": {"cmd": "rg -n protocol src"},
+        }
+    )
+
+    assert result["status"] == "warn"
+    messages = [item["message"] for item in result["warnings"]]
+    assert any("nexo_task_open" in message for message in messages)
+    assert any("nexo_workflow_open" in message for message in messages)
+    assert any("nexo_task_close" in message for message in messages)
+
+
+def test_process_tool_event_warns_when_multi_step_action_task_lacks_workflow(guardrail_env):
+    db, hook_guardrails = _reload_guardrail_stack()
+    db.init_db()
+    sid = "nexo-2010-3010"
+    db.register_session(
+        sid,
+        "edit without workflow",
+        external_session_id="claude-edit-3",
+        session_client="claude_code",
+    )
+    db.create_protocol_task(
+        sid,
+        "Implement multi-step fix",
+        task_type="edit",
+        files=["/repo/src/plugins/protocol.py"],
+        plan=["inspect", "patch", "verify"],
+        verification_step="pytest -q tests/test_protocol.py",
+        opened_with_guard=True,
+        must_verify=True,
+        must_change_log=True,
+    )
+
+    result = hook_guardrails.process_tool_event(
+        {
+            "session_id": "claude-edit-3",
+            "tool_name": "Bash",
+            "tool_input": {"cmd": "pytest -q tests/test_protocol.py"},
+        }
+    )
+
+    assert result["status"] == "warn"
+    messages = [item["message"] for item in result["warnings"]]
+    assert any("nexo_workflow_open" in message for message in messages)
+    assert any("nexo_task_close" in message for message in messages)
+    assert any("nexo_change_log" in message for message in messages)
+
+
 def test_process_pre_tool_event_blocks_write_without_open_task_in_strict_mode(guardrail_env):
     db, hook_guardrails = _reload_guardrail_stack()
     db.init_db()

--- a/tests/test_rehydrate_learnings_from_archive.py
+++ b/tests/test_rehydrate_learnings_from_archive.py
@@ -1,0 +1,83 @@
+"""Tests for the markdown learnings rehydration helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REPO_SRC = REPO_ROOT / "src"
+SCRIPT_PATH = REPO_ROOT / "src" / "scripts" / "rehydrate_learnings_from_archive.py"
+
+if str(REPO_SRC) not in sys.path:
+    sys.path.insert(0, str(REPO_SRC))
+
+
+def _load_module(monkeypatch, tmp_path):
+    home = tmp_path / "nexo"
+    (home / "data").mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("NEXO_HOME", str(home))
+    monkeypatch.setenv("NEXO_CODE", str(REPO_SRC))
+    spec = importlib.util.spec_from_file_location("rehydrate_learnings_from_archive", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module, home
+
+
+def test_parse_archive_dir_extracts_table_rows_and_bullets(tmp_path, monkeypatch):
+    module, _ = _load_module(monkeypatch, tmp_path)
+
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir()
+    (archive_dir / "nexo-ops.md").write_text(
+        """# Errores y Soluciones — NEXO Operativo
+
+## NEXO — Errores Operativos
+| Error | Solucion |
+|-------|----------|
+| Verificar plugins actualizados comparando contra marketplace LOCAL que puede estar stale | SIEMPRE verificar contra GitHub upstream |
+| ~~RECURRENTE: No usar LLM externo para tareas mecánicas~~ | OBSOLETO — LLM externo eliminado del stack |
+
+## 2026-02-26 — Errores operativos NEXO
+- **Error 1: Puerto SSH incorrecto.** Probé puertos 22 y 22022 antes de leer credentials.md.
+- **Regla:** Rutas locales PhpStorm: `vicshopsysteam` = servidor Recambios BMW.
+""",
+        encoding="utf-8",
+    )
+
+    records = module.parse_archive_dir(archive_dir)
+
+    assert len(records) == 4
+    titles = {item.title for item in records}
+    assert "Verificar plugins actualizados comparando contra marketplace LOCAL que puede estar stale" in titles
+    assert any(item.status == "superseded" for item in records)
+    assert any("Puerto SSH incorrecto" in item.title for item in records)
+    assert any(item.prevention.startswith("Regla:") for item in records)
+
+
+def test_apply_candidates_inserts_only_missing_rows(tmp_path, monkeypatch):
+    module, home = _load_module(monkeypatch, tmp_path)
+
+    module.init_db()
+    conn = module.get_db()
+    conn.execute(
+        "INSERT INTO learnings (category, title, content, created_at, updated_at) VALUES (?, ?, ?, 1, 1)",
+        ("nexo-ops", "Error repetido", "ya existe"),
+    )
+    conn.commit()
+
+    candidates = [
+        module.LearningCandidate("nexo-ops", "Error repetido", "ya existe", "source", "ya existe"),
+        module.LearningCandidate("nexo-ops", "Nuevo aprendizaje", "contenido", "source", "SIEMPRE probar"),
+    ]
+
+    summary = module.apply_candidates(candidates, apply=True)
+
+    assert summary["parsed"] == 2
+    assert summary["inserted"] == 1
+    assert summary["skipped_existing"] == 1

--- a/tests/test_release_readiness_baseline.py
+++ b/tests/test_release_readiness_baseline.py
@@ -80,7 +80,9 @@ class TestReleaseReadinessGates:
         assert VERIFIER.exists()
         text = VERIFIER.read_text()
         assert "def _check_contract" in text
+        assert "def _check_protocol_closeout" in text
         assert "evidence_required" in text
+        assert "--final-closeout" in text
 
     def test_release_contracts_directory_has_versions(self):
         assert CONTRACTS_DIR.is_dir()

--- a/tests/test_schedule_status.py
+++ b/tests/test_schedule_status.py
@@ -148,3 +148,87 @@ def test_schedule_status_marks_old_open_run_as_warning(monkeypatch):
     assert "⚠ shopify-backup" in output
     assert "1/1" in output
     assert "open run 5.1h" in output
+
+
+def test_schedule_status_prefers_legacy_backup_runs_when_newer_than_cron_runs(monkeypatch):
+    from plugins import schedule
+
+    monkeypatch.setattr(
+        schedule,
+        "cron_runs_recent",
+        lambda hours, cron_id: [{
+            "started_at": "2026-04-12 16:43:09",
+            "ended_at": "2026-04-12 16:43:10",
+            "exit_code": 0,
+            "summary": "",
+            "error": "",
+            "duration_secs": 1.0,
+        }] if cron_id == "backup" else [],
+    )
+    monkeypatch.setattr(
+        schedule,
+        "_legacy_backup_runs",
+        lambda hours: [{
+            "started_at": "2026-04-13 06:22:00",
+            "ended_at": "2026-04-13 06:22:00",
+            "exit_code": 0,
+            "summary": "legacy backup file evidence",
+            "error": "",
+            "duration_secs": 1.0,
+        }],
+    )
+    monkeypatch.setattr(schedule, "get_personal_script_schedule", lambda cron_id: {})
+
+    output = schedule.handle_schedule_status(hours=24, cron_id="backup")
+
+    assert "2026-04-13 06:22:00" in output
+    assert "legacy backup file evidence" in output
+    assert "2026-04-12 16:43:09" not in output
+
+
+def test_schedule_status_summary_prefers_legacy_backup_when_db_row_is_stale(monkeypatch):
+    from plugins import schedule
+
+    monkeypatch.setattr(
+        schedule,
+        "cron_runs_summary",
+        lambda hours: [{
+            "cron_id": "backup",
+            "succeeded": 5,
+            "completed_runs": 5,
+            "total_runs": 5,
+            "avg_duration": 1.0,
+            "last_summary": "",
+            "last_exit_code": 0,
+            "last_run": "2026-04-12 16:43:09",
+            "last_ended_at": "2026-04-12 16:43:10",
+        }],
+    )
+    monkeypatch.setattr(
+        schedule,
+        "_legacy_backup_runs",
+        lambda hours: [
+            {
+                "started_at": "2026-04-13 06:22:00",
+                "ended_at": "2026-04-13 06:22:00",
+                "exit_code": 0,
+                "summary": "legacy backup file evidence",
+                "error": "",
+                "duration_secs": 1.0,
+            },
+            {
+                "started_at": "2026-04-13 05:22:00",
+                "ended_at": "2026-04-13 05:22:00",
+                "exit_code": 0,
+                "summary": "legacy backup file evidence",
+                "error": "",
+                "duration_secs": 1.0,
+            },
+        ],
+    )
+    monkeypatch.setattr(schedule, "get_personal_script_schedule", lambda cron_id: {})
+
+    output = schedule.handle_schedule_status(hours=24)
+
+    assert "✅ backup: 2/2" in output
+    assert "legacy backup file evidence" in output

--- a/tests/test_self_audit.py
+++ b/tests/test_self_audit.py
@@ -746,6 +746,78 @@ def test_retire_stale_audit_goals_inline_abandons_old_placeholders(self_audit_en
     assert goal[3] is not None
 
 
+def test_upsert_workflow_goal_inline_reactivates_matching_abandoned_goal(self_audit_env):
+    module = _load_self_audit_module()
+    conn = sqlite3.connect(str(self_audit_env / "data" / "nexo.db"))
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        """CREATE TABLE workflow_goals (
+            goal_id TEXT PRIMARY KEY,
+            session_id TEXT,
+            title TEXT,
+            objective TEXT,
+            parent_goal_id TEXT,
+            status TEXT,
+            priority TEXT,
+            owner TEXT,
+            next_action TEXT,
+            success_signal TEXT,
+            shared_state TEXT,
+            blocker_reason TEXT,
+            opened_at TEXT,
+            updated_at TEXT,
+            closed_at TEXT
+        )"""
+    )
+    sample_goal = "Prepare release readiness checks for v3"
+    signature = module._topic_signature(sample_goal)
+    goal_id = (
+        "WG-AUDIT-"
+        + module.hashlib.sha1(
+            f"nexo:{signature or sample_goal}".encode("utf-8"),
+            usedforsecurity=False,
+        ).hexdigest()[:8].upper()
+    )
+    conn.execute(
+        """INSERT INTO workflow_goals (
+            goal_id, session_id, title, objective, parent_goal_id, status, priority, owner,
+            next_action, success_signal, shared_state, blocker_reason, opened_at, updated_at, closed_at
+        ) VALUES (?, '', ?, ?, '', 'abandoned', 'normal', ?, '', '', '{}', 'stale >24h', datetime('now', '-3 days'), datetime('now', '-3 days'), datetime('now', '-2 days'))""",
+        (
+            goal_id,
+            "Old placeholder",
+            "Outdated objective",
+            module.AUDIT_GOAL_OWNER,
+        ),
+    )
+    conn.commit()
+
+    result = module._upsert_workflow_goal_inline(
+        conn,
+        area="nexo",
+        sample_goal=sample_goal,
+        count=2,
+    )
+    goal = conn.execute(
+        "SELECT status, title, priority, next_action, blocker_reason, closed_at FROM workflow_goals WHERE goal_id = ?",
+        (goal_id,),
+    ).fetchone()
+    row_count = conn.execute(
+        "SELECT COUNT(*) FROM workflow_goals WHERE goal_id = ?",
+        (goal_id,),
+    ).fetchone()[0]
+    conn.close()
+
+    assert result == {"ok": True, "action": "reactivated", "goal_id": goal_id}
+    assert row_count == 1
+    assert goal["status"] == "active"
+    assert "Prepare release readiness checks" in goal["title"]
+    assert goal["priority"] == "high"
+    assert goal["next_action"] == module.AUDIT_GOAL_NEXT_ACTION
+    assert goal["blocker_reason"] == ""
+    assert goal["closed_at"] is None
+
+
 def test_check_automation_opportunities_creates_opportunity_followup(self_audit_env):
     module = _load_self_audit_module()
     module.findings.clear()

--- a/tests/test_verify_claude_code_mcp.py
+++ b/tests/test_verify_claude_code_mcp.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "verify_claude_code_mcp.py"
+SPEC = importlib.util.spec_from_file_location("verify_claude_code_mcp", SCRIPT_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload))
+
+
+def _base_server(runtime_root: Path) -> dict:
+    return {
+        "command": str(runtime_root / ".venv" / "bin" / "python3"),
+        "args": [str(runtime_root / "server.py")],
+        "env": {
+            "NEXO_HOME": str(runtime_root),
+            "NEXO_CODE": str(runtime_root),
+            "NEXO_NAME": "NEXO",
+        },
+    }
+
+
+def _prepare_runtime(home: Path, runtime_root: Path) -> None:
+    (runtime_root / ".venv" / "bin").mkdir(parents=True)
+    (runtime_root / ".venv" / "bin" / "python3").write_text("")
+    (runtime_root / "server.py").write_text("print('server')\n")
+    (runtime_root / "data").mkdir(parents=True)
+    (runtime_root / "data" / "nexo.db").write_text("db")
+    _write_json(home / ".claude.json", {"mcpServers": {"nexo": _base_server(runtime_root)}})
+    _write_json(home / ".claude" / "settings.json", {"mcpServers": {"nexo": _base_server(runtime_root)}})
+
+
+def test_inspect_ok_when_root_settings_and_cli_match(tmp_path):
+    home = tmp_path / "home"
+    runtime_root = home / ".nexo"
+    _prepare_runtime(home, runtime_root)
+
+    report = MODULE.inspect_claude_code_mcp(
+        home=home,
+        workspace=tmp_path,
+        cli_output=f"nexo: {runtime_root / '.venv' / 'bin' / 'python3'} {runtime_root / 'server.py'} - ✓ Connected\n",
+    )
+
+    assert report["ok"] is True
+    assert report["issues"] == []
+    assert str(runtime_root / "data" / "nexo.db") == report["active_db"]
+
+
+def test_inspect_fails_when_root_is_missing_but_settings_has_server(tmp_path):
+    home = tmp_path / "home"
+    runtime_root = home / ".nexo"
+    _prepare_runtime(home, runtime_root)
+    _write_json(home / ".claude.json", {})
+
+    report = MODULE.inspect_claude_code_mcp(
+        home=home,
+        workspace=tmp_path,
+        cli_output="",
+        cli_returncode=1,
+        cli_stderr="boom",
+    )
+
+    assert report["ok"] is False
+    assert any(".claude.json" in issue and "settings.json" in issue for issue in report["issues"])
+
+
+def test_inspect_fails_on_root_settings_drift(tmp_path):
+    home = tmp_path / "home"
+    runtime_root = home / ".nexo"
+    _prepare_runtime(home, runtime_root)
+    drifted = _base_server(runtime_root)
+    drifted["args"] = [str(runtime_root / "other-server.py")]
+    _write_json(home / ".claude" / "settings.json", {"mcpServers": {"nexo": drifted}})
+
+    report = MODULE.inspect_claude_code_mcp(
+        home=home,
+        workspace=tmp_path,
+        cli_output=f"nexo: {runtime_root / '.venv' / 'bin' / 'python3'} {runtime_root / 'server.py'} - ✓ Connected\n",
+    )
+
+    assert report["ok"] is False
+    assert any("desincronizado" in issue for issue in report["issues"])
+
+
+def test_inspect_fails_on_legacy_home_and_db(tmp_path):
+    home = tmp_path / "home"
+    managed = home / ".nexo"
+    legacy = home / "claude"
+    _prepare_runtime(home, managed)
+    (legacy / ".venv" / "bin").mkdir(parents=True)
+    (legacy / ".venv" / "bin" / "python3").write_text("")
+    (legacy / "server.py").write_text("print('legacy')\n")
+    (legacy / "data").mkdir(parents=True)
+    (legacy / "data" / "nexo.db").write_text("legacy-db")
+    legacy_server = {
+        "command": str(legacy / ".venv" / "bin" / "python3"),
+        "args": [str(legacy / "server.py")],
+        "env": {
+            "NEXO_HOME": str(legacy),
+            "NEXO_CODE": str(legacy),
+        },
+    }
+    _write_json(home / ".claude.json", {"mcpServers": {"nexo": legacy_server}})
+    _write_json(home / ".claude" / "settings.json", {"mcpServers": {"nexo": legacy_server}})
+
+    report = MODULE.inspect_claude_code_mcp(
+        home=home,
+        workspace=tmp_path,
+        cli_output=f"nexo: {legacy / '.venv' / 'bin' / 'python3'} {legacy / 'server.py'} - ✓ Connected\n",
+    )
+
+    assert report["ok"] is False
+    assert any("legacy" in issue for issue in report["issues"])
+
+
+def test_inspect_fails_when_workspace_override_differs(tmp_path):
+    home = tmp_path / "home"
+    runtime_root = home / ".nexo"
+    _prepare_runtime(home, runtime_root)
+    workspace = tmp_path / "workspace" / "project"
+    workspace.mkdir(parents=True)
+    local_server = _base_server(runtime_root)
+    local_server["args"] = [str(runtime_root / "workspace-server.py")]
+    _write_json(workspace / ".mcp.json", {"mcpServers": {"nexo": local_server}})
+
+    report = MODULE.inspect_claude_code_mcp(
+        home=home,
+        workspace=workspace,
+        cli_output=f"nexo: {runtime_root / '.venv' / 'bin' / 'python3'} {runtime_root / 'server.py'} - ✓ Connected\n",
+    )
+
+    assert report["ok"] is False
+    assert any("workspace" in issue.lower() for issue in report["issues"])
+
+
+def test_inspect_fails_when_cli_loads_another_server(tmp_path):
+    home = tmp_path / "home"
+    runtime_root = home / ".nexo"
+    _prepare_runtime(home, runtime_root)
+
+    report = MODULE.inspect_claude_code_mcp(
+        home=home,
+        workspace=tmp_path,
+        cli_output="nexo: /tmp/python /tmp/server.py - ✓ Connected\n",
+    )
+
+    assert report["ok"] is False
+    assert any("claude mcp list" in issue for issue in report["issues"])

--- a/tests/test_verify_release_readiness.py
+++ b/tests/test_verify_release_readiness.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import importlib.util
+import sqlite3
+import sys
 from pathlib import Path
 
 import pytest
@@ -16,6 +18,52 @@ def _load_module():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def _seed_closeout_db(
+    db_path: Path,
+    *,
+    task_id: str = "PT-1",
+    status: str = "done",
+    must_verify: int = 1,
+    close_evidence: str = "pytest -q tests/test_protocol.py",
+    must_change_log: int = 1,
+    change_log_id: int | None = 7,
+):
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE protocol_tasks (
+            task_id TEXT PRIMARY KEY,
+            status TEXT,
+            must_verify INTEGER,
+            close_evidence TEXT,
+            must_change_log INTEGER,
+            change_log_id INTEGER
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE change_log (
+            id INTEGER PRIMARY KEY,
+            what_changed TEXT,
+            why TEXT,
+            verify TEXT
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO protocol_tasks VALUES (?, ?, ?, ?, ?, ?)",
+        (task_id, status, must_verify, close_evidence, must_change_log, change_log_id),
+    )
+    if change_log_id:
+        conn.execute(
+            "INSERT INTO change_log VALUES (?, ?, ?, ?)",
+            (change_log_id, "Updated release closeout gates", "Harden final release audit", close_evidence),
+        )
+    conn.commit()
+    conn.close()
 
 
 def test_check_contract_accepts_valid_contract(tmp_path):
@@ -118,3 +166,40 @@ def test_check_contract_requires_completion_when_requested(tmp_path):
             require_complete=True,
             repo_root=tmp_path,
         )
+
+
+def test_check_protocol_closeout_accepts_done_task_with_change_log(tmp_path):
+    module = _load_module()
+    nexo_home = tmp_path / "nexo-home"
+    db_dir = nexo_home / "data"
+    db_dir.mkdir(parents=True)
+    _seed_closeout_db(db_dir / "nexo.db", task_id="PT-200")
+
+    module._check_protocol_closeout(nexo_home, "PT-200")
+
+
+def test_check_protocol_closeout_rejects_missing_change_log(tmp_path):
+    module = _load_module()
+    nexo_home = tmp_path / "nexo-home"
+    db_dir = nexo_home / "data"
+    db_dir.mkdir(parents=True)
+    _seed_closeout_db(db_dir / "nexo.db", task_id="PT-201", change_log_id=None)
+
+    with pytest.raises(SystemExit, match="missing change_log_id"):
+        module._check_protocol_closeout(nexo_home, "PT-201")
+
+
+def test_main_final_closeout_requires_protocol_task_id(tmp_path, monkeypatch):
+    module = _load_module()
+    nexo_home = tmp_path / "nexo-home"
+    nexo_home.mkdir()
+
+    monkeypatch.setattr(module, "_package_manifest", lambda: {"name": "nexo-brain", "version": "5.3.11", "repository": {"url": "git+https://github.com/wazionapps/nexo.git"}})
+    monkeypatch.setattr(module, "_check_changelog", lambda version: None)
+    monkeypatch.setattr(module, "_check_website", lambda version, website_root: None)
+    monkeypatch.setattr(module, "_run", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "_resolve_nexo_home", lambda explicit_home="": nexo_home)
+    monkeypatch.setattr(sys, "argv", ["verify_release_readiness.py", "--final-closeout"])
+
+    with pytest.raises(SystemExit, match="requires --protocol-task-id"):
+        module.main()


### PR DESCRIPTION
## Summary
- All automation profiles and Codex defaults now inherit the users configured model instead of hardcoding GPT-5.4
- Added resolve_user_model() for scripts to query the single source of truth
- Fast profile no longer defaults to Codex backend
- README updated to reflect one-model-everywhere design
- Includes pending changes from prior sessions (new skills, doctor planes, rehydrate script)

## Test plan
- 841 tests pass, 0 failures
- resolve_user_model() returns users configured model
- Zero gpt-5 references in src/ (except pricing tables)