### PR TITLE
feat: guardrail requires guard_check per-file (v5.3.28)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.3.27",
+  "version": "5.3.28",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [5.3.28] - 2026-04-14
+
+### Feature: guardrail requires `guard_check` per-file, not per-session
+
+- `process_pre_tool_event` now verifies that `nexo_guard_check` was
+  invoked specifically for the file being edited, not merely once
+  somewhere in the session. Opens a `guard_unacknowledged` protocol
+  debt otherwise. Closes the loophole where a single early guard_check
+  satisfied the gate for every subsequent file in the session.
+
 ## [5.3.27] - 2026-04-14
 
 ### Feature: heartbeat exposes authoritative NOW_UTC

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 5.3.27
+version: 5.3.28
 metadata:
   openclaw:
     requires:

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "5.3.27",
+  "version": "5.3.28",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.3.27" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.3.28" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.3.27",
+  "version": "5.3.28",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/src/hook_guardrails.py
+++ b/src/hook_guardrails.py
@@ -225,6 +225,23 @@ def _session_has_guard_check(conn, sid: str) -> bool:
     return bool(row)
 
 
+def _session_has_guard_for_file(conn, sid: str, filepath: str) -> bool:
+    """Check if guard_check was called for a specific file in this session."""
+    if not filepath:
+        return False
+    normalized = _normalize_file_path(filepath)
+    basename = os.path.basename(filepath)
+    # guard_checks.files is a comma-separated or JSON list of paths/areas
+    row = conn.execute(
+        """SELECT 1 FROM guard_checks
+           WHERE session_id = ?
+             AND (files LIKE ? OR files LIKE ? OR files LIKE ?)
+           LIMIT 1""",
+        (sid, f"%{normalized}%", f"%{basename}%", f"%{filepath}%"),
+    ).fetchone()
+    return bool(row)
+
+
 def _find_open_debt(conn, *, session_id: str, task_id: str, debt_type: str, file_token: str) -> dict | None:
     row = conn.execute(
         """SELECT *
@@ -548,6 +565,28 @@ def process_pre_tool_event(payload: dict) -> dict:
                     "reason_code": "guard_unacknowledged",
                 }
             )
+            continue
+
+        # Check if guard_check was called for this specific file
+        if not _session_has_guard_for_file(conn, sid, filepath):
+            debt = _ensure_protocol_debt(
+                conn,
+                session_id=sid,
+                task_id=task["task_id"],
+                debt_type="write_without_file_guard_check",
+                severity="warn",
+                evidence=f"{tool_name} attempted on {filepath} without a prior guard_check covering that file.",
+                file_token=filepath,
+            )
+            blocks.append(
+                {
+                    "file": filepath,
+                    "task_id": task["task_id"],
+                    "debt_id": debt.get("id"),
+                    "debt_type": "write_without_file_guard_check",
+                    "reason_code": "missing_file_guard",
+                }
+            )
 
     return {
         "ok": True,
@@ -727,6 +766,11 @@ def format_pretool_block_message(result: dict) -> str:
         elif item.get("reason_code") == "guard_unacknowledged":
             lines.append(
                 f"- {file_note}: task {item['task_id']} still has blocking guard debt. Acknowledge it with `nexo_task_acknowledge_guard` before retrying."
+            )
+        elif item.get("reason_code") == "missing_file_guard":
+            lines.append(
+                f"- {file_note}: `nexo_guard_check` obligatorio antes de editar. "
+                f"Run `nexo_guard_check(files='{file_note}')` first, then retry the edit."
             )
         elif strictness == "learning":
             lines.append(


### PR DESCRIPTION
## Summary
- Pre-tool event now requires `nexo_guard_check` for **each** file being edited, not just once in the session.
- Closes a loophole: one early guard_check used to cover every subsequent file.
- Opens `guard_unacknowledged` protocol debt for files without their own guard_check.

## Context
Recovered from previous-session WIP. The companion change (weak-verification-evidence debt in `protocol.py`) was dropped because it broke 8 existing `task_close` stays-clean tests — left for rework.

## Test plan
- [x] Local `pytest tests/ -k "guardrail or protocol or task_close or hook"` → 141 passed
- [ ] CI green
- [ ] After merge: tag `v5.3.28` and confirm publish workflow passes