### PR TITLE
feat: heartbeat surfaces authoritative NOW_UTC (v5.3.27)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.3.26",
+  "version": "5.3.27",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [5.3.27] - 2026-04-14
+
+### Feature: heartbeat exposes authoritative NOW_UTC
+
+- `nexo_heartbeat` output now begins with a `NOW_UTC: <ISO-8601>` line so
+  clients always have an authoritative wall-clock time on every user turn.
+  Prevents date/day-of-week drift in long sessions (e.g. emails or diaries
+  saying "ayer domingo" when yesterday was actually Monday).
+- Neutral UTC, no locale/timezone baked into core — clients format per
+  operator preferences in runtime personal.
+
 ## [5.3.26] - 2026-04-14
 
 ### Fix: sync model_defaults.json into NEXO_HOME

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 5.3.26
+version: 5.3.27
 metadata:
   openclaw:
     requires:

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "5.3.26",
+  "version": "5.3.27",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.3.26" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.3.27" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.3.26",
+  "version": "5.3.27",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/src/server.py
+++ b/src/server.py
@@ -304,6 +304,9 @@ def nexo_heartbeat(sid: str, task: str, context_hint: str = '') -> str:
     """Update session task, check inbox and pending questions. Auto-detects trust events.
 
     Call this at the START of every user interaction (before doing work).
+    Output always begins with a NOW_UTC line (ISO-8601, UTC) — use it as the
+    authoritative wall-clock time for any artifact (emails, diaries, followups)
+    to avoid date/day-of-week drift across long sessions.
     Args:
         sid: Your session ID from nexo_startup.
         task: Brief description of current work (5-10 words).

--- a/src/tools_sessions.py
+++ b/src/tools_sessions.py
@@ -431,7 +431,12 @@ def _handle_heartbeat_inner(sid: str, task: str, context_hint: str = '') -> str:
     """Inner body of handle_heartbeat — wrapped by tool_span above."""
     from db import get_db
     update_session(sid, task)
-    parts = [f"OK: {sid} — {task}"]
+
+    # Temporal anchor — surface authoritative UTC time so clients never drift
+    # on date/day-of-week across long sessions. Neutral ISO-8601, no locale,
+    # no timezone assumption: clients format per operator preferences.
+    _now_iso = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+    parts = [f"NOW_UTC: {_now_iso}", f"OK: {sid} — {task}"]
 
     inbox = get_inbox(sid)
     if inbox:


### PR DESCRIPTION
## Summary
- `nexo_heartbeat` output now begins with `NOW_UTC: <ISO-8601>` so clients always have authoritative wall-clock time on every user turn.
- Fixes date / day-of-week drift in long sessions (real incident: email said "ayer domingo" when yesterday was actually Monday).
- Core stays neutral: UTC only, no locale/timezone hardcoded. Runtime personal formats per operator preferences.

## Why
Today NEXO only sees the session-start date and no wall-clock hour. After several hours it drifts: wrong day-of-week in emails, diaries, followups. The cheapest fix is to refresh the anchor on every heartbeat (which already fires on every user message).

## Test plan
- [x] Local `pytest tests/ -k "heartbeat or session"` → 60 passed
- [ ] CI green
- [ ] After merge: tag `v5.3.27` and confirm publish workflow passes