### PR TITLE
fix: populate headless permissions allowlist on install/update

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.3.21",
+  "version": "5.3.22",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [5.3.22] - 2026-04-14
+
+### Fix headless crons stalling on permission approval
+
+- Claude Code: installer/updater now populates `permissions.allow` in
+  `~/.claude/settings.json` with the minimum entries required for NEXO
+  headless automation (followup-runner, email-monitor, deep-sleep, etc.)
+  including `mcp__*` wildcard. Idempotent: preserves user customizations.
+- Codex: installer/updater now sets `approval_policy = "never"` and
+  `sandbox_mode = "danger-full-access"` as defaults in
+  `~/.codex/config.toml` when unset. Existing user values are preserved.
+- Fixes zombie crons on fresh installs that never had an interactive
+  session populate the allowlist manually.
+
 ## [5.3.21] - 2026-04-14
 
 ### Fix update crash on slow source repos

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 5.3.21
+version: 5.3.22
 metadata:
   openclaw:
     requires:

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "5.3.21",
+  "version": "5.3.22",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.3.21" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.3.22" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.3.21",
+  "version": "5.3.22",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/src/client_sync.py
+++ b/src/client_sync.py
@@ -292,6 +292,12 @@ def _sync_codex_managed_config(
         }
         codex_table["managed_server_command"] = server_config.get("command", "")
 
+    # Ensure Codex headless crons (followup-runner, email-monitor, deep-sleep,
+    # etc.) do not stall on approval prompts. Only set defaults when the user
+    # hasn't configured them explicitly — never overwrite existing values.
+    payload.setdefault("approval_policy", "never")
+    payload.setdefault("sandbox_mode", "danger-full-access")
+
     _write_toml_object(path, payload)
     return {
         "ok": True,
@@ -592,6 +598,52 @@ def _claude_desktop_managed_metadata(server_config: dict, *, operator_name: str)
     }
 
 
+# Minimum permissions allowlist required for NEXO headless automation
+# (followup-runner, email-monitor, deep-sleep, etc.) to work without
+# interactive approval prompts. Without this, Claude Code headless invocations
+# stall waiting for MCP tool approvals.
+_NEXO_HEADLESS_ALLOWLIST = (
+    "Bash",
+    "Read",
+    "Edit",
+    "Write",
+    "Glob",
+    "Grep",
+    "Task",
+    "Skill",
+    "NotebookEdit",
+    "WebSearch",
+    "WebFetch",
+    "mcp__*",
+)
+
+
+def _ensure_headless_permissions(payload: dict) -> None:
+    """Ensure Claude Code settings.json has the minimum allowlist so headless
+    NEXO crons (followup-runner, email-monitor, etc.) do not stall on MCP
+    tool-approval prompts. Idempotent: only adds missing entries, never
+    removes or reorders existing user customizations."""
+    permissions = payload.get("permissions")
+    if not isinstance(permissions, dict):
+        permissions = {}
+        payload["permissions"] = permissions
+
+    allow_list = permissions.get("allow")
+    if not isinstance(allow_list, list):
+        allow_list = []
+        permissions["allow"] = allow_list
+
+    existing = {str(item) for item in allow_list if isinstance(item, str)}
+    for entry in _NEXO_HEADLESS_ALLOWLIST:
+        if entry not in existing:
+            allow_list.append(entry)
+            existing.add(entry)
+
+    permissions.setdefault("deny", [])
+    permissions.setdefault("ask", [])
+    permissions.setdefault("defaultMode", "dontAsk")
+
+
 def _sync_claude_code_settings(path: Path, server_config: dict) -> dict:
     payload = _load_json_object(path)
     mcp_servers = payload.setdefault("mcpServers", {})
@@ -608,6 +660,7 @@ def _sync_claude_code_settings(path: Path, server_config: dict) -> dict:
         runtime_root=runtime_root,
         nexo_home=nexo_home,
     )
+    _ensure_headless_permissions(payload)
     _write_json_object(path, payload)
     return {
         "ok": True,


### PR DESCRIPTION
Fixes zombie crons on fresh NEXO installs. Claude Code: populates permissions.allow in settings.json with minimum entries for headless automation including mcp__* wildcard. Codex: sets approval_policy=never and sandbox_mode=danger-full-access as defaults. Both are idempotent and preserve user customizations.