### PR TITLE
fix: catch TimeoutExpired in _git_in_repo

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.3.20",
+  "version": "5.3.21",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 build/
 .eggs/
 *.egg
+.venv/
 
 # Node
 node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [5.3.21] - 2026-04-14
+
+### Fix update crash on slow source repos
+
+- Catch `subprocess.TimeoutExpired` in `_git_in_repo()` so `nexo update`
+  no longer crashes when the source repo has heavy untracked directories.
+- Add `.venv/` to `.gitignore`.
+
 ## [5.3.20] - 2026-04-13
 
 ### Fix operator alias lost after update

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 5.3.20
+version: 5.3.21
 metadata:
   openclaw:
     requires:

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "5.3.20",
+  "version": "5.3.21",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.3.20" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.3.21" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.3.20",
+  "version": "5.3.21",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/src/auto_update.py
+++ b/src/auto_update.py
@@ -1653,14 +1653,17 @@ def _resolve_sync_source() -> tuple[Path | None, Path | None]:
 
 
 def _git_in_repo(repo_dir: Path, *args, timeout: int = 10) -> tuple[int, str, str]:
-    result = subprocess.run(
-        ["git"] + list(args),
-        cwd=str(repo_dir),
-        capture_output=True,
-        text=True,
-        timeout=timeout,
-    )
-    return result.returncode, result.stdout.strip(), result.stderr.strip()
+    try:
+        result = subprocess.run(
+            ["git"] + list(args),
+            cwd=str(repo_dir),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return result.returncode, result.stdout.strip(), result.stderr.strip()
+    except subprocess.TimeoutExpired:
+        return 128, "", f"git {' '.join(str(a) for a in args)} timed out after {timeout}s"
 
 
 def _source_repo_status(repo_dir: Path) -> dict:


### PR DESCRIPTION
Catches subprocess.TimeoutExpired in _git_in_repo() so nexo update does not crash when the source repo is slow (e.g. large .venv/ not in .gitignore). Returns rc=128 with descriptive error instead of unhandled exception. Also adds .venv/ to .gitignore.