### PR TITLE
v5.3.17: auto_update copies all templates

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.3.16",
+  "version": "5.3.17",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [5.3.17] - 2026-04-13
+
+### Template copy fix in auto_update (git-based updates)
+
+- Removed last hardcoded template file lists from `auto_update.py`.
+  Both the backfill path and the packaged-update path now scan the full
+  templates directory including subdirectories (`launchagents/`).
+- Fixes `startup_preflight` FileNotFoundError for `CLAUDE.md.template`
+  that blocked bootstrap sync and cron regeneration on npm installs.
+
 ## [5.3.16] - 2026-04-13
 
 ### Packaged installer fixes: client detection, template copy, doctor nvm

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 5.3.16
+version: 5.3.17
 metadata:
   openclaw:
     requires:

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "5.3.16",
+  "version": "5.3.17",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.3.16" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.3.17" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.3.16",
+  "version": "5.3.17",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/src/auto_update.py
+++ b/src/auto_update.py
@@ -1512,18 +1512,27 @@ def _auto_update_check_locked() -> dict:
     except Exception as e:
         _log(f"Doctor plugin backfill error: {e}")
 
-    # Backfill script/skill templates for existing installs
+    # Backfill all templates for existing installs (no hardcoded list)
     try:
         templates_src = REPO_DIR / "templates"
         templates_dest = NEXO_HOME / "templates"
         templates_dest.mkdir(parents=True, exist_ok=True)
-        for fname in ("script-template.py", "nexo_helper.py", "skill-template.md", "skill-script-template.py"):
-            src_file = templates_src / fname
-            dest_file = templates_dest / fname
-            if src_file.is_file() and (not dest_file.exists() or src_file.stat().st_mtime > dest_file.stat().st_mtime):
-                import shutil
-                shutil.copy2(str(src_file), str(dest_file))
-                _log(f"Backfilled template {fname}")
+        import shutil
+        if templates_src.is_dir():
+            for item in templates_src.iterdir():
+                if item.name == "__pycache__":
+                    continue
+                dest_item = templates_dest / item.name
+                if item.is_file():
+                    if not dest_item.exists() or item.stat().st_mtime > dest_item.stat().st_mtime:
+                        shutil.copy2(str(item), str(dest_item))
+                elif item.is_dir():
+                    dest_item.mkdir(parents=True, exist_ok=True)
+                    for sub in item.iterdir():
+                        if sub.is_file():
+                            dest_sub = dest_item / sub.name
+                            if not dest_sub.exists() or sub.stat().st_mtime > dest_sub.stat().st_mtime:
+                                shutil.copy2(str(sub), str(dest_sub))
     except Exception as e:
         _log(f"Template backfill error: {e}")
 
@@ -1888,8 +1897,16 @@ def _copy_runtime_from_source(src_dir: Path, repo_dir: Path, dest: Path = NEXO_H
     if templates_src.is_dir():
         templates_dest.mkdir(parents=True, exist_ok=True)
         for item in templates_src.iterdir():
+            if item.name == "__pycache__":
+                continue
             if item.is_file():
                 shutil.copy2(str(item), str(templates_dest / item.name))
+            elif item.is_dir():
+                sub_dest = templates_dest / item.name
+                sub_dest.mkdir(parents=True, exist_ok=True)
+                for sub in item.iterdir():
+                    if sub.is_file():
+                        shutil.copy2(str(sub), str(sub_dest / sub.name))
 
     package_json = repo_dir / "package.json"
     if package_json.is_file():


### PR DESCRIPTION
Removes last hardcoded template file lists. Both backfill and packaged-update paths now scan full directory. 843 tests pass.