### PR TITLE
fix: sync model_defaults.json into NEXO_HOME

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.3.25",
+  "version": "5.3.26",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [5.3.26] - 2026-04-14
+
+### Fix: sync model_defaults.json into NEXO_HOME
+
+- The npm installer's runtime-file sync only copied `.py` files from
+  `src/` into `~/.nexo/`, so `src/model_defaults.json` (introduced in
+  v5.3.24) never reached the runtime. Python then fell back to hardcoded
+  defaults inside `model_defaults.py`, meaning future
+  `recommendation_version` bumps in the JSON would not propagate until
+  the fallback was also edited. Installer now also copies
+  `*_defaults.json` files, and `model_defaults.json` is added to the
+  static file list explicitly.
+
 ## [5.3.25] - 2026-04-14
 
 ### Fix headless Claude Code automation actually running (add --dangerously-skip-permissions)

--- a/bin/nexo-brain.js
+++ b/bin/nexo-brain.js
@@ -187,10 +187,19 @@ function getCoreRuntimeFlatFiles(srcDir = path.join(__dirname, "..", "src")) {
     "cron_recovery.py",
     "runtime_power.py",
     "requirements.txt",
+    "model_defaults.json",
   ];
   const discoveredRootModules = fs.existsSync(srcDir)
     ? fs.readdirSync(srcDir)
-      .filter((name) => name.endsWith(".py") && fs.statSync(path.join(srcDir, name)).isFile())
+      .filter((name) => {
+        const stat = fs.statSync(path.join(srcDir, name));
+        if (!stat.isFile()) return false;
+        // Include Python modules and any flat JSON config the Python runtime
+        // reads at import time (e.g. model_defaults.json). The "_defaults.json"
+        // suffix convention lets us add future config JSONs without touching
+        // this list.
+        return name.endsWith(".py") || name.endsWith("_defaults.json");
+      })
     : [];
   return [...new Set([...staticFiles, ...discoveredRootModules])];
 }

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 5.3.25
+version: 5.3.26
 metadata:
   openclaw:
     requires:

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "5.3.25",
+  "version": "5.3.26",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.3.25" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.3.26" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.3.25",
+  "version": "5.3.26",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",


### PR DESCRIPTION
v5.3.26: The runtime file sync only copied .py files, so src/model_defaults.json introduced in 5.3.24 never reached ~/.nexo/. Python fell back to hardcoded defaults, meaning future recommendation_version bumps would not propagate. Installer now also copies _defaults.json files.