### PR TITLE
fix: Codex broken with Claude model default

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.3.22",
+  "version": "5.3.23",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [5.3.23] - 2026-04-14
+
+### Fix Codex broken with Claude model default + centralize model recommendations
+
+- `DEFAULT_CODEX_MODEL` was aliased to the Claude default, causing Codex to
+  write `model = "claude-opus-4-6[1m]"` into `~/.codex/config.toml` and fail
+  with "model not supported when using Codex with a ChatGPT account" on first
+  run. Codex default is now `gpt-5.4` / `xhigh` (matching the onboarding
+  installer).
+- **Single source of truth for model defaults:** new `src/model_defaults.json`
+  read by both the Python runtime (`src/model_defaults.py`) and the JS
+  installer (`bin/nexo-brain.js`). Editing the JSON updates install defaults
+  for new users and — when `recommendation_version` is bumped — triggers a
+  one-time upgrade prompt for existing users on their next interactive
+  `nexo update`.
+- **Recommendation prompt:** during interactive `nexo update`, if the JSON
+  recommends a newer model than the user's current profile AND the user's
+  model is a prior NEXO default (not a customization), they are offered to
+  migrate with `[y/N/later]`. Customized models are respected silently.
+  Non-TTY (cron/headless) updates only log a hint and apply nothing.
+- **Self-heal on update:** Claude-family models written into the Codex
+  runtime profile by previous buggy versions are automatically reset to the
+  current Codex default before client sync, so `~/.codex/config.toml` is
+  regenerated clean.
+- Client sync refuses to write Claude-family models into Codex config
+  (defense in depth against future regressions).
+
 ## [5.3.22] - 2026-04-14
 
 ### Fix headless crons stalling on permission approval

--- a/bin/nexo-brain.js
+++ b/bin/nexo-brain.js
@@ -33,10 +33,32 @@ const LAUNCH_AGENTS = path.join(
 );
 const MACOS_FDA_SETTINGS_URL = "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles";
 const PUBLIC_CONTRIBUTION_UPSTREAM = "wazionapps/nexo";
-const DEFAULT_CLAUDE_CODE_MODEL = "claude-opus-4-6[1m]";
-const DEFAULT_CLAUDE_CODE_REASONING_EFFORT = "";
-const DEFAULT_CODEX_MODEL = "gpt-5.4";
-const DEFAULT_CODEX_REASONING_EFFORT = "xhigh";
+// Model defaults loaded from src/model_defaults.json — single source of truth
+// shared with the Python runtime (src/model_defaults.py). Edit the JSON to
+// change the recommended default for new installs and to offer an upgrade
+// prompt to existing users via `nexo update`.
+const MODEL_DEFAULTS_PATH = path.join(__dirname, "..", "src", "model_defaults.json");
+function _loadModelDefaults() {
+  const fallback = {
+    claude_code: { model: "claude-opus-4-6[1m]", reasoning_effort: "", display_name: "Opus 4.6 with 1M context" },
+    codex: { model: "gpt-5.4", reasoning_effort: "xhigh", display_name: "GPT-5.4 with max reasoning" },
+  };
+  try {
+    const raw = JSON.parse(fs.readFileSync(MODEL_DEFAULTS_PATH, "utf8"));
+    if (raw && typeof raw === "object") {
+      return {
+        claude_code: { ...fallback.claude_code, ...(raw.claude_code || {}) },
+        codex: { ...fallback.codex, ...(raw.codex || {}) },
+      };
+    }
+  } catch (_) {}
+  return fallback;
+}
+const _MODEL_DEFAULTS = _loadModelDefaults();
+const DEFAULT_CLAUDE_CODE_MODEL = _MODEL_DEFAULTS.claude_code.model;
+const DEFAULT_CLAUDE_CODE_REASONING_EFFORT = _MODEL_DEFAULTS.claude_code.reasoning_effort || "";
+const DEFAULT_CODEX_MODEL = _MODEL_DEFAULTS.codex.model;
+const DEFAULT_CODEX_REASONING_EFFORT = _MODEL_DEFAULTS.codex.reasoning_effort || "";
 
 function isEphemeralInstall(nexoHome) {
   const homeDir = require("os").homedir();

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 5.3.22
+version: 5.3.23
 metadata:
   openclaw:
     requires:

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "5.3.22",
+  "version": "5.3.23",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.3.22" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.3.23" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.3.22",
+  "version": "5.3.23",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/src/auto_update.py
+++ b/src/auto_update.py
@@ -2068,9 +2068,19 @@ def _run_runtime_post_sync(dest: Path = NEXO_HOME, progress_fn=None) -> tuple[bo
     try:
         from client_sync import sync_all_clients
         from client_preferences import normalize_client_preferences
+        from model_defaults import heal_runtime_profiles
 
         schedule_path = dest / "config" / "schedule.json"
         schedule_payload = json.loads(schedule_path.read_text()) if schedule_path.exists() else {}
+        # Heal Claude-family models written into Codex runtime profile by
+        # earlier buggy versions (DEFAULT_CODEX_MODEL was aliased to Claude).
+        existing_profiles = schedule_payload.get("client_runtime_profiles") or {}
+        healed_profiles, heal_messages = heal_runtime_profiles(existing_profiles)
+        if heal_messages:
+            schedule_payload["client_runtime_profiles"] = healed_profiles
+            for msg in heal_messages:
+                _emit_progress(progress_fn, msg)
+                actions.append("model-heal")
         normalized_preferences = normalize_client_preferences(schedule_payload)
         if normalized_preferences != {
             key: schedule_payload.get(key)

--- a/src/cli.py
+++ b/src/cli.py
@@ -915,9 +915,92 @@ def _update(args):
                 print(f"  Contributor mode: {public_contribution['format_public_contribution_label'](contrib_choice)}")
             if contrib_choice.get("message"):
                 print(f"  Contributor mode: {contrib_choice.get('message')}")
+            # One-time model-recommendation upgrade prompt (interactive only).
+            try:
+                _prompt_model_recommendations(interactive=interactive)
+            except Exception as exc:
+                print(f"  Model recommendation check skipped: {exc}", file=sys.stderr)
         else:
             print(f"UPDATE FAILED: {result.get('error', 'sync failed')}", file=sys.stderr)
     return 0 if result.get("ok") else 1
+
+
+def _prompt_model_recommendations(*, interactive: bool) -> None:
+    """If model_defaults.json has bumped recommendation_version beyond what
+    the user has acknowledged, offer a one-time upgrade prompt. In
+    non-interactive (cron/headless) contexts, only log a hint. Honours
+    customized models by skipping silently (see was_nexo_default)."""
+    from client_preferences import (
+        load_client_preferences,
+        save_client_preferences,
+        normalize_client_key,
+    )
+    from model_defaults import detect_outdated_recommendations, client_default
+
+    preferences = load_client_preferences()
+    pending = detect_outdated_recommendations(preferences)
+    if not pending:
+        return
+
+    is_tty = bool(interactive and sys.stdin.isatty() and sys.stdout.isatty())
+    if not is_tty:
+        for entry in pending:
+            print(
+                f"  ⭐ Model recommendation available for "
+                f"{entry['client']}: {entry['display_name']}. "
+                f"Run `nexo update` interactively to review and apply.",
+                file=sys.stderr,
+            )
+        return
+
+    updated_profiles = dict(preferences.get("client_runtime_profiles") or {})
+    updated_ack = dict(preferences.get("acknowledged_model_recommendations") or {})
+    changed = False
+    for entry in pending:
+        client = entry["client"]
+        effort_str = f" / {entry['current_effort']}" if entry["current_effort"] else ""
+        prev_effort = f" / {entry['user_effort']}" if entry["user_effort"] else ""
+        print()
+        print(f"[NEXO] ⭐ Nueva recomendación de modelo para {client}:")
+        print(
+            f"       {entry['current_model']}{effort_str}  "
+            f"(antes: {entry['user_model']}{prev_effort})"
+        )
+        print(f"       {entry['display_name']} — recomendado por NEXO.")
+        answer = input("       ¿Migrar tu configuración? [y/N/later]: ").strip().lower()
+        client_key = normalize_client_key(client) or client
+        if answer in {"y", "yes", "s", "si", "sí"}:
+            updated_profiles[client_key] = {
+                "model": entry["current_model"],
+                "reasoning_effort": entry["current_effort"],
+            }
+            updated_ack[client_key] = entry["current_version"]
+            print(f"       ✅ Migrado a {entry['current_model']}.")
+            changed = True
+        elif answer in {"later", "l", "luego"}:
+            # Do NOT acknowledge — will prompt again next interactive update.
+            print("       ↻ Te lo preguntaré en el próximo update.")
+        else:
+            # "N" / empty / anything else → record ack so we don't re-ask.
+            updated_ack[client_key] = entry["current_version"]
+            print(f"       Mantenido {entry['user_model']}. No te preguntaré de nuevo para esta versión.")
+            changed = True
+
+    if changed:
+        save_client_preferences(
+            client_runtime_profiles=updated_profiles,
+            acknowledged_model_recommendations=updated_ack,
+        )
+        # Re-sync clients so config.toml / settings.json reflect the new model.
+        try:
+            from client_sync import sync_all_clients
+            sync_all_clients(
+                nexo_home=NEXO_HOME,
+                runtime_root=NEXO_CODE,
+                preferences=load_client_preferences(),
+            )
+        except Exception:
+            pass
 
 
 def _clients_sync(args):

--- a/src/client_preferences.py
+++ b/src/client_preferences.py
@@ -46,13 +46,18 @@ INSTALL_PREFERENCE_KEYS = {
     "skip",
     "manual",
 }
-DEFAULT_CLAUDE_CODE_MODEL = "claude-opus-4-6[1m]"
-DEFAULT_CLAUDE_CODE_REASONING_EFFORT = ""
-# Codex/fast defaults: fall back to the user's configured model, not a hardcoded
-# third-party model.  The user picks their model once at install time; every
-# profile and backend should honour that choice.
-DEFAULT_CODEX_MODEL = DEFAULT_CLAUDE_CODE_MODEL
-DEFAULT_CODEX_REASONING_EFFORT = ""
+# Model defaults are loaded from src/model_defaults.json (single source of
+# truth shared with bin/nexo-brain.js). Do not hardcode model values here —
+# edit the JSON instead.
+from model_defaults import client_default as _model_client_default
+
+_CLAUDE_DEFAULTS = _model_client_default("claude_code")
+_CODEX_DEFAULTS = _model_client_default("codex")
+
+DEFAULT_CLAUDE_CODE_MODEL = _CLAUDE_DEFAULTS["model"]
+DEFAULT_CLAUDE_CODE_REASONING_EFFORT = _CLAUDE_DEFAULTS["reasoning_effort"]
+DEFAULT_CODEX_MODEL = _CODEX_DEFAULTS["model"]
+DEFAULT_CODEX_REASONING_EFFORT = _CODEX_DEFAULTS["reasoning_effort"]
 DEFAULT_FAST_MODEL = DEFAULT_CLAUDE_CODE_MODEL
 DEFAULT_FAST_REASONING_EFFORT = ""
 
@@ -99,6 +104,14 @@ def default_client_preferences() -> dict:
             CLIENT_CLAUDE_CODE: "ask",
             CLIENT_CODEX: "ask",
             CLIENT_CLAUDE_DESKTOP: "manual",
+        },
+        # Tracks which model-recommendation version the user has already
+        # acknowledged per client. If an update ships a newer
+        # recommendation_version in src/model_defaults.json, the update flow
+        # offers a one-time upgrade prompt (see auto_update.py).
+        "acknowledged_model_recommendations": {
+            CLIENT_CLAUDE_CODE: 0,
+            CLIENT_CODEX: 0,
         },
     }
 
@@ -384,7 +397,28 @@ def normalize_client_preferences(
             schedule.get("automation_task_profiles")
         ),
         "client_install_preferences": install_preferences,
+        "acknowledged_model_recommendations": normalize_acknowledged_model_recommendations(
+            schedule.get("acknowledged_model_recommendations")
+        ),
     }
+
+
+def normalize_acknowledged_model_recommendations(value) -> dict[str, int]:
+    """Normalize the per-client acknowledged recommendation_version map.
+    Missing clients default to 0 (never acknowledged)."""
+    defaults = {CLIENT_CLAUDE_CODE: 0, CLIENT_CODEX: 0}
+    if not isinstance(value, dict):
+        return defaults
+    result = dict(defaults)
+    for raw_key, raw_val in value.items():
+        client_key = normalize_client_key(raw_key)
+        if client_key not in TERMINAL_CLIENT_KEYS:
+            continue
+        try:
+            result[client_key] = max(0, int(raw_val))
+        except (TypeError, ValueError):
+            continue
+    return result
 
 
 def apply_client_preferences(
@@ -398,6 +432,7 @@ def apply_client_preferences(
     client_runtime_profiles: dict | None = None,
     automation_task_profiles: dict | None = None,
     client_install_preferences: dict | None = None,
+    acknowledged_model_recommendations: dict | None = None,
 ) -> dict:
     merged = dict(schedule or {})
     current = normalize_client_preferences(schedule)
@@ -434,6 +469,13 @@ def apply_client_preferences(
         if client_install_preferences is not None
         else current["client_install_preferences"]
     )
+    merged["acknowledged_model_recommendations"] = (
+        normalize_acknowledged_model_recommendations(
+            acknowledged_model_recommendations
+            if acknowledged_model_recommendations is not None
+            else current.get("acknowledged_model_recommendations")
+        )
+    )
     return merged
 
 
@@ -451,6 +493,7 @@ def save_client_preferences(
     client_runtime_profiles: dict | None = None,
     automation_task_profiles: dict | None = None,
     client_install_preferences: dict | None = None,
+    acknowledged_model_recommendations: dict | None = None,
 ) -> Path:
     schedule = apply_client_preferences(
         load_schedule_config(),
@@ -462,6 +505,7 @@ def save_client_preferences(
         client_runtime_profiles=client_runtime_profiles,
         automation_task_profiles=automation_task_profiles,
         client_install_preferences=client_install_preferences,
+        acknowledged_model_recommendations=acknowledged_model_recommendations,
     )
     return save_schedule_config(schedule)
 

--- a/src/client_sync.py
+++ b/src/client_sync.py
@@ -263,8 +263,25 @@ def _sync_codex_managed_config(
     runtime_profile = dict(runtime_profile or {})
     server_config = dict(server_config or {})
 
-    if runtime_profile.get("model"):
-        payload["model"] = runtime_profile["model"]
+    def _looks_like_claude_model(value: str) -> bool:
+        return value.strip().lower().startswith(
+            ("claude", "opus", "sonnet", "haiku")
+        )
+
+    # Heal any pre-existing Claude model written by earlier NEXO versions.
+    existing_model = str(payload.get("model") or "").strip()
+    if existing_model and _looks_like_claude_model(existing_model):
+        payload["model"] = "gpt-5.4"
+
+    # Only write a model from the runtime profile into Codex config if it
+    # looks like a Codex/OpenAI model. Claude models are invalid for Codex
+    # and cause "model not supported" errors on first run.
+    profile_model = (runtime_profile.get("model") or "").strip()
+    if profile_model and not _looks_like_claude_model(profile_model):
+        payload["model"] = profile_model
+    elif profile_model:
+        # Fall back to a known-good Codex default to self-heal.
+        payload["model"] = "gpt-5.4"
     if "reasoning_effort" in runtime_profile:
         payload["model_reasoning_effort"] = runtime_profile.get("reasoning_effort") or ""
 
@@ -281,7 +298,8 @@ def _sync_codex_managed_config(
     codex_table["mcp_managed"] = True
     codex_table["bootstrap_bytes"] = len(bootstrap_prompt.encode("utf-8")) if bootstrap_prompt else 0
     if runtime_profile.get("model"):
-        codex_table["managed_model"] = runtime_profile["model"]
+        # Record the healed/actual model in use, not the raw (possibly Claude) profile.
+        codex_table["managed_model"] = payload.get("model") or runtime_profile["model"]
     codex_table["managed_reasoning_effort"] = runtime_profile.get("reasoning_effort", "") or ""
     if server_config:
         mcp_servers = payload.setdefault("mcp_servers", {})

--- a/src/model_defaults.json
+++ b/src/model_defaults.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "claude_code": {
+    "model": "claude-opus-4-6[1m]",
+    "reasoning_effort": "",
+    "display_name": "Opus 4.6 with 1M context",
+    "recommendation_version": 1,
+    "previous_defaults": []
+  },
+  "codex": {
+    "model": "gpt-5.4",
+    "reasoning_effort": "xhigh",
+    "display_name": "GPT-5.4 with max reasoning",
+    "recommendation_version": 1,
+    "previous_defaults": []
+  }
+}

--- a/src/model_defaults.py
+++ b/src/model_defaults.py
@@ -1,0 +1,173 @@
+"""Single source of truth for default model recommendations.
+
+Values are loaded from `src/model_defaults.json` at runtime. The same JSON is
+read by `bin/nexo-brain.js` during install/onboarding so that Python and JS
+stay in sync automatically. Do not hardcode model defaults elsewhere — import
+from this module (or read the JSON) so editing one file updates both runtimes.
+
+When a new model is recommended, bump the client's `recommendation_version`
+and append the previous default to `previous_defaults`. Existing users whose
+model is in `[model] + previous_defaults` will be offered a one-time upgrade
+prompt on their next interactive `nexo update`.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+_FALLBACK: dict[str, Any] = {
+    "schema_version": 1,
+    "claude_code": {
+        "model": "claude-opus-4-6[1m]",
+        "reasoning_effort": "",
+        "display_name": "Opus 4.6 with 1M context",
+        "recommendation_version": 1,
+        "previous_defaults": [],
+    },
+    "codex": {
+        "model": "gpt-5.4",
+        "reasoning_effort": "xhigh",
+        "display_name": "GPT-5.4 with max reasoning",
+        "recommendation_version": 1,
+        "previous_defaults": [],
+    },
+}
+
+
+def _json_path() -> Path:
+    return Path(__file__).resolve().parent / "model_defaults.json"
+
+
+def _load_raw() -> dict[str, Any]:
+    try:
+        text = _json_path().read_text()
+        data = json.loads(text)
+        if isinstance(data, dict):
+            return data
+    except Exception:
+        pass
+    return _FALLBACK
+
+
+def load_defaults() -> dict[str, Any]:
+    """Return the raw defaults mapping, preferring the JSON and falling back
+    to hardcoded values if the file is missing or malformed."""
+    return _load_raw()
+
+
+def client_default(client: str) -> dict[str, Any]:
+    """Return normalized default config for a single client."""
+    raw = _load_raw()
+    fallback = _FALLBACK.get(client) or {}
+    entry = raw.get(client) if isinstance(raw.get(client), dict) else fallback
+    return {
+        "model": str(entry.get("model") or fallback.get("model") or ""),
+        "reasoning_effort": str(
+            entry.get("reasoning_effort")
+            if entry.get("reasoning_effort") is not None
+            else fallback.get("reasoning_effort") or ""
+        ),
+        "display_name": str(entry.get("display_name") or fallback.get("display_name") or ""),
+        "recommendation_version": int(entry.get("recommendation_version") or 0),
+        "previous_defaults": [
+            str(item) for item in (entry.get("previous_defaults") or []) if item
+        ],
+    }
+
+
+def was_nexo_default(client: str, model: str) -> bool:
+    """True if `model` is (or ever was) a NEXO recommended default for
+    `client`. Used to distinguish a user who was riding our defaults (and
+    should be offered upgrades) from one who customized (respect their choice)."""
+    if not model:
+        return False
+    cfg = client_default(client)
+    if model == cfg["model"]:
+        return True
+    return model in cfg["previous_defaults"]
+
+
+_CLAUDE_MODEL_PREFIXES = ("claude", "opus", "sonnet", "haiku")
+
+
+def looks_like_claude_model(model: str) -> bool:
+    """Heuristic to detect a Claude-family model written where a Codex model
+    is expected. Used by the heal path for users hit by the historical
+    DEFAULT_CODEX_MODEL = DEFAULT_CLAUDE_CODE_MODEL alias bug."""
+    return str(model or "").strip().lower().startswith(_CLAUDE_MODEL_PREFIXES)
+
+
+def heal_runtime_profiles(profiles: dict) -> tuple[dict, list[str]]:
+    """Detect and repair invalid models in client_runtime_profiles. Returns
+    (healed_profiles_dict, list_of_heal_messages). A Claude-family model in
+    the codex profile is the main historical corruption; we reset such a
+    profile to the current Codex default."""
+    if not isinstance(profiles, dict):
+        return profiles, []
+    healed = dict(profiles)
+    messages: list[str] = []
+    codex_profile = healed.get("codex") if isinstance(healed.get("codex"), dict) else None
+    if codex_profile is not None:
+        current = str(codex_profile.get("model") or "").strip()
+        if current and looks_like_claude_model(current):
+            default = client_default("codex")
+            healed["codex"] = {
+                "model": default["model"],
+                "reasoning_effort": default["reasoning_effort"],
+            }
+            messages.append(
+                f"Healed Codex profile: model '{current}' → '{default['model']}' "
+                f"(Claude models are invalid for Codex)."
+            )
+    return healed, messages
+
+
+def detect_outdated_recommendations(
+    preferences: dict,
+) -> list[dict]:
+    """Return a list of clients whose user is on an older recommendation and
+    hasn't acknowledged the current one. Entries shape:
+      {
+        "client": "codex",
+        "current_model": "gpt-5.9",
+        "current_effort": "high",
+        "current_version": 2,
+        "user_model": "gpt-5.4",
+        "user_effort": "xhigh",
+        "display_name": "GPT-5.9 with high reasoning",
+      }
+    """
+    out: list[dict] = []
+    profiles = preferences.get("client_runtime_profiles") or {}
+    acknowledged = preferences.get("acknowledged_model_recommendations") or {}
+    for client in ("claude_code", "codex"):
+        profile = profiles.get(client) if isinstance(profiles.get(client), dict) else None
+        if not profile:
+            continue
+        user_model = str(profile.get("model") or "").strip()
+        user_effort = str(profile.get("reasoning_effort") or "").strip()
+        default = client_default(client)
+        current_v = int(default.get("recommendation_version") or 0)
+        ack_v = int(acknowledged.get(client) or 0)
+        if current_v <= ack_v:
+            continue
+        # Only offer upgrade if user is on a prior NEXO default.
+        # If they customized, respect their choice silently.
+        if not was_nexo_default(client, user_model):
+            continue
+        # No change needed if they already match current (race: install wrote
+        # the new default but ack wasn't bumped). Treat as auto-acknowledged.
+        if user_model == default["model"] and user_effort == default["reasoning_effort"]:
+            continue
+        out.append({
+            "client": client,
+            "current_model": default["model"],
+            "current_effort": default["reasoning_effort"],
+            "current_version": current_v,
+            "user_model": user_model,
+            "user_effort": user_effort,
+            "display_name": default.get("display_name") or default["model"],
+        })
+    return out

--- a/src/runtime_power.py
+++ b/src/runtime_power.py
@@ -65,11 +65,16 @@ MACOS_FDA_PROBE_PATHS = (
     Path.home() / "Library" / "Safari",
     Path.home() / "Library" / "Application Support" / "AddressBook",
 )
-DEFAULT_CLAUDE_CODE_MODEL = "claude-opus-4-6[1m]"
-DEFAULT_CLAUDE_CODE_REASONING_EFFORT = ""
-# Codex defaults mirror the user's primary model — no hardcoded third-party models.
-DEFAULT_CODEX_MODEL = DEFAULT_CLAUDE_CODE_MODEL
-DEFAULT_CODEX_REASONING_EFFORT = ""
+# Model defaults loaded from src/model_defaults.json (single source of truth).
+from model_defaults import client_default as _model_client_default
+
+_CLAUDE_DEFAULTS = _model_client_default("claude_code")
+_CODEX_DEFAULTS = _model_client_default("codex")
+
+DEFAULT_CLAUDE_CODE_MODEL = _CLAUDE_DEFAULTS["model"]
+DEFAULT_CLAUDE_CODE_REASONING_EFFORT = _CLAUDE_DEFAULTS["reasoning_effort"]
+DEFAULT_CODEX_MODEL = _CODEX_DEFAULTS["model"]
+DEFAULT_CODEX_REASONING_EFFORT = _CODEX_DEFAULTS["reasoning_effort"]
 
 
 def resolve_launchagent_path() -> str:

--- a/tests/test_client_sync.py
+++ b/tests/test_client_sync.py
@@ -275,8 +275,8 @@ def test_sync_codex_uses_codex_cli_when_available(tmp_path, monkeypatch):
     assert "NEXO Shared Brain for Codex" in bootstrap_text
     config_path = home / ".codex" / "config.toml"
     config_text = config_path.read_text()
-    assert 'model = "claude-opus-4-6[1m]"' in config_text
-    assert 'model_reasoning_effort = ""' in config_text
+    assert 'model = "gpt-5.4"' in config_text
+    assert 'model_reasoning_effort = "xhigh"' in config_text
     assert "initial_messages = [{ role = \"system\"" in config_text
     assert "[nexo.codex]" in config_text
     assert "bootstrap_managed = true" in config_text


### PR DESCRIPTION
DEFAULT_CODEX_MODEL was aliased to DEFAULT_CLAUDE_CODE_MODEL. Codex with ChatGPT account rejects Claude models. Fix: default to gpt-5-codex, refuse to write Claude-family models into Codex config, and self-heal pre-existing bad values on next sync.