### PR TITLE
fix: restore operator shell alias after update

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.3.19",
+  "version": "5.3.20",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [5.3.20] - 2026-04-13
+
+### Fix operator alias lost after update
+
+- Migration now restores the custom operator shell alias (e.g. `nora`) in
+  `.zshrc`/`.bash_profile` if it was lost during a previous update.
+- Skip alias creation when operator name is "nexo" to avoid shadowing the
+  CLI binary.
+
 ## [5.3.19] - 2026-04-13
 
 ### Deep scan: know the user better than they know themselves

--- a/bin/nexo-brain.js
+++ b/bin/nexo-brain.js
@@ -1692,6 +1692,40 @@ async function main() {
           }
         }
 
+        // Restore operator shell alias + PATH if lost during previous updates
+        const migOperatorName = installed.operator_name || "NEXO";
+        const migAliasName = migOperatorName.toLowerCase();
+        if (migAliasName !== "nexo") {
+          const migAliasLine = `alias ${migAliasName}='nexo chat .'`;
+          const migAliasComment = `# ${migOperatorName} — open the configured NEXO terminal client`;
+          const migNexoPathLine = `export PATH="${path.join(NEXO_HOME, "bin")}:$PATH"`;
+          const migNexoPathComment = "# NEXO runtime CLI";
+          const migUserShell = process.env.SHELL || "/bin/bash";
+          const migHomeDir = require("os").homedir();
+          const migRcFiles = [];
+          if (migUserShell.includes("zsh")) {
+            migRcFiles.push(path.join(migHomeDir, ".zshrc"));
+          } else {
+            migRcFiles.push(path.join(migHomeDir, ".bash_profile"));
+            migRcFiles.push(path.join(migHomeDir, ".bashrc"));
+          }
+          for (const rcFile of migRcFiles) {
+            let rcContent = "";
+            if (fs.existsSync(rcFile)) {
+              rcContent = fs.readFileSync(rcFile, "utf8");
+            }
+            if (!rcContent.includes(migNexoPathLine)) {
+              fs.appendFileSync(rcFile, `\n${migNexoPathComment}\n${migNexoPathLine}\n`);
+              log(`  Restored NEXO runtime CLI in ${path.basename(rcFile)}`);
+              rcContent += `\n${migNexoPathComment}\n${migNexoPathLine}\n`;
+            }
+            if (!rcContent.includes(`alias ${migAliasName}=`)) {
+              fs.appendFileSync(rcFile, `\n${migAliasComment}\n${migAliasLine}\n`);
+              log(`  Restored '${migAliasName}' alias in ${path.basename(rcFile)}`);
+            }
+          }
+        }
+
         console.log("");
         log(`Migration complete: v${installedVersion} → v${currentVersion}`);
         log("Your data (memories, learnings, preferences) is untouched.");
@@ -3138,14 +3172,11 @@ ${doScan ? `- Stack: ${Object.keys(profileData.code.languages || {}).slice(0, 5)
   await setupKeychainPassFile(NEXO_HOME);
 
   // Step 8: Create shell alias and add runtime CLI to PATH
-  log("Creating shell alias...");
   const aliasName = operatorName.toLowerCase();
-  const aliasLine = `alias ${aliasName}='nexo chat .'`;
-  const aliasComment = `# ${operatorName} — open the configured NEXO terminal client`;
   const nexoPathLine = `export PATH="${path.join(NEXO_HOME, "bin")}:$PATH"`;
   const nexoPathComment = "# NEXO runtime CLI";
 
-  // Detect shell and add alias
+  // Detect shell rc files
   const userShell = process.env.SHELL || "/bin/bash";
   const homeDir = require("os").homedir();
   const rcFiles = [];
@@ -3159,6 +3190,11 @@ ${doScan ? `- Stack: ${Object.keys(profileData.code.languages || {}).slice(0, 5)
     const bashrc = path.join(homeDir, ".bashrc");
     rcFiles.push(bashrc);
   }
+
+  // Skip alias when operator name matches the CLI binary ("nexo") to avoid shadowing it
+  const skipAlias = aliasName === "nexo";
+  const aliasLine = skipAlias ? null : `alias ${aliasName}='nexo chat .'`;
+  const aliasComment = skipAlias ? null : `# ${operatorName} — open the configured NEXO terminal client`;
 
   for (const rcFile of rcFiles) {
     let rcContent = "";
@@ -3174,14 +3210,20 @@ ${doScan ? `- Stack: ${Object.keys(profileData.code.languages || {}).slice(0, 5)
       log(`Runtime CLI already present in ${path.basename(rcFile)}`);
     }
 
-    if (!rcContent.includes(`alias ${aliasName}=`)) {
-      fs.appendFileSync(rcFile, `\n${aliasComment}\n${aliasLine}\n`);
-      log(`Added '${aliasName}' alias to ${path.basename(rcFile)}`);
-    } else {
-      log(`Alias '${aliasName}' already exists in ${path.basename(rcFile)}`);
+    if (!skipAlias) {
+      if (!rcContent.includes(`alias ${aliasName}=`)) {
+        fs.appendFileSync(rcFile, `\n${aliasComment}\n${aliasLine}\n`);
+        log(`Added '${aliasName}' alias to ${path.basename(rcFile)}`);
+      } else {
+        log(`Alias '${aliasName}' already exists in ${path.basename(rcFile)}`);
+      }
     }
   }
-  log(`After setup, open a new terminal and type: ${aliasName} or nexo`);
+  if (skipAlias) {
+    log(`Operator name is 'nexo' — skipping alias (CLI binary already provides 'nexo' command)`);
+  } else {
+    log(`After setup, open a new terminal and type: ${aliasName} or nexo`);
+  }
   console.log("");
 
   // Step 9: Generate CLAUDE.md template

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 5.3.19
+version: 5.3.20
 metadata:
   openclaw:
     requires:

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "5.3.19",
+  "version": "5.3.20",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.3.19" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.3.20" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.3.19",
+  "version": "5.3.20",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",


### PR DESCRIPTION
## Summary
- Migration now restores custom operator shell aliases (e.g. `nora`) in `.zshrc`/`.bash_profile` if lost during previous updates
- Skip alias creation when `operator_name` is "nexo" to avoid shadowing the CLI binary
- Bumps to v5.3.20

## Bug
The migration path in `nexo-brain.js` returned (line 1699) before reaching Step 8 (alias creation, line 3140). Custom aliases set during onboarding were silently lost on every `npm update`.

## Test plan
- [ ] Fresh install with custom name → alias created in rc file
- [ ] Fresh install with name "nexo" → no alias created, log explains why
- [ ] Update with existing custom alias → alias preserved (already exists)
- [ ] Update after alias was lost → alias restored in rc file

🤖 Generated with [Claude Code](https://claude.com/claude-code)