### PR TITLE
v5.3.15: installer nvm PATH + Keychain unlock

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.3.14",
+  "version": "5.3.15",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [5.3.15] - 2026-04-13
+
+### Installer nvm PATH + Keychain unlock for headless
+
+- `nexo-brain init` installer now uses `resolveLaunchAgentPath()` to auto-detect
+  nvm node paths in generated LaunchAgent plists (was hardcoded to Homebrew paths).
+- New Keychain setup step during install: stores macOS login password (chmod 600)
+  so `nexo-cron-wrapper.sh` can `security unlock-keychain` before headless runs.
+- `nexo-cron-wrapper.sh` now unlocks the login Keychain before executing commands,
+  fixing "Not logged in" errors in headless Claude Code sessions.
+
 ## [5.3.14] - 2026-04-13
 
 ### LaunchAgent PATH detection + tomli dependency fix

--- a/bin/nexo-brain.js
+++ b/bin/nexo-brain.js
@@ -177,6 +177,54 @@ function getCoreRuntimePackages() {
   return ["db", "cognitive", "doctor"];
 }
 
+function resolveLaunchAgentPath(home) {
+  const parts = ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin",
+    path.join(home, ".local/bin"), path.join(home, ".nexo/bin")];
+  // Detect nvm node
+  const nvmDir = path.join(home, ".nvm/versions/node");
+  try {
+    const versions = fs.readdirSync(nvmDir)
+      .map(v => ({ name: v, mtime: fs.statSync(path.join(nvmDir, v)).mtimeMs }))
+      .sort((a, b) => b.mtime - a.mtime);
+    for (const v of versions) {
+      const nodeBin = path.join(nvmDir, v.name, "bin");
+      if (fs.existsSync(path.join(nodeBin, "node"))) {
+        parts.unshift(nodeBin);
+        break;
+      }
+    }
+  } catch { /* nvm not installed — skip */ }
+  return parts.join(":");
+}
+
+function setupKeychainPassFile(nexoHome) {
+  if (process.platform !== "darwin") return;
+  const configDir = path.join(nexoHome, "config");
+  const passFile = path.join(configDir, ".keychain-pass");
+  if (fs.existsSync(passFile)) return; // already set up
+  fs.mkdirSync(configDir, { recursive: true });
+  log("");
+  log("macOS Keychain setup for headless automation:");
+  log("  Claude Code stores auth in the login Keychain, which auto-locks.");
+  log("  Background jobs need to unlock it. Enter your macOS login password");
+  log("  (stored locally in ~/.nexo/config/.keychain-pass, chmod 600).");
+  log("");
+  return new Promise((resolve) => {
+    const rl = require("readline").createInterface({ input: process.stdin, output: process.stdout });
+    rl.question("  macOS login password (or Enter to skip): ", (answer) => {
+      rl.close();
+      if (answer && answer.trim()) {
+        fs.writeFileSync(passFile, answer.trim(), { mode: 0o600 });
+        log("  Keychain password saved. Background jobs will auto-unlock.");
+      } else {
+        log("  Skipped. Background jobs may fail with 'Not logged in' if Keychain locks.");
+        log("  Run: echo 'YOUR_PASSWORD' > ~/.nexo/config/.keychain-pass && chmod 600 ~/.nexo/config/.keychain-pass");
+      }
+      resolve();
+    });
+  });
+}
+
 function isProtectedMacPath(candidate) {
   if (process.platform !== "darwin" || !candidate) return false;
   const homeDir = require("os").homedir();
@@ -1250,7 +1298,7 @@ function installAllProcesses(platform, pythonPath, nexoHome, schedule, launchAge
         <key>NEXO_CODE</key>
         <string>${nexoCode}</string>
         <key>PATH</key>
-        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <string>${resolveLaunchAgentPath(home)}</string>
     </dict>
 </dict>
 </plist>`;
@@ -2964,6 +3012,9 @@ ${doScan ? `- Stack: ${Object.keys(profileData.code.languages || {}).slice(0, 5)
 
   // Note: prevent-sleep and tcc-approve are now part of ALL_PROCESSES
   // and installed by installAllProcesses() above. No separate caffeinate block needed.
+
+  // Step 7b: macOS Keychain setup for headless automation
+  await setupKeychainPassFile(NEXO_HOME);
 
   // Step 8: Create shell alias and add runtime CLI to PATH
   log("Creating shell alias...");

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 5.3.14
+version: 5.3.15
 metadata:
   openclaw:
     requires:

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "5.3.14",
+  "version": "5.3.15",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.3.14" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.3.15" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.3.14",
+  "version": "5.3.15",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/src/scripts/nexo-cron-wrapper.sh
+++ b/src/scripts/nexo-cron-wrapper.sh
@@ -14,6 +14,13 @@ shift
 NEXO_HOME="${NEXO_HOME:-$HOME/.nexo}"
 DB="$NEXO_HOME/data/nexo.db"
 
+# Unlock macOS Keychain so headless Claude Code can read auth tokens.
+# Claude Code stores its API key in the login keychain which auto-locks.
+KEYCHAIN_PASS_FILE="$NEXO_HOME/config/.keychain-pass"
+if [ -f "$KEYCHAIN_PASS_FILE" ] && [ "$(uname)" = "Darwin" ]; then
+    security unlock-keychain -p "$(cat "$KEYCHAIN_PASS_FILE")" ~/Library/Keychains/login.keychain-db 2>/dev/null || true
+fi
+
 # Record start
 RUN_ID=$(sqlite3 "$DB" "INSERT INTO cron_runs (cron_id) VALUES ('$CRON_ID'); SELECT last_insert_rowid();" 2>/dev/null)
 


### PR DESCRIPTION
Fixes 3 bugs affecting all new installations: nvm PATH in installer plists, Keychain unlock in cron-wrapper, and keychain-pass setup during install. 843 tests pass.