### PR TITLE
fix: recommendation auto-ack + heal on packaged update path

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.3.23",
+  "version": "5.3.24",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [5.3.24] - 2026-04-14
+
+### Fix false-positive recommendation prompt + heal on packaged update path
+
+- `detect_outdated_recommendations` now classifies each client into
+  `pending` (needs interactive prompt) vs `auto_ack` (silent
+  acknowledge). If the user's model already matches the current
+  recommendation (regardless of reasoning_effort), their preferences are
+  auto-acknowledged silently without prompting. Fixes spurious
+  "Model recommendation available" noise on fresh installs whose
+  defaults already match the recommendation (e.g. Nora on v5.3.23).
+- Customized models (not a previously recommended NEXO default) also
+  auto-acknowledge silently — respects the user's choice without
+  repeating the stderr hint on every `nexo update`.
+- Model-profile heal is now applied on the npm packaged-install update
+  path (`plugins/update.py`), not just the legacy sync flow. Fixes
+  stale `schedule.json` keeping `claude-opus-*` in the Codex profile
+  after v5.3.23 update, which caused `nexo chat` → Codex to pass the
+  Claude model via `--model` and fail with "model not supported".
+
 ## [5.3.23] - 2026-04-14
 
 ### Fix Codex broken with Claude model default + centralize model recommendations

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 5.3.23
+version: 5.3.24
 metadata:
   openclaw:
     requires:

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "5.3.23",
+  "version": "5.3.24",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.3.23" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.3.24" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.3.23",
+  "version": "5.3.24",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/src/cli.py
+++ b/src/cli.py
@@ -938,7 +938,21 @@ def _prompt_model_recommendations(*, interactive: bool) -> None:
     from model_defaults import detect_outdated_recommendations, client_default
 
     preferences = load_client_preferences()
-    pending = detect_outdated_recommendations(preferences)
+    result = detect_outdated_recommendations(preferences)
+    pending = result.get("pending") or []
+    auto_ack = result.get("auto_ack") or {}
+
+    # Apply silent acknowledgements first (user already on current model, or
+    # has customized their model — either way no prompt needed). This avoids
+    # repeated stderr hints in cron/headless updates.
+    if auto_ack:
+        try:
+            existing_ack = dict(preferences.get("acknowledged_model_recommendations") or {})
+            existing_ack.update({k: int(v) for k, v in auto_ack.items()})
+            save_client_preferences(acknowledged_model_recommendations=existing_ack)
+        except Exception:
+            pass
+
     if not pending:
         return
 
@@ -955,7 +969,8 @@ def _prompt_model_recommendations(*, interactive: bool) -> None:
 
     updated_profiles = dict(preferences.get("client_runtime_profiles") or {})
     updated_ack = dict(preferences.get("acknowledged_model_recommendations") or {})
-    changed = False
+    updated_ack.update({k: int(v) for k, v in auto_ack.items()})
+    changed = bool(auto_ack)
     for entry in pending:
         client = entry["client"]
         effort_str = f" / {entry['current_effort']}" if entry["current_effort"] else ""

--- a/src/model_defaults.py
+++ b/src/model_defaults.py
@@ -126,9 +126,22 @@ def heal_runtime_profiles(profiles: dict) -> tuple[dict, list[str]]:
 
 def detect_outdated_recommendations(
     preferences: dict,
-) -> list[dict]:
-    """Return a list of clients whose user is on an older recommendation and
-    hasn't acknowledged the current one. Entries shape:
+) -> dict:
+    """Classify clients into "needs interactive prompt" vs "silent ack".
+
+    Returns a dict with two keys:
+      - ``pending``: list of entries that require an interactive prompt
+        because the user is still on an older NEXO-recommended model and a
+        newer recommendation is available.
+      - ``auto_ack``: mapping of ``{client: recommendation_version}`` that
+        should be acknowledged silently without prompting (because either
+        the user already matches the current recommended model, or they
+        have customized their model and we must respect that silently).
+
+    Saving the ``auto_ack`` entries prevents repeated stderr spam in
+    non-interactive (cron/headless) update runs.
+
+    ``pending`` entry shape:
       {
         "client": "codex",
         "current_model": "gpt-5.9",
@@ -139,7 +152,8 @@ def detect_outdated_recommendations(
         "display_name": "GPT-5.9 with high reasoning",
       }
     """
-    out: list[dict] = []
+    pending: list[dict] = []
+    auto_ack: dict[str, int] = {}
     profiles = preferences.get("client_runtime_profiles") or {}
     acknowledged = preferences.get("acknowledged_model_recommendations") or {}
     for client in ("claude_code", "codex"):
@@ -153,15 +167,22 @@ def detect_outdated_recommendations(
         ack_v = int(acknowledged.get(client) or 0)
         if current_v <= ack_v:
             continue
-        # Only offer upgrade if user is on a prior NEXO default.
-        # If they customized, respect their choice silently.
+        # User customized their model entirely (not a previously recommended
+        # NEXO default) — respect their choice and record ack silently so we
+        # don't log a hint every `nexo update`.
         if not was_nexo_default(client, user_model):
+            auto_ack[client] = current_v
             continue
-        # No change needed if they already match current (race: install wrote
-        # the new default but ack wasn't bumped). Treat as auto-acknowledged.
-        if user_model == default["model"] and user_effort == default["reasoning_effort"]:
+        # User is already on the current recommended model. Even if their
+        # reasoning_effort differs (e.g. they picked "max" at onboarding and
+        # the JSON stores ""), nothing to migrate — their effort is a
+        # personal choice layered on top of the recommended model.
+        if user_model == default["model"]:
+            auto_ack[client] = current_v
             continue
-        out.append({
+        # User is on a prior NEXO default and the current recommendation is
+        # a different model → offer interactive upgrade.
+        pending.append({
             "client": client,
             "current_model": default["model"],
             "current_effort": default["reasoning_effort"],
@@ -170,4 +191,4 @@ def detect_outdated_recommendations(
             "user_effort": user_effort,
             "display_name": default.get("display_name") or default["model"],
         })
-    return out
+    return {"pending": pending, "auto_ack": auto_ack}

--- a/src/plugins/update.py
+++ b/src/plugins/update.py
@@ -442,9 +442,17 @@ def _restore_code_tree(backup_dir: str) -> str | None:
 
 def _normalize_preferences_for_client_sync() -> dict:
     from client_preferences import normalize_client_preferences
+    from model_defaults import heal_runtime_profiles
 
     schedule_path = NEXO_HOME / "config" / "schedule.json"
     schedule_payload = json.loads(schedule_path.read_text()) if schedule_path.exists() else {}
+    # Heal invalid models (e.g. Claude-family written into codex profile by
+    # earlier buggy versions). Must run BEFORE normalize so the healed values
+    # propagate into preferences and downstream client config files.
+    existing_profiles = schedule_payload.get("client_runtime_profiles") or {}
+    healed_profiles, _heal_messages = heal_runtime_profiles(existing_profiles)
+    if _heal_messages:
+        schedule_payload["client_runtime_profiles"] = healed_profiles
     normalized_preferences = normalize_client_preferences(schedule_payload)
     if normalized_preferences != {
         key: schedule_payload.get(key)
@@ -902,9 +910,20 @@ def handle_update(remote: str = "origin", branch: str = "main", progress_fn=None
             _emit_progress(progress_fn, "Refreshing shared client configs...")
             from client_sync import sync_all_clients
             from client_preferences import normalize_client_preferences
+            from model_defaults import heal_runtime_profiles
 
             schedule_path = NEXO_HOME / "config" / "schedule.json"
             schedule_payload = json.loads(schedule_path.read_text()) if schedule_path.exists() else {}
+            # Heal Claude-family models written into Codex profile by earlier
+            # buggy versions.  Must run BEFORE normalize so healed values
+            # propagate into the saved preferences.
+            existing_profiles = schedule_payload.get("client_runtime_profiles") or {}
+            healed_profiles, heal_messages = heal_runtime_profiles(existing_profiles)
+            if heal_messages:
+                schedule_payload["client_runtime_profiles"] = healed_profiles
+                for msg in heal_messages:
+                    _emit_progress(progress_fn, msg)
+                    steps_done.append("model-heal")
             normalized_preferences = normalize_client_preferences(schedule_payload)
             if normalized_preferences != {
                 key: schedule_payload.get(key)

--- a/tests/test_client_preferences.py
+++ b/tests/test_client_preferences.py
@@ -16,10 +16,13 @@ def test_normalize_client_preferences_preserves_old_defaults(tmp_path):
     assert prefs["automation_enabled"] is True
     assert prefs["automation_backend"] == "claude_code"
     assert prefs["client_runtime_profiles"]["claude_code"]["model"] == "claude-opus-4-6[1m]"
-    assert prefs["client_runtime_profiles"]["codex"]["model"] == "claude-opus-4-6[1m]"
-    assert prefs["client_runtime_profiles"]["codex"]["reasoning_effort"] == ""
+    assert prefs["client_runtime_profiles"]["codex"]["model"] == "gpt-5.4"
+    assert prefs["client_runtime_profiles"]["codex"]["reasoning_effort"] == "xhigh"
     assert prefs["automation_task_profiles"]["fast"]["backend"] == ""
     assert prefs["automation_task_profiles"]["fast"]["model"] == ""
+    # New: acknowledged_model_recommendations is part of the normalized
+    # preferences schema so cron updates can record ack state silently.
+    assert prefs["acknowledged_model_recommendations"] == {"claude_code": 0, "codex": 0}
 
 
 def test_apply_client_preferences_forces_backend_none_when_automation_disabled():


### PR DESCRIPTION
v5.3.24: (1) detect_outdated_recommendations now separates pending interactive prompts from silent auto-acks so fresh installs already on the current model do not spam a false-positive recommendation every update. (2) heal_runtime_profiles now also runs on the npm packaged update code path (plugins/update.py), not just the legacy sync flow.