### PR TITLE
v5.3.18: fix REPO_DIR for npm installs

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.3.17",
+  "version": "5.3.18",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [5.3.18] - 2026-04-13
+
+### Fix REPO_DIR resolution for npm installs
+
+- `auto_update.py` now resolves templates, migrations, and version metadata
+  from NEXO_HOME when running inside an npm-installed runtime (where
+  `SRC_DIR.parent` points to the user home, not a repo root).
+- Fixes `FileNotFoundError: CLAUDE.md.template` that blocked bootstrap sync,
+  cron regeneration, and LaunchAgent updates on all npm-based installs.
+
 ## [5.3.17] - 2026-04-13
 
 ### Template copy fix in auto_update (git-based updates)

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 5.3.17
+version: 5.3.18
 metadata:
   openclaw:
     requires:

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "5.3.17",
+  "version": "5.3.18",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.3.17" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.3.18" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.3.17",
+  "version": "5.3.18",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/src/auto_update.py
+++ b/src/auto_update.py
@@ -28,11 +28,30 @@ SRC_DIR = Path(__file__).resolve().parent
 NEXO_CODE = Path(os.environ.get("NEXO_CODE", str(SRC_DIR)))
 REPO_DIR = SRC_DIR.parent
 
+
+def _resolve_repo_dir() -> Path:
+    """Return the source repo root, falling back to NEXO_HOME for npm installs.
+
+    On git installs SRC_DIR is ``<repo>/src`` so parent is the repo root.
+    On npm installs SRC_DIR *is* NEXO_HOME (``~/.nexo``) so parent is ``~``,
+    which has no ``templates/`` or ``migrations/``.  In that case we fall back
+    to NEXO_HOME itself where the installer already copied the runtime files.
+    """
+    candidate = SRC_DIR.parent
+    if (candidate / "templates").is_dir():
+        return candidate
+    if (NEXO_HOME / "templates").is_dir():
+        return NEXO_HOME
+    return candidate
+
+
+_RESOLVED_REPO_DIR = _resolve_repo_dir()
+
 LAST_CHECK_FILE = DATA_DIR / "auto_update_last_check.json"
 MIGRATION_VERSION_FILE = DATA_DIR / "migration_version"
 CLAUDE_MD_VERSION_FILE = DATA_DIR / "claude_md_version.txt"
-MIGRATIONS_DIR = REPO_DIR / "migrations"
-TEMPLATE_FILE = REPO_DIR / "templates" / "CLAUDE.md.template"
+MIGRATIONS_DIR = _RESOLVED_REPO_DIR / "migrations"
+TEMPLATE_FILE = _RESOLVED_REPO_DIR / "templates" / "CLAUDE.md.template"
 
 CHECK_COOLDOWN_SECONDS = 3600  # 1 hour
 GIT_TIMEOUT_SECONDS = 4  # stay well under the 5s total budget
@@ -1514,7 +1533,7 @@ def _auto_update_check_locked() -> dict:
 
     # Backfill all templates for existing installs (no hardcoded list)
     try:
-        templates_src = REPO_DIR / "templates"
+        templates_src = _RESOLVED_REPO_DIR / "templates"
         templates_dest = NEXO_HOME / "templates"
         templates_dest.mkdir(parents=True, exist_ok=True)
         import shutil
@@ -1569,8 +1588,8 @@ def _auto_update_check_locked() -> dict:
             result["git_update"] = _check_git_updates()
         else:
             # Non-git install — check npm for newer version
-            version_json = REPO_DIR / "version.json"
-            pkg_json = REPO_DIR / "package.json"
+            version_json = _RESOLVED_REPO_DIR / "version.json"
+            pkg_json = _RESOLVED_REPO_DIR / "package.json"
             if version_json.exists() or pkg_json.exists():
                 result["npm_notice"] = _check_npm_version()
 


### PR DESCRIPTION
auto_update.py falls back to NEXO_HOME for templates/migrations when REPO_DIR has no templates dir (npm installs). 843 tests pass.