### PR TITLE
Harden block 1 runtime hygiene and startup safety

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.3.28",
+  "version": "5.3.29",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,5 @@ credentials*.json
 .mcpregistry_*
 .clawhub/
 
-# macOS Finder duplicates
-* 2*
-* 2.*
+# Duplicate artifact copies must stay visible so preflight/release can fail.
 .githooks/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [5.3.29] - 2026-04-14
+
+### Fix: runtime hygiene, fail-closed startup, and honest release surfaces
+
+- Duplicate `* 2` artifacts are now treated as contamination instead of tolerated noise: `.gitignore` no longer hides them, runtime/plugin/update loaders skip them, and preflight/release checks fail if they return.
+- `src/scripts/nexo-update.sh` no longer carries a parallel shell update path; it delegates to the canonical Python update handler so packaged/runtime updates stop diverging.
+- Server startup now runs preflight synchronously, and corrupt SQLite state no longer respawns a fresh empty brain by default. Fresh-DB recovery requires explicit `NEXO_ALLOW_FRESH_DB_ON_CORRUPTION=1`.
+- Cron execution logging now writes a complete row after command exit and spools JSON under `~/.nexo/operations/cron-spool` when SQLite is unavailable, so runs stop disappearing silently.
+- `scripts/verify_release_readiness.py` now also checks repo-facing public surfaces (`README.md`, `llms.txt`, `index.html`, `blog/index.html`, `changelog/index.html`, `sitemap.xml`) so code, docs, and public web copy cannot drift apart quietly before tag publish.
+
 ## [5.3.28] - 2026-04-14
 
 ### Feature: guardrail requires `guard_check` per-file, not per-session

--- a/README.md
+++ b/README.md
@@ -488,7 +488,9 @@ NEXO Brain doesn't just respond — it runs 13 core recovery-aware background jo
 | **followup-hygiene** | Weekly (Sun) | Normalizes statuses, flags stale followups, cleans orphans |
 | **learning-housekeep** | 03:15 daily | Dedup learnings, adjust weights by usage, process overdue reviews, reconcile decision outcomes |
 | **immune** | Every 30 min | Quarantine processing, memory promotion/rejection, synaptic pruning |
+| **impact-scorer** | 05:45 daily | Scores active followups so queues can prioritize by expected impact |
 | **synthesis** | 06:00 daily | Memory synthesis — discovers cross-memory patterns |
+| **outcome-checker** | 08:00 daily | Verifies tracked outcomes and marks them met, pending, or missed |
 | **watchdog** | Every 30 min | Monitors services, LaunchAgents, and infrastructure health |
 | **auto-close-sessions** | Every 5 min | Cleans stale sessions |
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [Watch the overview video](https://nexo-brain.com/watch/) · [Watch on YouTube](https://www.youtube.com/watch?v=i2lkGhKyVqI) · [Open the infographic](https://nexo-brain.com/assets/nexo-brain-infographic-v5.png)
 
-Version `5.3.11` is the current packaged-runtime line: protocol and Cortex now reject malformed `outcome`, `task_type`, and `impact_level` values explicitly instead of silently coercing them into other valid states, so task history, debt, hot context, and decision telemetry stay trustworthy even when a caller passes a bad contract payload.
+Version `5.3.29` is the current packaged-runtime line: duplicate `* 2` artifacts now fail hygiene gates instead of hiding in the tree, packaged/runtime update paths converge on one canonical core, startup preflight runs synchronously, corrupt DB state no longer respawns an empty brain by default, and cron runs spool locally when SQLite is unavailable.
 
 Start here:
 - [5-minute quickstart](docs/quickstart-5-minutes.md)

--- a/bin/nexo-brain.js
+++ b/bin/nexo-brain.js
@@ -88,6 +88,20 @@ function log(msg) {
   console.log(`  ${msg}`);
 }
 
+function duplicateArtifactCanonicalName(name) {
+  const ext = path.extname(name);
+  const stem = ext ? name.slice(0, -ext.length) : name;
+  const match = stem.match(/^(.*) ([2-9]\d*)$/);
+  if (!match) return null;
+  return `${match[1]}${ext}`;
+}
+
+function isDuplicateArtifactName(name, dirPath = "") {
+  const canonical = duplicateArtifactCanonicalName(name);
+  if (!canonical || !dirPath) return false;
+  return fs.existsSync(path.join(dirPath, canonical));
+}
+
 function syncWatchdogHashRegistry(nexoHome) {
   try {
     const watchdogPath = path.join(nexoHome, "scripts", "nexo-watchdog.sh");
@@ -122,7 +136,7 @@ function writeRuntimeCoreArtifactsManifest(nexoHome, srcDir) {
       return fs.readdirSync(dirPath)
         .filter((name) => {
           const full = path.join(dirPath, name);
-          return fs.existsSync(full) && fs.statSync(full).isFile();
+          return fs.existsSync(full) && fs.statSync(full).isFile() && !isDuplicateArtifactName(name, dirPath);
         })
         .sort();
     };
@@ -192,6 +206,7 @@ function getCoreRuntimeFlatFiles(srcDir = path.join(__dirname, "..", "src")) {
   const discoveredRootModules = fs.existsSync(srcDir)
     ? fs.readdirSync(srcDir)
       .filter((name) => {
+        if (isDuplicateArtifactName(name, srcDir)) return false;
         const stat = fs.statSync(path.join(srcDir, name));
         if (!stat.isFile()) return false;
         // Include Python modules and any flat JSON config the Python runtime
@@ -1551,7 +1566,7 @@ async function main() {
         const copyDirRec = (src, dest) => {
           fs.mkdirSync(dest, { recursive: true });
           fs.readdirSync(src).forEach(item => {
-            if (item === "__pycache__" || item.endsWith(".pyc") || item.endsWith(".db")) return;
+            if (item === "__pycache__" || item.endsWith(".pyc") || item.endsWith(".db") || isDuplicateArtifactName(item, src)) return;
             const srcPath = path.join(src, item);
             const destPath = path.join(dest, item);
             if (fs.statSync(srcPath).isDirectory()) {
@@ -1620,7 +1635,7 @@ async function main() {
         const pluginsDest = path.join(NEXO_HOME, "plugins");
         fs.mkdirSync(pluginsDest, { recursive: true });
         if (fs.existsSync(pluginsSrc)) {
-          fs.readdirSync(pluginsSrc).filter(f => f.endsWith(".py")).forEach((f) => {
+          fs.readdirSync(pluginsSrc).filter(f => f.endsWith(".py") && !isDuplicateArtifactName(f, pluginsSrc)).forEach((f) => {
             fs.copyFileSync(path.join(pluginsSrc, f), path.join(pluginsDest, f));
           });
         }
@@ -1772,7 +1787,7 @@ async function main() {
         const copyDirRec2 = (src, dest) => {
           fs.mkdirSync(dest, { recursive: true });
           fs.readdirSync(src).forEach(item => {
-            if (item === "__pycache__" || item.endsWith(".pyc") || item.endsWith(".db")) return;
+            if (item === "__pycache__" || item.endsWith(".pyc") || item.endsWith(".db") || isDuplicateArtifactName(item, src)) return;
             const srcP = path.join(src, item);
             const destP = path.join(dest, item);
             if (fs.statSync(srcP).isDirectory()) copyDirRec2(srcP, destP);
@@ -1806,7 +1821,7 @@ async function main() {
         const copyDirRec3 = (src, dest) => {
           fs.mkdirSync(dest, { recursive: true });
           fs.readdirSync(src).forEach(item => {
-            if (item === "__pycache__" || item.endsWith(".pyc")) return;
+            if (item === "__pycache__" || item.endsWith(".pyc") || isDuplicateArtifactName(item, src)) return;
             const srcP = path.join(src, item);
             const destP = path.join(dest, item);
             if (fs.statSync(srcP).isDirectory()) copyDirRec3(srcP, destP);
@@ -1831,6 +1846,7 @@ async function main() {
       if (fs.existsSync(templatesSrc)) {
         fs.mkdirSync(templatesDest, { recursive: true });
         for (const f of fs.readdirSync(templatesSrc)) {
+          if (isDuplicateArtifactName(f, templatesSrc)) continue;
           const src = path.join(templatesSrc, f);
           const dest = path.join(templatesDest, f);
           if (fs.statSync(src).isFile()) {
@@ -1838,6 +1854,7 @@ async function main() {
           } else if (fs.statSync(src).isDirectory()) {
             fs.mkdirSync(dest, { recursive: true });
             for (const sf of fs.readdirSync(src)) {
+              if (isDuplicateArtifactName(sf, src)) continue;
               const ssrc = path.join(src, sf);
               if (fs.statSync(ssrc).isFile()) {
                 fs.copyFileSync(ssrc, path.join(dest, sf));
@@ -2354,7 +2371,7 @@ async function main() {
   const copyDirRecursive = (src, dest) => {
     fs.mkdirSync(dest, { recursive: true });
     fs.readdirSync(src).forEach(item => {
-      if (item === "__pycache__" || item.endsWith(".pyc") || item.endsWith(".db")) return;
+      if (item === "__pycache__" || item.endsWith(".pyc") || item.endsWith(".db") || isDuplicateArtifactName(item, src)) return;
       const srcPath = path.join(src, item);
       const destPath = path.join(dest, item);
       if (fs.statSync(srcPath).isDirectory()) {
@@ -2461,7 +2478,7 @@ async function main() {
   // Plugins (all .py files in plugins/)
   fs.mkdirSync(path.join(NEXO_HOME, "plugins"), { recursive: true });
   if (fs.existsSync(pluginsSrcDir)) {
-    fs.readdirSync(pluginsSrcDir).filter(f => f.endsWith(".py")).forEach((f) => {
+    fs.readdirSync(pluginsSrcDir).filter(f => f.endsWith(".py") && !isDuplicateArtifactName(f, pluginsSrcDir)).forEach((f) => {
       fs.copyFileSync(path.join(pluginsSrcDir, f), path.join(NEXO_HOME, "plugins", f));
     });
   }

--- a/blog/index.html
+++ b/blog/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Blog — NEXO Brain</title>
-    <meta name="description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, now including the v5.3.24 single-source model defaults and headless-safe update release.">
+    <meta name="description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, now including the v5.3.29 runtime hygiene, fail-closed startup, and honest cron tracing release.">
     <meta name="robots" content="index, follow">
     <link rel="canonical" href="https://nexo-brain.com/blog/">
 
@@ -12,7 +12,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://nexo-brain.com/blog/">
     <meta property="og:title" content="Blog — NEXO Brain">
-    <meta property="og:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, now including the v5.3.24 single-source model defaults and headless-safe update release.">
+    <meta property="og:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, now including the v5.3.29 runtime hygiene, fail-closed startup, and honest cron tracing release.">
     <meta property="og:image" content="https://nexo-brain.com/assets/og/og-blog.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -20,7 +20,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Blog — NEXO Brain">
-    <meta name="twitter:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, now including the v5.3.24 single-source model defaults and headless-safe update release.">
+    <meta name="twitter:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, now including the v5.3.29 runtime hygiene, fail-closed startup, and honest cron tracing release.">
     <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-blog.png">
 
     <script type="application/ld+json">
@@ -28,7 +28,7 @@
         "@context": "https://schema.org",
         "@type": "CollectionPage",
         "name": "Blog — NEXO Brain",
-        "description": "Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, now including the v5.3.24 single-source model defaults and headless-safe update release.",
+        "description": "Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, now including the v5.3.29 runtime hygiene, fail-closed startup, and honest cron tracing release.",
         "url": "https://nexo-brain.com/blog/",
         "isPartOf": {
             "@type": "WebSite",
@@ -134,7 +134,7 @@
                     <span class="page-chip">Competitive analysis</span>
                 </div>
                 <div class="hero-actions" style="justify-content:flex-start;">
-                    <a href="/blog/nexo-5-3-24-model-defaults-and-headless-safe-update/" class="btn btn-primary">Read latest release</a>
+                    <a href="/blog/nexo-5-3-29-runtime-hygiene-and-fail-closed-startup/" class="btn btn-primary">Read latest release</a>
                     <a href="/changelog/" class="btn btn-secondary">Latest release notes</a>
                     <a href="/evolution/" class="btn btn-secondary">See Evolution</a>
                 </div>
@@ -142,25 +142,25 @@
             <div class="blog-featured-card">
                 <div class="section-label">Latest release</div>
                 <div class="blog-featured-meta">
-                    <span class="compare-chip">April 13, 2026</span>
-                    <span class="compare-chip">Protocol contracts</span>
-                    <span class="compare-chip">Cortex contracts</span>
-                    <span class="compare-chip">No silent coercion</span>
+                    <span class="compare-chip">April 14, 2026</span>
+                    <span class="compare-chip">Runtime hygiene</span>
+                    <span class="compare-chip">Fail-closed startup</span>
+                    <span class="compare-chip">Honest cron tracing</span>
                 </div>
-                <h2>NEXO 5.3.11: Protocol and Cortex Contract Hardening</h2>
-                <p>NEXO 5.3.11 hardens the runtime's trust layer: malformed <code>outcome</code>, <code>task_type</code>, and <code>impact_level</code> payloads now fail explicitly instead of being silently coerced into other valid states.</p>
+                <h2>NEXO 5.3.29: Runtime Hygiene, Fail-Closed Startup, and Honest Cron Tracing</h2>
+                <p>NEXO 5.3.29 turns several quiet failure paths into explicit contracts: duplicate <code>* 2</code> artifacts now fail hygiene gates, packaged/runtime updates converge on one core, corrupt DB state no longer spawns an empty brain by default, and cron evidence survives transient SQLite failure.</p>
                 <div class="hero-actions" style="justify-content:flex-start;margin-bottom:18px;">
-                    <a href="/blog/nexo-5-3-24-model-defaults-and-headless-safe-update/" class="btn btn-primary">Open article</a>
-                    <a href="/changelog/#v5311" class="btn btn-secondary">Open changelog</a>
+                    <a href="/blog/nexo-5-3-29-runtime-hygiene-and-fail-closed-startup/" class="btn btn-primary">Open article</a>
+                    <a href="/changelog/#v5329" class="btn btn-secondary">Open changelog</a>
                 </div>
                 <div class="blog-mini-stack">
                     <div class="blog-mini-card">
                         <strong>Companion view</strong>
-                        <span><a href="/changelog/#v5311">The 5.3.11 changelog section</a></span>
+                        <span><a href="/changelog/#v5329">The 5.3.29 changelog section</a></span>
                     </div>
                     <div class="blog-mini-card">
                         <strong>Previous release</strong>
-                        <span><a href="/blog/nexo-5-3-10-runtime-metadata-and-deep-doctor-hardening/">NEXO 5.3.10: Packaged Runtime Truth, Evolution Telemetry, and Synthesis Loop Closure</a>.</span>
+                        <span><a href="/blog/nexo-5-3-24-model-defaults-and-headless-safe-update/">NEXO 5.3.24: Single-Source Model Defaults + Headless-Safe Update</a>.</span>
                     </div>
                 </div>
             </div>
@@ -175,9 +175,9 @@
 
             <div class="blog-card">
                 <div class="blog-card-date">April 14, 2026</div>
-                <h2><a href="/blog/nexo-5-3-24-model-defaults-and-headless-safe-update/">NEXO 5.3.24: Single-Source Model Defaults + Headless-Safe Update</a></h2>
-                <p>One JSON shared by the Python runtime and JS installer for all model defaults. Codex profiles self-heal on update, fresh installs get headless-safe <code>permissions.allow</code> so cron automation stops zombie-waiting for approvals, and a one-time upgrade prompt ships when a new model recommendation is published.</p>
-                <a href="/blog/nexo-5-3-24-model-defaults-and-headless-safe-update/" class="read-more">Read article <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14"/><path d="M12 5l7 7-7 7"/></svg></a>
+                <h2><a href="/blog/nexo-5-3-29-runtime-hygiene-and-fail-closed-startup/">NEXO 5.3.29: Runtime Hygiene, Fail-Closed Startup, and Honest Cron Tracing</a></h2>
+                <p>A release-engineering hardening pass for the shared brain: duplicate <code>* 2</code> artifacts now fail hygiene gates instead of hiding in the tree, update paths converge on one core, startup preflight runs synchronously, corrupt DB state fails closed, and cron runs spool locally when SQLite is unavailable.</p>
+                <a href="/blog/nexo-5-3-29-runtime-hygiene-and-fail-closed-startup/" class="read-more">Read article <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14"/><path d="M12 5l7 7-7 7"/></svg></a>
             </div>
 
             <div class="blog-card">

--- a/blog/nexo-5-3-29-runtime-hygiene-and-fail-closed-startup/index.html
+++ b/blog/nexo-5-3-29-runtime-hygiene-and-fail-closed-startup/index.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>NEXO Brain v5.3.29 — Runtime Hygiene, Fail-Closed Startup, and Honest Cron Tracing | nexo-brain.com</title>
+<meta name="description" content="v5.3.29 hardens duplicate-artifact hygiene, converges update paths on one core, makes startup fail closed on corrupt DB state, and preserves cron evidence even when SQLite is down.">
+<link rel="stylesheet" href="../../assets/blog.css">
+</head>
+<body>
+<article class="blog-post">
+<header>
+<h1>v5.3.29 — Runtime Hygiene, Fail-Closed Startup, and Honest Cron Tracing</h1>
+<time datetime="2026-04-14">April 14, 2026</time>
+</header>
+
+<p>This release closes a class of problems that are easy to dismiss as “local mess” until they turn into user-facing drift. The audit behind Block 1 found that the published repo was cleaner than the live worktree looked, but that was not comforting: duplicate <code>* 2</code> artifacts were being hidden instead of rejected, the shell update path still carried logic parallel to the Python core, server startup could keep mutating state in the background, and cron evidence still depended too much on SQLite being healthy at the exact moment the wrapper tried to write.</p>
+
+<p>v5.3.29 turns those soft failure paths into explicit contracts. The runtime now fails closed where it used to improvise, and the public release surface is finally forced to stay aligned with the packaged line before a tag can ship.</p>
+
+<h2>1. Duplicate artifacts are now contamination, not tolerated noise</h2>
+
+<p>Files such as <code>alpha 2.py</code> or duplicated test files were not always in <code>HEAD</code>, but they could still poison a live checkout because <code>.gitignore</code> hid them and several loaders walked the tree too permissively. That meant a local repo could behave differently from the clean published tree without anyone noticing.</p>
+
+<p>Now:</p>
+
+<ul>
+  <li><code>.gitignore</code> stops hiding those duplicates</li>
+  <li>runtime/plugin/update loaders skip duplicate artifacts explicitly</li>
+  <li><code>nexo-preflight.sh</code> and <code>verify_release_readiness.py</code> fail if they reappear</li>
+</ul>
+
+<p>The point is simple: if the tree is contaminated, release gates should say so loudly instead of hoping the operator notices.</p>
+
+<h2>2. There is one update core again</h2>
+
+<p><code>src/scripts/nexo-update.sh</code> no longer carries a parallel shell implementation of update behavior. It now delegates to the canonical Python update handler, so packaged/runtime updates stop diverging depending on which entry point happened to run.</p>
+
+<p>That matters because update logic is not a harmless convenience layer. Divergent paths create different runtime states, and one of them can quietly preserve bugs the other already fixed.</p>
+
+<h2>3. Startup now fails closed on corrupt DB state</h2>
+
+<p>The server no longer starts while a mutating preflight still runs in the background, and corrupt SQLite state no longer spawns a brand-new empty brain by default. If the DB is broken, the runtime now stops and tells the truth unless the operator explicitly opts into fresh-DB recovery with <code>NEXO_ALLOW_FRESH_DB_ON_CORRUPTION=1</code>.</p>
+
+<p>That change matters more than it sounds. “Keep the process alive” is the wrong priority if staying alive means erasing the very continuity the product exists to preserve.</p>
+
+<h2>4. Cron tracing survives transient DB failure</h2>
+
+<p>The cron wrapper used to create an open row and then patch it later. If the DB write path failed at the wrong time, the command could still run while leaving misleading or incomplete telemetry behind.</p>
+
+<p>Now the wrapper records a complete row after execution, and if SQLite is unavailable it writes a spool JSON artifact under <code>~/.nexo/operations/cron-spool</code>. The evidence survives long enough to be recovered instead of vanishing into a blank spot in history.</p>
+
+<h2>5. Release discipline is now enforced more honestly</h2>
+
+<p>This patch also hardens the release audit itself. <code>verify_release_readiness.py</code> now checks repo-facing public surfaces too: <code>README.md</code>, <code>llms.txt</code>, <code>index.html</code>, <code>blog/index.html</code>, <code>changelog/index.html</code>, and <code>sitemap.xml</code>. A tag is no longer considered “ready” just because code and npm metadata line up while the public copy still describes an older release.</p>
+
+<p>That is the release-engineering lesson behind this patch: the code can be correct and the release can still be dishonest if the outward-facing surfaces drift.</p>
+
+<h2>Update</h2>
+
+<pre><code>npm update -g nexo-brain
+nexo update
+</code></pre>
+
+<p>If your runtime is clean, the update should stay boring. If it is not, boring is exactly what the new gates are designed to restore.</p>
+
+</article>
+</body>
+</html>

--- a/changelog/index.html
+++ b/changelog/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Changelog — NEXO Brain</title>
-    <meta name="description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.3.24 centralizes model defaults in a single JSON shared by the Python runtime and JS installer, heals Claude-family models written into Codex profiles, and ships headless-safe client permissions so automation stops zombie-waiting for approvals.">
+    <meta name="description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.3.29 hardens runtime hygiene, converges update paths on one core, makes startup fail closed on corrupt DB state, and preserves cron evidence when SQLite is unavailable.">
     <meta name="robots" content="index, follow">
     <link rel="canonical" href="https://nexo-brain.com/changelog/">
 
@@ -12,7 +12,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://nexo-brain.com/changelog/">
     <meta property="og:title" content="Changelog — NEXO Brain">
-    <meta property="og:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.3.24 centralizes model defaults in a single JSON shared by the Python runtime and JS installer, heals Claude-family models written into Codex profiles, and ships headless-safe client permissions so automation stops zombie-waiting for approvals.">
+    <meta property="og:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.3.29 hardens runtime hygiene, converges update paths on one core, makes startup fail closed on corrupt DB state, and preserves cron evidence when SQLite is unavailable.">
     <meta property="og:image" content="https://nexo-brain.com/assets/og/og-changelog.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -20,7 +20,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Changelog — NEXO Brain">
-    <meta name="twitter:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.3.24 centralizes model defaults in a single JSON shared by the Python runtime and JS installer, heals Claude-family models written into Codex profiles, and ships headless-safe client permissions so automation stops zombie-waiting for approvals.">
+    <meta name="twitter:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v5.3.29 hardens runtime hygiene, converges update paths on one core, makes startup fail closed on corrupt DB state, and preserves cron evidence when SQLite is unavailable.">
     <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-changelog.png">
 
     <script type="application/ld+json">
@@ -28,7 +28,7 @@
         "@context": "https://schema.org",
         "@type": "CollectionPage",
         "name": "Changelog — NEXO Brain",
-        "description": "Full version history for NEXO Brain cognitive runtime. Latest release: v5.3.24 centralizes model defaults in a single JSON shared by the Python runtime and JS installer, heals Claude-family models written into Codex profiles, and ships headless-safe client permissions so automation stops zombie-waiting for approvals.",
+        "description": "Full version history for NEXO Brain cognitive runtime. Latest release: v5.3.29 hardens runtime hygiene, converges update paths on one core, makes startup fail closed on corrupt DB state, and preserves cron evidence when SQLite is unavailable.",
         "url": "https://nexo-brain.com/changelog/",
         "isPartOf": {
             "@type": "WebSite",
@@ -87,13 +87,13 @@
                 <h1 class="section-title" style="font-size:clamp(32px,5vw,56px);">Changelog</h1>
                 <p class="section-subtitle">Every feature, fix, and improvement &mdash; from the beginning, with the same visual clarity as the rest of the site.</p>
                 <div class="page-chip-row">
-                    <span class="page-chip">v5.3.24 live</span>
-                    <span class="page-chip">Single-source model defaults</span>
-                    <span class="page-chip">Codex self-heal</span>
-                    <span class="page-chip">Headless-safe permissions</span>
+                    <span class="page-chip">v5.3.29 live</span>
+                    <span class="page-chip">Runtime hygiene</span>
+                    <span class="page-chip">Fail-closed startup</span>
+                    <span class="page-chip">Honest cron tracing</span>
                 </div>
                 <div class="hero-actions" style="justify-content:flex-start;">
-                    <a href="#v5324" class="btn btn-primary">Start with v5.3.24</a>
+                    <a href="#v5329" class="btn btn-primary">Start with v5.3.29</a>
                     <a href="#v400" class="btn btn-secondary">See v4.0.0</a>
                     <a href="/evolution/" class="btn btn-secondary">See Evolution</a>
                 </div>
@@ -101,16 +101,16 @@
             <div class="page-visual">
                 <div class="page-stack">
                     <div class="page-stack-card">
-                        <strong>v5.3.24</strong>
-                        <span>Single JSON source of truth for model defaults shared by Python runtime and JS installer. Self-heal for Claude-family models in Codex profiles. Headless-safe <code>permissions.allow</code> and Codex <code>approval_policy</code> defaults so cron automation stops stalling on approval prompts.</span>
+                        <strong>v5.3.29</strong>
+                        <span>Duplicate artifact hygiene now fails closed, packaged/runtime updates converge on one core, startup stops respawning an empty brain on corrupt DB state, and cron evidence survives transient SQLite failure.</span>
                     </div>
                     <div class="page-stack-card">
-                        <strong>v5.3.11</strong>
-                        <span>Malformed <code>outcome</code>, <code>task_type</code>, and <code>impact_level</code> payloads now fail explicitly instead of being silently rewritten into other valid states.</span>
+                        <strong>v5.3.28</strong>
+                        <span><code>guard_check</code> is now enforced per-file instead of being satisfiable once per session, closing a loophole in protocol discipline.</span>
                     </div>
                     <div class="page-stack-card">
-                        <strong>v5.3.0</strong>
-                        <span><code>nexo uninstall</code> — stops all crons, removes runtime, preserves user data. Clean separation of runtime vs user data for safe reinstall.</span>
+                        <strong>v5.3.27</strong>
+                        <span><code>nexo_heartbeat</code> now emits authoritative <code>NOW_UTC</code>, stopping date drift in long sessions and delayed closeouts.</span>
                     </div>
                     <div class="page-stack-card">
                         <strong>v5.2.1</strong>
@@ -165,39 +165,127 @@
     </div>
 </section>
 
-<!-- v5.3.24 single-source model defaults + headless-safe update -->
-<section id="v5324" class="section-compact" style="background:linear-gradient(135deg,#07111f 0%,#122a4d 34%,#2563eb 68%,#10b981 100%);">
+<!-- v5.3.29 runtime hygiene + fail-closed startup -->
+<section id="v5329" class="section-compact" style="background:linear-gradient(135deg,#09111f 0%,#1f2a44 34%,#2563eb 68%,#f97316 100%);">
     <div class="container">
-        <div class="section-label">New in v5.3.24 <span style="opacity:.5;font-weight:400;">&mdash; April 14, 2026</span></div>
-        <h2 class="section-title">Single-Source Model Defaults + Headless-Safe Update</h2>
+        <div class="section-label">New in v5.3.29 <span style="opacity:.5;font-weight:400;">&mdash; April 14, 2026</span></div>
+        <h2 class="section-title">Runtime Hygiene + Fail-Closed Startup + Honest Cron Tracing</h2>
         <p class="section-subtitle">
-            Three compounding bugs shared one root cause: NEXO had no single source of truth for model defaults. Python runtime, JS installer, and client-config sync each kept their own copy and silently drifted. v5.3.24 consolidates everything into <code>src/model_defaults.json</code>, read identically by both runtimes, with a one-time upgrade prompt when a maintainer ships a new recommendation.
+            Block 1 of the technical audit closes as a real public release: duplicate artifacts stop hiding in local trees, packaged/runtime updates converge on one canonical core, corrupt DB state no longer respawns an empty brain by default, and cron evidence survives transient SQLite failure instead of vanishing quietly.
         </p>
         <div class="cognitive-group">
             <div class="cognitive-grid" style="grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:16px;">
                 <div class="cognitive-card">
-                    <h3>One JSON to rule model defaults</h3>
-                    <p><code>src/model_defaults.json</code> defines Claude Code + Codex defaults (model, reasoning effort, display name, recommendation version, previous defaults). Both Python and the JS installer read the same file, so drift is impossible.</p>
+                    <h3>Duplicate artifacts now fail hygiene gates</h3>
+                    <p><code>.gitignore</code> no longer hides <code>* 2</code> copies, loaders skip them explicitly, and both preflight and release-readiness fail if they reappear. Local contamination stops pretending to be harmless noise.</p>
                 </div>
                 <div class="cognitive-card">
-                    <h3>Codex no longer inherits Claude models</h3>
-                    <p>The historical <code>DEFAULT_CODEX_MODEL = DEFAULT_CLAUDE_CODE_MODEL</code> alias is gone. Codex default is <code>gpt-5.4</code> / <code>xhigh</code>. Client sync refuses to write Claude-family models into <code>~/.codex/config.toml</code>, and existing bad writes are healed on the next <code>nexo update</code>.</p>
+                    <h3>One update core again</h3>
+                    <p><code>src/scripts/nexo-update.sh</code> now delegates to the canonical Python handler instead of carrying a parallel shell implementation. Packaged/runtime updates stop drifting depending on which entry point ran.</p>
                 </div>
                 <div class="cognitive-card">
-                    <h3>Headless crons no longer zombie</h3>
-                    <p>Fresh installs now write a minimum <code>permissions.allow</code> list into <code>~/.claude/settings.json</code> (<code>Bash, Read, Edit, Write, Glob, Grep, Task, Skill, NotebookEdit, WebSearch, WebFetch, mcp__*</code>) so headless automation stops stalling on approval prompts. Codex gets <code>approval_policy = "never"</code> and <code>sandbox_mode = "danger-full-access"</code> as defaults.</p>
+                    <h3>Startup fails closed on corrupt DB state</h3>
+                    <p>Server preflight now runs synchronously, and corrupt SQLite state no longer spawns a fresh empty brain by default. Recovery requires explicit operator intent via <code>NEXO_ALLOW_FRESH_DB_ON_CORRUPTION=1</code>.</p>
                 </div>
                 <div class="cognitive-card">
-                    <h3>One-time upgrade prompt when a new model ships</h3>
-                    <p>Bumping <code>recommendation_version</code> in the JSON triggers a single interactive prompt on the user's next <code>nexo update</code> — only if they are still on a prior NEXO default. Customized models are respected silently. Users already on the current recommendation are auto-acknowledged without any output.</p>
+                    <h3>Cron runs keep evidence even when SQLite is down</h3>
+                    <p>The cron wrapper now writes a complete row after command exit and spools JSON under <code>~/.nexo/operations/cron-spool</code> if SQLite is unavailable. Execution traces stop disappearing into null-ended rows.</p>
                 </div>
                 <div class="cognitive-card">
-                    <h3><code>nexo update</code> no longer crashes on slow repos</h3>
-                    <p>If the runtime was ever synced from a local checkout, <code>git status --porcelain</code> timing out now returns a graceful error instead of an unhandled <code>TimeoutExpired</code> that crashed every <code>nexo update</code>.</p>
+                    <h3>Release audit now checks public repo surfaces too</h3>
+                    <p><code>verify_release_readiness.py</code> now verifies the repo-facing public copy as well: <code>README.md</code>, <code>llms.txt</code>, <code>index.html</code>, <code>blog/index.html</code>, <code>changelog/index.html</code>, and <code>sitemap.xml</code>. A tag is no longer “ready” if the outward-facing story still describes an older version.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<!-- v5.3.28 guard_check per-file -->
+<section id="v5328" class="section-compact" style="background:linear-gradient(135deg,#07111f 0%,#14233c 34%,#2563eb 68%,#8b5cf6 100%);">
+    <div class="container">
+        <div class="section-label">New in v5.3.28 <span style="opacity:.5;font-weight:400;">&mdash; April 14, 2026</span></div>
+        <h2 class="section-title">Per-File Guard Enforcement</h2>
+        <p class="section-subtitle">
+            A subtle protocol loophole is gone: calling <code>nexo_guard_check</code> once early in the session no longer satisfies the contract for every later file edit.
+        </p>
+        <div class="cognitive-group">
+            <div class="cognitive-grid" style="grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:16px;">
+                <div class="cognitive-card">
+                    <h3>Guard now binds to the file actually being edited</h3>
+                    <p><code>process_pre_tool_event</code> verifies that the guarded file matches the edit target, so conditioned learnings stop being bypassable by one stale check earlier in the session.</p>
                 </div>
                 <div class="cognitive-card">
-                    <h3>Heal applies on both update paths</h3>
-                    <p>Model-profile heal now runs on both the legacy sync flow (<code>auto_update.py::manual_sync_update</code>) and the packaged npm update flow (<code>plugins/update.py</code>) so stale <code>claude-*</code> values in <code>schedule.json</code> are cleaned regardless of install method.</p>
+                    <h3>Protocol debt opens when the file-level contract is violated</h3>
+                    <p>Instead of silently accepting the mismatch, the runtime now records explicit debt when a write happens without the corresponding per-file guard evidence.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<!-- v5.3.27 heartbeat now utc -->
+<section id="v5327" class="section-compact" style="background:linear-gradient(135deg,#07111f 0%,#17304a 34%,#0ea5e9 68%,#22c55e 100%);">
+    <div class="container">
+        <div class="section-label">New in v5.3.27 <span style="opacity:.5;font-weight:400;">&mdash; April 14, 2026</span></div>
+        <h2 class="section-title">Heartbeat Emits Authoritative NOW_UTC</h2>
+        <p class="section-subtitle">
+            Long sessions and delayed closeouts stop guessing the calendar. Every heartbeat now begins with an authoritative UTC timestamp that clients can format locally.
+        </p>
+        <div class="cognitive-group">
+            <div class="cognitive-grid" style="grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:16px;">
+                <div class="cognitive-card">
+                    <h3>Clients stop inventing relative dates</h3>
+                    <p><code>nexo_heartbeat</code> now emits <code>NOW_UTC</code>, so “ayer”, “mañana”, and day-of-week phrasing stop drifting during long-running tasks and email work.</p>
+                </div>
+                <div class="cognitive-card">
+                    <h3>Timezone stays a client concern</h3>
+                    <p>The core remains neutral: UTC is authoritative, while formatting stays in the operator/runtime layer instead of hardcoding locale or timezone into product logic.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<!-- v5.3.26 sync model defaults json -->
+<section id="v5326" class="section-compact" style="background:linear-gradient(135deg,#07111f 0%,#1b2840 34%,#2563eb 68%,#14b8a6 100%);">
+    <div class="container">
+        <div class="section-label">New in v5.3.26 <span style="opacity:.5;font-weight:400;">&mdash; April 14, 2026</span></div>
+        <h2 class="section-title">Packaged Runtime Now Receives <code>model_defaults.json</code></h2>
+        <p class="section-subtitle">
+            The single-source model-defaults architecture from v5.3.24 was correct in the repo but incomplete in the packaged runtime path until the JSON itself was copied into <code>~/.nexo</code>.
+        </p>
+        <div class="cognitive-group">
+            <div class="cognitive-grid" style="grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:16px;">
+                <div class="cognitive-card">
+                    <h3>Packaged installs now carry the JSON source of truth</h3>
+                    <p>The installer/runtime sync now copies <code>model_defaults.json</code> into <code>NEXO_HOME</code>, so future recommendation bumps propagate without depending on hardcoded Python fallbacks.</p>
+                </div>
+                <div class="cognitive-card">
+                    <h3>New recommendations actually reach upgraded users</h3>
+                    <p>Without the JSON in the runtime, packaged users could stay on stale defaults even though the repo and npm package had already moved forward. That delivery gap is now closed.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<!-- v5.3.25 headless safe update -->
+<section id="v5325" class="section-compact" style="background:linear-gradient(135deg,#07111f 0%,#12223d 34%,#7c3aed 68%,#ec4899 100%);">
+    <div class="container">
+        <div class="section-label">New in v5.3.25 <span style="opacity:.5;font-weight:400;">&mdash; April 14, 2026</span></div>
+        <h2 class="section-title">Headless Claude Automation Actually Runs</h2>
+        <p class="section-subtitle">
+            The permissions allowlist from v5.3.24 was necessary but not sufficient: headless <code>claude -p</code> still needed the explicit bypass flag or cron automation would wait forever for approvals nobody could grant.
+        </p>
+        <div class="cognitive-group">
+            <div class="cognitive-grid" style="grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:16px;">
+                <div class="cognitive-card">
+                    <h3>Headless Claude now gets the right execution flag</h3>
+                    <p><code>agent_runner.run_automation_prompt</code> now passes the permissions-bypass flag on every headless Claude invocation, so followup-runner, email-monitor, and Deep Sleep stop zombifying on approval prompts.</p>
+                </div>
+                <div class="cognitive-card">
+                    <h3>Interactive sessions remain unchanged</h3>
+                    <p>The fix applies only to non-interactive automation. Daily interactive work keeps the normal approval flow and operator control.</p>
                 </div>
             </div>
         </div>

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 5.3.28
+version: 5.3.29
 metadata:
   openclaw:
     requires:

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents</title>
-    <meta name="description" content="Libre/open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.15 centralizes model selection so users pick their model once and every component — automation scripts, task profiles, and backends — respects that choice.">
+    <meta name="description" content="Libre/open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.29 hardens runtime hygiene, fail-closed startup, and honest cron tracing so packaged and repo releases stop drifting from operational truth.">
     <meta name="keywords" content="AI memory, cognitive architecture, MCP, Claude Code, Codex, Claude Desktop, agent memory, vector search, AI agents, shared brain, open source">
     <meta name="author" content="WAzion">
     <meta name="robots" content="index, follow">
@@ -14,7 +14,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://nexo-brain.com">
     <meta property="og:title" content="NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents">
-    <meta property="og:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.15 centralizes model selection so users pick their model once and every component — automation scripts, task profiles, and backends — respects that choice.">
+    <meta property="og:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.29 hardens runtime hygiene, fail-closed startup, and honest cron tracing so packaged and repo releases stop drifting from operational truth.">
     <meta property="og:image" content="https://nexo-brain.com/assets/og/og-home.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -22,7 +22,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents">
-    <meta name="twitter:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.15 centralizes model selection so users pick their model once and every component — automation scripts, task profiles, and backends — respects that choice.">
+    <meta name="twitter:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.29 hardens runtime hygiene, fail-closed startup, and honest cron tracing so packaged and repo releases stop drifting from operational truth.">
     <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-home.png">
 
     <!-- Google Analytics (GA4) -->
@@ -46,12 +46,12 @@
         "@context": "https://schema.org",
         "@type": "SoftwareApplication",
         "name": "NEXO Brain",
-        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.15 centralizes model selection so users pick their model once and every component — automation scripts, task profiles, and backends — respects that choice.",
+        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.29 hardens runtime hygiene, fail-closed startup, and honest cron tracing so packaged and repo releases stop drifting from operational truth.",
         "applicationCategory": "DeveloperApplication",
         "operatingSystem": "macOS, Linux, Windows",
         "url": "https://nexo-brain.com",
         "downloadUrl": "https://www.npmjs.com/package/nexo-brain",
-        "softwareVersion": "5.3.15",
+        "softwareVersion": "5.3.29",
         "license": "https://www.gnu.org/licenses/agpl-3.0",
         "author": {
             "@type": "Organization",
@@ -88,7 +88,7 @@
         "@type": "WebSite",
         "name": "NEXO Brain",
         "url": "https://nexo-brain.com",
-        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.15 centralizes model selection so users pick their model once and every component — automation scripts, task profiles, and backends — respects that choice.",
+        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.29 hardens runtime hygiene, fail-closed startup, and honest cron tracing so packaged and repo releases stop drifting from operational truth.",
         "publisher": {
             "@type": "Organization",
             "name": "WAzion",
@@ -697,7 +697,7 @@
     <div class="container">
         <div class="hero-badge fade-up">
             <span class="dot"></span>
-            <span id="version-badge">v5.3.15</span> &mdash; installer nvm PATH + Keychain unlock for headless
+            <span id="version-badge">v5.3.29</span> &mdash; runtime hygiene + fail-closed startup
         </div>
         <div class="fade-up" style="display:flex;gap:8px;justify-content:center;margin-bottom:12px;">
             <img src="https://img.shields.io/npm/v/nexo-brain?color=7C3AED&label=npm" alt="npm version">
@@ -1156,9 +1156,9 @@
 
         <div class="release-evolution-grid">
             <div class="release-evolution-card">
-                <div class="release-evolution-version">v5.3.15</div>
-                <h3>Protocol and Cortex stop inventing valid states</h3>
-                <p>5.3.15 hardens the shared-brain contract layer: malformed <code>outcome</code>, <code>task_type</code>, and <code>impact_level</code> payloads now fail explicitly instead of being silently coerced into other valid values, so persisted task, debt, context, and decision data stays trustworthy.</p>
+                <div class="release-evolution-version">v5.3.29</div>
+                <h3>Runtime hygiene now fails closed instead of drifting quietly</h3>
+                <p>5.3.29 turns several soft failure paths into explicit release/runtime contracts: duplicate <code>* 2</code> artifacts now fail hygiene gates, startup preflight runs synchronously, corrupt DB state no longer respawns an empty brain by default, and cron runs spool locally if SQLite is unavailable.</p>
             </div>
             <div class="release-evolution-card">
                 <div class="release-evolution-version">v5.1.0</div>

--- a/llms.txt
+++ b/llms.txt
@@ -1,9 +1,10 @@
 # NEXO Brain
 
-> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.3.11).
+> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.3.29).
 
 NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. It adds a local shared brain across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, smarter retrieval defaults, long-horizon overnight analysis, and 150+ MCP tools.
 
+v5.3.29: runtime hygiene + fail-closed startup + honest cron tracing — duplicate `* 2` artifacts now fail release gates instead of hiding in the tree, update paths converge on one canonical core, startup preflight runs synchronously, corrupt DB state no longer respawns an empty brain by default, and cron runs spool locally when SQLite is unavailable
 v5.3.11: protocol + cortex contract hardening — malformed `outcome`, `task_type`, and `impact_level` values now fail explicitly instead of being silently coerced into other valid states, so persisted task/debt/context/decision data stays trustworthy
 v5.3.10: packaged runtime truth + evolution telemetry + synthesis loop closure — installs and updates now keep `~/.nexo/package.json` aligned with the published npm package, deep doctor stays honest during fresh bootstrap, weekly Evolution asks for explicit dimension telemetry again, and daily synthesis only absorbs actionable startup/update summaries
 v5.3.9: packaged core-artifact manifest heal — packaged updates now rebuild the core runtime manifest from the canonical npm package source so personal scripts stop being reclassified as core, portable exports keep including them, and runtime doctor can recover personal LaunchAgents cleanly after a bad `5.3.8` update

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "5.3.28",
+  "version": "5.3.29",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.3.28" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.3.29" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.3.28",
+  "version": "5.3.29",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/release-contracts/v5.3.29.json
+++ b/release-contracts/v5.3.29.json
@@ -1,0 +1,101 @@
+{
+  "release_line": "v5.3",
+  "target_version": "5.3.29",
+  "scope_owner": "NEXO",
+  "distribution": {
+    "git_updates_on": "merge_to_main",
+    "packaged_release_on": "tag_publish"
+  },
+  "required_repo_files": [
+    "package.json",
+    "CHANGELOG.md",
+    "README.md",
+    "llms.txt",
+    "sitemap.xml",
+    "index.html",
+    "blog/index.html",
+    "blog/nexo-5-3-29-runtime-hygiene-and-fail-closed-startup/index.html",
+    "changelog/index.html",
+    "scripts/sync_release_artifacts.py",
+    "scripts/verify_release_readiness.py",
+    "release-contracts/v5.3.29.json",
+    ".claude-plugin/plugin.json",
+    "clawhub-skill/SKILL.md",
+    "openclaw-plugin/package.json",
+    "openclaw-plugin/src/mcp-bridge.ts",
+    "src/auto_update.py",
+    "src/plugin_loader.py",
+    "src/plugins/update.py",
+    "src/scripts/nexo-cron-wrapper.sh",
+    "src/scripts/nexo-update.sh",
+    "src/server.py",
+    "src/tree_hygiene.py",
+    "tests/test_packaged_update_runtime.py",
+    "tests/test_plugin_loader_baseline.py",
+    "tests/test_verify_release_readiness.py",
+    "tests/test_server_startup_contract.py",
+    "tests/test_cron_wrapper_contract.py",
+    "tests/test_update_shell_contract.py"
+  ],
+  "required_website_files": [
+    "index.html",
+    "blog/index.html",
+    "blog/nexo-5-3-29-runtime-hygiene-and-fail-closed-startup/index.html",
+    "changelog/index.html",
+    "llms.txt",
+    ".well-known/llms.txt",
+    "sitemap.xml"
+  ],
+  "gates": [
+    {
+      "id": "duplicate_artifacts_fail_release",
+      "title": "Duplicate `* 2` artifacts fail runtime and release hygiene instead of hiding in the tree",
+      "status": "complete",
+      "evidence_required": [
+        "`.gitignore` no longer hides duplicate `* 2` artifacts",
+        "Runtime/plugin/update loaders skip duplicate artifacts explicitly",
+        "Preflight and release-readiness fail when duplicate artifacts are present"
+      ]
+    },
+    {
+      "id": "single_update_core",
+      "title": "Shell update entry point delegates to the canonical Python update core",
+      "status": "complete",
+      "evidence_required": [
+        "`src/scripts/nexo-update.sh` delegates into the Python update handler",
+        "Packaged/runtime update behavior no longer depends on a parallel shell implementation",
+        "Regression coverage keeps the delegation contract pinned"
+      ]
+    },
+    {
+      "id": "startup_fails_closed_on_corrupt_db",
+      "title": "Server startup no longer races preflight or respawns an empty brain on corrupt DB state",
+      "status": "complete",
+      "evidence_required": [
+        "Server startup runs preflight synchronously before serving",
+        "Corrupt DB state stops startup by default instead of creating a fresh empty DB",
+        "Fresh-DB recovery requires explicit operator override"
+      ]
+    },
+    {
+      "id": "cron_spool_preserves_evidence",
+      "title": "Cron execution evidence survives transient SQLite failure",
+      "status": "complete",
+      "evidence_required": [
+        "Cron wrapper writes a complete run row after command exit",
+        "When SQLite is unavailable the wrapper writes a spool JSON artifact",
+        "Regression coverage protects both the DB path and the spool fallback"
+      ]
+    },
+    {
+      "id": "public_release_surfaces_stay_aligned",
+      "title": "Repo copy, website copy, and packaged release line all reflect the same version before tag publish",
+      "status": "complete",
+      "evidence_required": [
+        "README, llms, homepage, blog index, changelog page, and sitemap reference v5.3.29",
+        "Website worktree contains the same v5.3.29 public surfaces including `.well-known/llms.txt`",
+        "`verify_release_readiness.py` checks both repo-facing and website-facing public surfaces before final closeout"
+      ]
+    }
+  ]
+}

--- a/scripts/nexo-preflight.sh
+++ b/scripts/nexo-preflight.sh
@@ -25,15 +25,36 @@ echo "============================================================"
 echo "NEXO Preflight — $(date '+%Y-%m-%d %H:%M:%S')"
 echo "============================================================"
 
-# ── 1. py_compile for all Python scripts in src/scripts/ ──────────────────
+# ── 1. duplicate artifact hygiene ─────────────────────────────────────────
+echo ""
+echo "--- Check 1: Duplicate artifact hygiene ---"
+DUPLICATES=$(python3 - <<PY
+import sys
+from pathlib import Path
+sys.path.insert(0, "$SRC")
+from tree_hygiene import find_duplicate_artifact_paths
+
+repo_root = Path("$REPO_ROOT")
+for path in find_duplicate_artifact_paths(repo_root):
+    print(path.relative_to(repo_root))
+PY
+)
+if [ -n "$DUPLICATES" ]; then
+    while IFS= read -r duplicate; do
+        [ -n "$duplicate" ] || continue
+        fail "$duplicate — duplicate artifact copy detected"
+    done <<< "$DUPLICATES"
+else
+    pass "no duplicate artifact copies found"
+fi
+
+# ── 2. py_compile for all Python scripts in src/scripts/ ──────────────────
 echo ""
 # Non-core scripts to exclude from compilation checks
 NON_CORE="check-context.py"
 
-echo "--- Check 1: Python syntax (src/scripts/*.py) ---"
+echo "--- Check 2: Python syntax (src/scripts/*.py) ---"
 for pyfile in "$SRC"/scripts/*.py; do
-    # Skip " 2" duplicate files (backup copies)
-    [[ "$pyfile" == *" 2"* ]] && continue
     [ -f "$pyfile" ] || continue
     name=$(basename "$pyfile")
     # Skip non-core scripts
@@ -47,9 +68,9 @@ for pyfile in "$SRC"/scripts/*.py; do
     fi
 done
 
-# ── 2. py_compile for auto_close_sessions.py ──────────────────────────────
+# ── 3. py_compile for auto_close_sessions.py ──────────────────────────────
 echo ""
-echo "--- Check 2: Python syntax (auto_close_sessions.py) ---"
+echo "--- Check 3: Python syntax (auto_close_sessions.py) ---"
 ACS="$SRC/auto_close_sessions.py"
 if [ -f "$ACS" ]; then
     if python3 -m py_compile "$ACS" 2>/dev/null; then
@@ -61,12 +82,10 @@ else
     fail "auto_close_sessions.py — file not found"
 fi
 
-# ── 3. bash -n for all shell scripts in src/scripts/ ─────────────────────
+# ── 4. bash -n for all shell scripts in src/scripts/ ─────────────────────
 echo ""
-echo "--- Check 3: Shell syntax (src/scripts/*.sh) ---"
+echo "--- Check 4: Shell syntax (src/scripts/*.sh) ---"
 for shfile in "$SRC"/scripts/*.sh; do
-    # Skip " 2" duplicate files (backup copies)
-    [[ "$shfile" == *" 2"* ]] && continue
     [ -f "$shfile" ] || continue
     name=$(basename "$shfile")
     if bash -n "$shfile" 2>/dev/null; then
@@ -76,9 +95,9 @@ for shfile in "$SRC"/scripts/*.sh; do
     fi
 done
 
-# ── 4. Manifest<->file consistency ────────────────────────────────────────
+# ── 5. Manifest<->file consistency ────────────────────────────────────────
 echo ""
-echo "--- Check 4: Manifest crons have existing script files ---"
+echo "--- Check 5: Manifest crons have existing script files ---"
 if [ ! -f "$MANIFEST" ]; then
     fail "manifest.json not found at $MANIFEST"
 else
@@ -109,9 +128,9 @@ except Exception as e:
     fi
 fi
 
-# ── 5. Manifest<->watchdog MONITORS consistency ──────────────────────────
+# ── 6. Manifest<->watchdog MONITORS consistency ──────────────────────────
 echo ""
-echo "--- Check 5: Manifest crons present in watchdog MONITORS ---"
+echo "--- Check 6: Manifest crons present in watchdog MONITORS ---"
 if [ ! -f "$WATCHDOG" ]; then
     fail "nexo-watchdog.sh not found at $WATCHDOG"
 else
@@ -141,9 +160,9 @@ else
     fi
 fi
 
-# ── 6. Manifest<->README consistency ─────────────────────────────────────
+# ── 7. Manifest<->README consistency ─────────────────────────────────────
 echo ""
-echo "--- Check 6: Manifest crons mentioned in README ---"
+echo "--- Check 7: Manifest crons mentioned in README ---"
 README="$REPO_ROOT/README.md"
 if [ -f "$README" ] && [ -f "$MANIFEST" ]; then
     manifest_ids=$(python3 -c "
@@ -164,9 +183,9 @@ else
     warn "README.md or manifest.json not found, skipping"
 fi
 
-# ── 7. Smoke tests ──────────────────────────────────────────────────────
+# ── 8. Smoke tests ──────────────────────────────────────────────────────
 echo ""
-echo "--- Check 7: Smoke tests ---"
+echo "--- Check 8: Smoke tests ---"
 
 # 7a: catchup weekday conversion (manifest 0=Sunday -> python 6)
 WEEKDAY_TEST=$(python3 -c "

--- a/scripts/verify_release_readiness.py
+++ b/scripts/verify_release_readiness.py
@@ -23,6 +23,12 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from tree_hygiene import find_duplicate_artifact_paths
+
 PACKAGE_JSON = ROOT / "package.json"
 CHANGELOG = ROOT / "CHANGELOG.md"
 DEFAULT_WEBSITE_ROOT = ROOT.parent / "nexo-gh-pages"
@@ -130,6 +136,14 @@ def _check_changelog(version: str) -> None:
             f"[release-readiness] top changelog version {top_version} != package.json {version}"
         )
     print(f"[release-readiness] changelog OK ({version})")
+
+
+def _check_duplicate_artifacts(repo_root: Path = ROOT) -> None:
+    duplicates = find_duplicate_artifact_paths(repo_root)
+    if duplicates:
+        rendered = "\n- ".join(str(path.relative_to(repo_root)) for path in duplicates)
+        raise SystemExit("[release-readiness] duplicate artifacts found:\n- " + rendered)
+    print(f"[release-readiness] duplicate artifact hygiene OK ({repo_root})")
 
 
 def _check_website(version: str, website_root: Path) -> None:
@@ -409,6 +423,7 @@ def main() -> int:
     nexo_home = _resolve_nexo_home(args.nexo_home)
     website_root = Path(args.website_root).expanduser()
     _check_changelog(version)
+    _check_duplicate_artifacts()
     _run([sys.executable, "scripts/sync_release_artifacts.py", "--check"])
     _run([sys.executable, "scripts/verify_client_parity.py"])
     _check_website(version, website_root)

--- a/scripts/verify_release_readiness.py
+++ b/scripts/verify_release_readiness.py
@@ -146,20 +146,80 @@ def _check_duplicate_artifacts(repo_root: Path = ROOT) -> None:
     print(f"[release-readiness] duplicate artifact hygiene OK ({repo_root})")
 
 
+def _surface_version_markers(version: str) -> list[tuple[str, list[str]]]:
+    version_slug = version.replace(".", "-")
+    version_anchor = version.replace(".", "")
+    return [
+        ("README.md", [f"Version `{version}` is the current packaged-runtime line"]),
+        ("llms.txt", [f"(v{version}).", f"v{version}:"]),
+        (
+            "index.html",
+            [f'id="version-badge">v{version}<', f'"softwareVersion": "{version}"'],
+        ),
+        ("blog/index.html", [f"/blog/nexo-{version_slug}", f"NEXO {version}:"]),
+        ("changelog/index.html", [f'id="v{version_anchor}"', f"New in v{version}"]),
+        ("sitemap.xml", [f"/blog/nexo-{version_slug}"]),
+    ]
+
+
+def _check_public_surfaces(
+    version: str,
+    root: Path,
+    *,
+    label: str,
+    include_readme: bool,
+    include_well_known: bool,
+) -> None:
+    missing = []
+    for raw_path, markers in _surface_version_markers(version):
+        if raw_path == "README.md" and not include_readme:
+            continue
+        path = root / raw_path
+        if not path.is_file():
+            continue
+        text = path.read_text(encoding="utf-8")
+        for marker in markers:
+            if marker not in text:
+                missing.append(f"{path} missing {marker}")
+                break
+
+    if include_well_known:
+        well_known = root / ".well-known" / "llms.txt"
+        if not well_known.is_file():
+            missing.append(f"{well_known} missing file")
+        else:
+            text = well_known.read_text(encoding="utf-8")
+            for marker in (f"(v{version}).", f"v{version}:"):
+                if marker not in text:
+                    missing.append(f"{well_known} missing {marker}")
+                    break
+
+    if missing:
+        raise SystemExit(f"[release-readiness] {label} drift:\n- " + "\n- ".join(missing))
+    print(f"[release-readiness] {label} OK ({root})")
+
+
 def _check_website(version: str, website_root: Path) -> None:
     if not website_root.is_dir():
         print(f"[release-readiness] website skipped (missing {website_root})")
         return
-    changelog_page = website_root / "changelog" / "index.html"
-    home_page = website_root / "index.html"
-    missing = []
-    if changelog_page.is_file() and f"v{version}" not in changelog_page.read_text(encoding="utf-8"):
-        missing.append(f"{changelog_page} missing v{version}")
-    if home_page.is_file() and version not in home_page.read_text(encoding="utf-8"):
-        missing.append(f"{home_page} missing {version}")
-    if missing:
-        raise SystemExit("[release-readiness] website drift:\n- " + "\n- ".join(missing))
-    print(f"[release-readiness] website OK ({website_root})")
+    _check_public_surfaces(
+        version,
+        website_root,
+        label="website",
+        include_readme=False,
+        include_well_known=True,
+    )
+
+
+def _check_repo_public_surfaces(version: str, repo_root: Path = ROOT) -> None:
+    _check_public_surfaces(
+        version,
+        repo_root,
+        label="repo public surfaces",
+        include_readme=True,
+        include_well_known=False,
+    )
 
 
 def _check_github_release(version: str, repository_slug: str) -> None:
@@ -423,6 +483,7 @@ def main() -> int:
     nexo_home = _resolve_nexo_home(args.nexo_home)
     website_root = Path(args.website_root).expanduser()
     _check_changelog(version)
+    _check_repo_public_surfaces(version)
     _check_duplicate_artifacts()
     _run([sys.executable, "scripts/sync_release_artifacts.py", "--check"])
     _run([sys.executable, "scripts/verify_client_parity.py"])

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://nexo-brain.com/</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
@@ -44,7 +44,7 @@
   </url>
   <url>
     <loc>https://nexo-brain.com/changelog/</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
@@ -143,6 +143,12 @@
     <lastmod>2026-04-14</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://nexo-brain.com/blog/nexo-5-3-29-runtime-hygiene-and-fail-closed-startup/</loc>
+    <lastmod>2026-04-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.95</priority>
   </url>
   <url>
     <loc>https://nexo-brain.com/blog/nexo-5-3-24-model-defaults-and-headless-safe-update/</loc>

--- a/src/auto_update.py
+++ b/src/auto_update.py
@@ -18,6 +18,7 @@ import time
 from pathlib import Path
 
 from runtime_home import export_resolved_nexo_home, managed_nexo_home
+from tree_hygiene import is_duplicate_artifact_name
 
 NEXO_HOME = export_resolved_nexo_home()
 DATA_DIR = NEXO_HOME / "data"
@@ -61,6 +62,20 @@ CRITICAL_BACKUP_TABLES = ("learnings", "session_diary", "guard_checks", "protoco
 def _log(msg: str):
     """Log to stderr with prefix."""
     print(f"[NEXO auto-update] {msg}", file=sys.stderr)
+
+
+def _runtime_copy_ignore(*extra_patterns: str):
+    base_ignore = shutil.ignore_patterns("__pycache__", "*.pyc", "*.pyo", "*.db", *extra_patterns)
+
+    def _ignore(dir_name: str, names: list[str]) -> set[str]:
+        ignored = set(base_ignore(dir_name, names))
+        ignored.update(
+            name for name in names
+            if is_duplicate_artifact_name(Path(dir_name) / name)
+        )
+        return ignored
+
+    return _ignore
 
 
 def _critical_table_count(db_path: Path, table: str) -> int | None:
@@ -470,7 +485,7 @@ def _refresh_installed_manifest():
         if src_crons.exists():
             dst_crons.mkdir(parents=True, exist_ok=True)
             for f in src_crons.iterdir():
-                if f.is_file():
+                if f.is_file() and not is_duplicate_artifact_name(f):
                     shutil.copy2(str(f), str(dst_crons / f.name))
             _log("Refreshed installed crons manifest")
     except Exception as e:
@@ -746,7 +761,7 @@ def _sync_hooks():
     hooks_dest.mkdir(parents=True, exist_ok=True)
     synced = 0
     for f in hooks_src.iterdir():
-        if f.is_file() and f.suffix == ".sh":
+        if f.is_file() and f.suffix == ".sh" and not is_duplicate_artifact_name(f):
             dest = hooks_dest / f.name
             shutil.copy2(str(f), str(dest))
             os.chmod(str(dest), 0o755)
@@ -1441,7 +1456,7 @@ def _auto_update_check_locked() -> dict:
             import shutil
             scripts_dest.mkdir(parents=True, exist_ok=True)
             for f in scripts_src.iterdir():
-                if f.name.startswith('.') or f.name == '__pycache__':
+                if f.name.startswith('.') or f.name == '__pycache__' or is_duplicate_artifact_name(f):
                     continue
                 dest = scripts_dest / f.name
                 if f.is_file() and not dest.exists():
@@ -1475,12 +1490,12 @@ def _auto_update_check_locked() -> dict:
         if doctor_src.is_dir():
             import shutil
             if not doctor_dest.is_dir():
-                shutil.copytree(str(doctor_src), str(doctor_dest), ignore=shutil.ignore_patterns("__pycache__", "*.pyc"))
+                shutil.copytree(str(doctor_src), str(doctor_dest), ignore=_runtime_copy_ignore())
                 _log("Backfilled doctor package")
             else:
                 # Update existing files
                 for root, dirs, files in os.walk(str(doctor_src)):
-                    dirs[:] = [d for d in dirs if d != "__pycache__"]
+                    dirs[:] = [d for d in dirs if d != "__pycache__" and not is_duplicate_artifact_name(Path(root) / d)]
                     rel = os.path.relpath(root, str(doctor_src))
                     dest_dir = doctor_dest / rel
                     dest_dir.mkdir(parents=True, exist_ok=True)
@@ -1488,6 +1503,8 @@ def _auto_update_check_locked() -> dict:
                         if f.endswith(".pyc"):
                             continue
                         src_f = Path(root) / f
+                        if is_duplicate_artifact_name(src_f):
+                            continue
                         dst_f = dest_dir / f
                         if not dst_f.exists() or src_f.stat().st_mtime > dst_f.stat().st_mtime:
                             shutil.copy2(str(src_f), str(dst_f))
@@ -1501,11 +1518,11 @@ def _auto_update_check_locked() -> dict:
         if skills_src.is_dir():
             import shutil
             if not skills_dest.is_dir():
-                shutil.copytree(str(skills_src), str(skills_dest), ignore=shutil.ignore_patterns("__pycache__", "*.pyc"))
+                shutil.copytree(str(skills_src), str(skills_dest), ignore=_runtime_copy_ignore())
                 _log("Backfilled skills-core")
             else:
                 for root, dirs, files in os.walk(str(skills_src)):
-                    dirs[:] = [d for d in dirs if d != "__pycache__"]
+                    dirs[:] = [d for d in dirs if d != "__pycache__" and not is_duplicate_artifact_name(Path(root) / d)]
                     rel = os.path.relpath(root, str(skills_src))
                     dest_dir = skills_dest / rel
                     dest_dir.mkdir(parents=True, exist_ok=True)
@@ -1513,6 +1530,8 @@ def _auto_update_check_locked() -> dict:
                         if f.endswith(".pyc"):
                             continue
                         src_f = Path(root) / f
+                        if is_duplicate_artifact_name(src_f):
+                            continue
                         dst_f = dest_dir / f
                         if not dst_f.exists() or src_f.stat().st_mtime > dst_f.stat().st_mtime:
                             shutil.copy2(str(src_f), str(dst_f))
@@ -1539,7 +1558,7 @@ def _auto_update_check_locked() -> dict:
         import shutil
         if templates_src.is_dir():
             for item in templates_src.iterdir():
-                if item.name == "__pycache__":
+                if item.name == "__pycache__" or is_duplicate_artifact_name(item):
                     continue
                 dest_item = templates_dest / item.name
                 if item.is_file():
@@ -1548,7 +1567,7 @@ def _auto_update_check_locked() -> dict:
                 elif item.is_dir():
                     dest_item.mkdir(parents=True, exist_ok=True)
                     for sub in item.iterdir():
-                        if sub.is_file():
+                        if sub.is_file() and not is_duplicate_artifact_name(sub):
                             dest_sub = dest_item / sub.name
                             if not dest_sub.exists() or sub.stat().st_mtime > dest_sub.stat().st_mtime:
                                 shutil.copy2(str(sub), str(dest_sub))
@@ -1735,6 +1754,8 @@ def _discover_runtime_root_python_modules(base_dir: Path) -> list[str]:
             continue
         if item.name.startswith(".") or item.name == "__init__.py":
             continue
+        if is_duplicate_artifact_name(item):
+            continue
         modules.append(item.name)
     return modules
 
@@ -1857,7 +1878,7 @@ def _copy_runtime_from_source(src_dir: Path, repo_dir: Path, dest: Path = NEXO_H
             shutil.copytree(
                 str(pkg_src),
                 str(pkg_dest),
-                ignore=shutil.ignore_patterns("__pycache__", "*.pyc", "*.pyo", "*.db"),
+                ignore=_runtime_copy_ignore(),
             )
             copied_packages += 1
 
@@ -1874,7 +1895,7 @@ def _copy_runtime_from_source(src_dir: Path, repo_dir: Path, dest: Path = NEXO_H
     if plugins_src.is_dir():
         plugins_dest.mkdir(parents=True, exist_ok=True)
         for item in plugins_src.iterdir():
-            if item.is_file() and item.suffix == ".py":
+            if item.is_file() and item.suffix == ".py" and not is_duplicate_artifact_name(item):
                 shutil.copy2(str(item), str(plugins_dest / item.name))
 
     _emit_progress(progress_fn, "Copying scripts...")
@@ -1883,13 +1904,13 @@ def _copy_runtime_from_source(src_dir: Path, repo_dir: Path, dest: Path = NEXO_H
     if scripts_src.is_dir():
         scripts_dest.mkdir(parents=True, exist_ok=True)
         for item in scripts_src.iterdir():
-            if item.name == "__pycache__" or item.name.startswith("."):
+            if item.name == "__pycache__" or item.name.startswith(".") or is_duplicate_artifact_name(item):
                 continue
             dst = scripts_dest / item.name
             if item.is_dir():
                 if dst.exists():
                     shutil.rmtree(str(dst), ignore_errors=True)
-                shutil.copytree(str(item), str(dst), ignore=shutil.ignore_patterns("__pycache__", "*.pyc"))
+                shutil.copytree(str(item), str(dst), ignore=_runtime_copy_ignore())
             elif item.is_file():
                 existing_class = installed_script_classes.get(item.name, "")
                 if dst.exists() and existing_class in {"personal", "non-script"}:
@@ -1919,7 +1940,7 @@ def _copy_runtime_from_source(src_dir: Path, repo_dir: Path, dest: Path = NEXO_H
     if templates_src.is_dir():
         templates_dest.mkdir(parents=True, exist_ok=True)
         for item in templates_src.iterdir():
-            if item.name == "__pycache__":
+            if item.name == "__pycache__" or is_duplicate_artifact_name(item):
                 continue
             if item.is_file():
                 shutil.copy2(str(item), str(templates_dest / item.name))
@@ -1927,7 +1948,7 @@ def _copy_runtime_from_source(src_dir: Path, repo_dir: Path, dest: Path = NEXO_H
                 sub_dest = templates_dest / item.name
                 sub_dest.mkdir(parents=True, exist_ok=True)
                 for sub in item.iterdir():
-                    if sub.is_file():
+                    if sub.is_file() and not is_duplicate_artifact_name(sub):
                         shutil.copy2(str(sub), str(sub_dest / sub.name))
 
     package_json = repo_dir / "package.json"
@@ -1948,7 +1969,7 @@ def _copy_runtime_from_source(src_dir: Path, repo_dir: Path, dest: Path = NEXO_H
     if skills_src.is_dir():
         if skills_dest.exists():
             shutil.rmtree(str(skills_dest), ignore_errors=True)
-        shutil.copytree(str(skills_src), str(skills_dest), ignore=shutil.ignore_patterns("__pycache__", "*.pyc"))
+        shutil.copytree(str(skills_src), str(skills_dest), ignore=_runtime_copy_ignore())
 
     bin_dir = dest / "bin"
     bin_dir.mkdir(parents=True, exist_ok=True)

--- a/src/plugin_loader.py
+++ b/src/plugin_loader.py
@@ -10,6 +10,7 @@ import time
 
 from db import get_db
 from fastmcp.tools import Tool
+from tree_hygiene import is_duplicate_artifact_name
 
 SERVER_DIR = os.path.dirname(os.path.abspath(__file__))
 PLUGINS_DIR = os.path.join(SERVER_DIR, "plugins")
@@ -47,12 +48,16 @@ def load_all_plugins(mcp) -> int:
     if os.path.isdir(PLUGINS_DIR):
         for f in sorted(os.listdir(PLUGINS_DIR)):
             if f.endswith(".py") and f != "__init__.py":
+                if is_duplicate_artifact_name(os.path.join(PLUGINS_DIR, f)):
+                    continue
                 plugin_map[f] = (PLUGINS_DIR, "repo")
 
     # 2. Personal plugins (override if same filename)
     if os.path.isdir(PERSONAL_PLUGINS_DIR):
         for f in sorted(os.listdir(PERSONAL_PLUGINS_DIR)):
             if f.endswith(".py") and f != "__init__.py":
+                if is_duplicate_artifact_name(os.path.join(PERSONAL_PLUGINS_DIR, f)):
+                    continue
                 source = "personal (override)" if f in plugin_map else "personal"
                 plugin_map[f] = (PERSONAL_PLUGINS_DIR, source)
 

--- a/src/plugins/update.py
+++ b/src/plugins/update.py
@@ -10,6 +10,7 @@ import time
 from pathlib import Path
 
 from runtime_home import export_resolved_nexo_home
+from tree_hygiene import is_duplicate_artifact_name
 
 # Code root is the parent of plugins/:
 # - source checkout: <repo>/src
@@ -100,7 +101,7 @@ def _refresh_installed_manifest():
         if src_crons.exists():
             dst_crons.mkdir(parents=True, exist_ok=True)
             for f in src_crons.iterdir():
-                if f.is_file():
+                if f.is_file() and not is_duplicate_artifact_name(f):
                     dest = dst_crons / f.name
                     if _paths_match(f, dest):
                         continue
@@ -111,11 +112,11 @@ def _refresh_installed_manifest():
             "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
             "script_names": sorted(
                 f.name for f in (artifact_src / "scripts").iterdir()
-                if f.is_file()
+                if f.is_file() and not is_duplicate_artifact_name(f)
             ) if (artifact_src / "scripts").is_dir() else [],
             "hook_names": sorted(
                 f.name for f in (artifact_src / "hooks").iterdir()
-                if f.is_file()
+                if f.is_file() and not is_duplicate_artifact_name(f)
             ) if (artifact_src / "hooks").is_dir() else [],
         }
         (config_dir / "runtime-core-artifacts.json").write_text(
@@ -368,7 +369,7 @@ def _sync_hooks_to_home():
     hooks_dest.mkdir(parents=True, exist_ok=True)
     synced = 0
     for f in hooks_src.iterdir():
-        if f.is_file() and f.suffix == ".sh":
+        if f.is_file() and f.suffix == ".sh" and not is_duplicate_artifact_name(f):
             dest = hooks_dest / f.name
             if not _paths_match(f, dest):
                 shutil.copy2(str(f), str(dest))

--- a/src/scripts/nexo-cron-wrapper.sh
+++ b/src/scripts/nexo-cron-wrapper.sh
@@ -13,6 +13,7 @@ shift
 
 NEXO_HOME="${NEXO_HOME:-$HOME/.nexo}"
 DB="$NEXO_HOME/data/nexo.db"
+SPOOL_DIR="$NEXO_HOME/operations/cron-spool"
 
 # Unlock macOS Keychain so headless Claude Code can read auth tokens.
 # Claude Code stores its API key in the login keychain which auto-locks.
@@ -21,40 +22,95 @@ if [ -f "$KEYCHAIN_PASS_FILE" ] && [ "$(uname)" = "Darwin" ]; then
     security unlock-keychain -p "$(cat "$KEYCHAIN_PASS_FILE")" ~/Library/Keychains/login.keychain-db 2>/dev/null || true
 fi
 
-# Record start
-RUN_ID=$(sqlite3 "$DB" "INSERT INTO cron_runs (cron_id) VALUES ('$CRON_ID'); SELECT last_insert_rowid();" 2>/dev/null)
-
-if [ -z "$RUN_ID" ]; then
-    # DB not ready — run without tracking
-    exec "$@"
-fi
+START_EPOCH=$(python3 - <<'PY'
+import time
+print(f"{time.time():.6f}")
+PY
+)
+STARTED_AT=$(python3 - <<'PY'
+from datetime import datetime, timezone
+print(datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S"))
+PY
+)
 
 # Run the actual command, capture output
 OUTPUT_FILE=$(mktemp)
+trap 'rm -f "$OUTPUT_FILE"' EXIT
 "$@" > "$OUTPUT_FILE" 2>&1
 EXIT_CODE=$?
+ENDED_AT=$(python3 - <<'PY'
+from datetime import datetime, timezone
+print(datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S"))
+PY
+)
+DURATION_SECS=$(python3 - <<PY
+start = float("$START_EPOCH")
+import time
+print(round(time.time() - start, 1))
+PY
+)
 
 # Extract summary (last meaningful line, max 500 chars)
-SUMMARY=$(tail -5 "$OUTPUT_FILE" | grep -v "^$" | tail -1 | head -c 500 | sed "s/'/''/g")
+SUMMARY=$(tail -5 "$OUTPUT_FILE" | grep -v "^$" | tail -1 | head -c 500)
 
 # Extract error if failed
 ERROR=""
 if [ $EXIT_CODE -ne 0 ]; then
-    ERROR=$(grep -i "error\|exception\|fail\|traceback" "$OUTPUT_FILE" | tail -1 | head -c 500 | sed "s/'/''/g")
+    ERROR=$(grep -i "error\|exception\|fail\|traceback" "$OUTPUT_FILE" | tail -1 | head -c 500)
 fi
 
-# Record end
-sqlite3 "$DB" "
-    UPDATE cron_runs SET
-        ended_at = datetime('now'),
-        exit_code = $EXIT_CODE,
-        summary = '$SUMMARY',
-        error = '$ERROR',
-        duration_secs = ROUND((julianday(datetime('now')) - julianday(started_at)) * 86400, 1)
-    WHERE id = $RUN_ID;
-" 2>/dev/null
+if ! python3 - "$DB" "$CRON_ID" "$STARTED_AT" "$ENDED_AT" "$EXIT_CODE" "$SUMMARY" "$ERROR" "$DURATION_SECS" <<'PY'
+from __future__ import annotations
 
-# Clean output
-rm -f "$OUTPUT_FILE"
+import sqlite3
+import sys
+
+db_path, cron_id, started_at, ended_at, exit_code, summary, error, duration_secs = sys.argv[1:]
+conn = sqlite3.connect(db_path)
+try:
+    conn.execute(
+        """
+        INSERT INTO cron_runs (
+            cron_id, started_at, ended_at, exit_code, summary, error, duration_secs
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            cron_id,
+            started_at,
+            ended_at,
+            int(exit_code),
+            summary,
+            error,
+            float(duration_secs),
+        ),
+    )
+    conn.commit()
+finally:
+    conn.close()
+PY
+then
+    mkdir -p "$SPOOL_DIR"
+    SPOOL_FILE="$SPOOL_DIR/${CRON_ID}-$(date +%Y%m%d-%H%M%S)-$$.json"
+    python3 - "$SPOOL_FILE" "$CRON_ID" "$STARTED_AT" "$ENDED_AT" "$EXIT_CODE" "$SUMMARY" "$ERROR" "$DURATION_SECS" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+spool_file, cron_id, started_at, ended_at, exit_code, summary, error, duration_secs = sys.argv[1:]
+payload = {
+    "cron_id": cron_id,
+    "started_at": started_at,
+    "ended_at": ended_at,
+    "exit_code": int(exit_code),
+    "summary": summary,
+    "error": error,
+    "duration_secs": float(duration_secs),
+}
+Path(spool_file).write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+PY
+    echo "[nexo-cron-wrapper] DB write failed; spooled run to $SPOOL_FILE" >&2
+fi
 
 exit $EXIT_CODE

--- a/src/scripts/nexo-update.sh
+++ b/src/scripts/nexo-update.sh
@@ -1,306 +1,32 @@
 #!/usr/bin/env bash
-# nexo-update.sh — Standalone NEXO update script
-# Same logic as the MCP tool but usable when the server itself needs updating.
-#
+# nexo-update.sh — Thin wrapper around the canonical Python update core.
 # Usage:
 #   nexo-update.sh                    # pull from origin main
 #   nexo-update.sh origin beta        # pull from origin beta
-#   NEXO_HOME=/path nexo-update.sh    # custom NEXO_HOME
 
 set -euo pipefail
 
-# --- Configuration ---
 REMOTE="${1:-origin}"
 BRANCH="${2:-main}"
-NEXO_HOME="${NEXO_HOME:-$HOME/.nexo}"
-
-# Determine repo directory: script is at src/scripts/, repo root is ../../
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
-SRC_DIR="$REPO_DIR/src"
-PACKAGE_JSON="$REPO_DIR/package.json"
+SRC_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+RUNTIME_PYTHON="${NEXO_RUNTIME_PYTHON:-python3}"
 
-# --- Helpers ---
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m'
+export NEXO_CODE="${NEXO_CODE:-$SRC_DIR}"
+export PYTHONPATH="$SRC_DIR${PYTHONPATH:+:$PYTHONPATH}"
 
-log()  { echo -e "${GREEN}[nexo-update]${NC} $*"; }
-warn() { echo -e "${YELLOW}[nexo-update]${NC} $*"; }
-err()  { echo -e "${RED}[nexo-update]${NC} $*" >&2; }
+"$RUNTIME_PYTHON" - "$REMOTE" "$BRANCH" <<'PY'
+from __future__ import annotations
 
-read_version() {
-    python3 -c "import json; print(json.load(open('$PACKAGE_JSON')).get('version','unknown'))" 2>/dev/null || echo "unknown"
-}
-
-# --- Check if this is a git repo ---
-if [ ! -d "$REPO_DIR/.git" ] && [ ! -f "$REPO_DIR/.git" ]; then
-    err "ABORTED: Not a git repository at $REPO_DIR"
-    err "For packaged installs, use: npm update -g nexo-brain"
-    exit 1
-fi
-
-# --- Step 1: Check for uncommitted changes in entire worktree ---
-log "Checking for uncommitted changes..."
-cd "$REPO_DIR"
-
-if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
-    err "ABORTED: Uncommitted changes in worktree"
-    git status --short
-    exit 1
-fi
-log "Working tree clean."
-
-# Record current state
-OLD_VERSION="$(read_version)"
-OLD_COMMIT="$(git rev-parse HEAD)"
-REQ_FILE="$SRC_DIR/requirements.txt"
-OLD_REQ_HASH=""
-if [ -f "$REQ_FILE" ]; then
-    OLD_REQ_HASH="$(shasum -a 256 "$REQ_FILE" | cut -d' ' -f1)"
-fi
-log "Current: v${OLD_VERSION} (${OLD_COMMIT:0:8})"
-
-# --- Step 2: Backup databases ---
-TIMESTAMP="$(date +%Y-%m-%d-%H%M)"
-BACKUP_DIR="$NEXO_HOME/backups/pre-update-$TIMESTAMP"
-
-backup_dbs() {
-    local found=0
-    # Check data/, NEXO_HOME root, and src/ for .db files
-    for dir in "$NEXO_HOME/data" "$NEXO_HOME" "$SRC_DIR"; do
-        if [ -d "$dir" ]; then
-            for db in "$dir"/*.db; do
-                [ -f "$db" ] || continue
-                found=1
-                mkdir -p "$BACKUP_DIR"
-                cp "$db" "$BACKUP_DIR/$(basename "$db")"
-                log "  Backed up: $(basename "$db")"
-            done
-        fi
-    done
-    if [ "$found" -eq 0 ]; then
-        log "  No databases found to backup."
-    fi
-}
-
-log "Backing up databases..."
-backup_dbs
-
-# --- Step 3: git pull ---
-log "Pulling from ${REMOTE}/${BRANCH}..."
-PULL_OUTPUT="$(git pull "$REMOTE" "$BRANCH" 2>&1)" || {
-    err "git pull failed:"
-    err "$PULL_OUTPUT"
-    exit 1
-}
-log "$PULL_OUTPUT"
-
-if echo "$PULL_OUTPUT" | grep -q "Already up to date"; then
-    log "Already up to date (v${OLD_VERSION}). Done."
-    exit 0
-fi
-
-# --- Step 4: Check version ---
-NEW_VERSION="$(read_version)"
-log "New version: v${NEW_VERSION}"
-
-# --- Step 4b: Reinstall Python dependencies if requirements.txt changed ---
-NEW_REQ_HASH=""
-if [ -f "$REQ_FILE" ]; then
-    NEW_REQ_HASH="$(shasum -a 256 "$REQ_FILE" | cut -d' ' -f1)"
-fi
-
-DEPS_CHANGED=false
-if [ "$OLD_REQ_HASH" != "$NEW_REQ_HASH" ]; then
-    DEPS_CHANGED=true
-fi
-
-reinstall_pip_deps() {
-    local VENV_PIP="$NEXO_HOME/.venv/bin/pip"
-    if [ -f "$REQ_FILE" ]; then
-        if [ -x "$VENV_PIP" ]; then
-            "$VENV_PIP" install --quiet -r "$REQ_FILE" || return 1
-        else
-            python3 -m pip install --quiet -r "$REQ_FILE" --break-system-packages 2>/dev/null || return 1
-        fi
-    fi
-    return 0
-}
-
-if [ "$DEPS_CHANGED" = true ] || [ "$OLD_VERSION" != "$NEW_VERSION" ]; then
-    log "Reinstalling Python dependencies..."
-    if ! reinstall_pip_deps; then
-        err "pip install failed! Rolling back..."
-        git reset --hard "$OLD_COMMIT"
-        reinstall_pip_deps || warn "pip rollback also had issues"
-        if [ -d "$BACKUP_DIR" ]; then
-            for db in "$BACKUP_DIR"/*.db; do
-                [ -f "$db" ] || continue
-                BASENAME="$(basename "$db")"
-                for candidate in "$NEXO_HOME/data/$BASENAME" "$NEXO_HOME/$BASENAME" "$SRC_DIR/$BASENAME"; do
-                    if [ -f "$candidate" ]; then
-                        cp "$db" "$candidate"
-                        warn "  Restored: $BASENAME"
-                        break
-                    fi
-                done
-            done
-        fi
-        err "Rolled back to ${OLD_COMMIT:0:8}. Databases restored."
-        exit 1
-    fi
-    log "Python dependencies updated."
-fi
-
-# --- Step 5: Run migrations if version changed ---
-if [ "$OLD_VERSION" != "$NEW_VERSION" ]; then
-    log "Version changed: ${OLD_VERSION} -> ${NEW_VERSION}"
-    log "Running migrations..."
-    if ! (cd "$SRC_DIR" && python3 -c "import db; db.init_db()" 2>&1); then
-        err "Migration failed! Rolling back..."
-        git reset --hard "$OLD_COMMIT"
-        # Reinstall pip deps from restored old requirements.txt
-        reinstall_pip_deps || warn "pip rollback also had issues"
-        # Restore DB backups
-        if [ -d "$BACKUP_DIR" ]; then
-            for db in "$BACKUP_DIR"/*.db; do
-                [ -f "$db" ] || continue
-                BASENAME="$(basename "$db")"
-                for candidate in "$NEXO_HOME/data/$BASENAME" "$NEXO_HOME/$BASENAME" "$SRC_DIR/$BASENAME"; do
-                    if [ -f "$candidate" ]; then
-                        cp "$db" "$candidate"
-                        warn "  Restored: $BASENAME"
-                        break
-                    fi
-                done
-            done
-        fi
-        err "Rolled back to ${OLD_COMMIT:0:8}. Databases and deps restored."
-        exit 1
-    fi
-    log "Migrations applied."
-else
-    log "Version unchanged (${OLD_VERSION}), skipping migrations."
-fi
-
-# --- Step 6: Verify import ---
-log "Verifying server.py import..."
-if ! (cd "$SRC_DIR" && python3 -c "import server" 2>&1); then
-    err "Import verification failed! Rolling back..."
-    git reset --hard "$OLD_COMMIT"
-    # Reinstall pip deps from restored old requirements.txt
-    reinstall_pip_deps || warn "pip rollback also had issues"
-    if [ -d "$BACKUP_DIR" ]; then
-        for db in "$BACKUP_DIR"/*.db; do
-            [ -f "$db" ] || continue
-            BASENAME="$(basename "$db")"
-            for candidate in "$NEXO_HOME/data/$BASENAME" "$NEXO_HOME/$BASENAME" "$SRC_DIR/$BASENAME"; do
-                if [ -f "$candidate" ]; then
-                    cp "$db" "$candidate"
-                    warn "  Restored: $BASENAME"
-                    break
-                fi
-            done
-        done
-    fi
-    err "Rolled back to ${OLD_COMMIT:0:8}. Databases and deps restored."
-    exit 1
-fi
-
-# --- Step 7: Sync hooks to NEXO_HOME ---
-HOOKS_SRC="$SRC_DIR/hooks"
-HOOKS_DEST="$NEXO_HOME/hooks"
-if [ -d "$HOOKS_SRC" ]; then
-    mkdir -p "$HOOKS_DEST"
-    SYNCED=0
-    for hook in "$HOOKS_SRC"/*.sh; do
-        [ -f "$hook" ] || continue
-        cp "$hook" "$HOOKS_DEST/$(basename "$hook")"
-        chmod 755 "$HOOKS_DEST/$(basename "$hook")"
-        SYNCED=$((SYNCED + 1))
-    done
-    if [ "$SYNCED" -gt 0 ]; then
-        log "Synced $SYNCED hook(s) to $HOOKS_DEST"
-    fi
-fi
-
-# --- Step 8: Sync cron definitions with manifest ---
-CRON_SYNC="$SRC_DIR/crons/sync.py"
-CRON_SYNC_OK=false
-if [ -f "$CRON_SYNC" ]; then
-    log "Syncing cron definitions..."
-    if NEXO_HOME="$NEXO_HOME" NEXO_CODE="$SRC_DIR" python3 "$CRON_SYNC" 2>&1; then
-        log "Cron definitions synced."
-        CRON_SYNC_OK=true
-    else
-        warn "Cron sync failed (non-fatal). Installed manifest NOT refreshed to avoid divergence."
-    fi
-fi
-
-# --- Step 8b: Refresh installed manifest for catchup/watchdog (only if sync succeeded) ---
-if $CRON_SYNC_OK && [ -d "$SRC_DIR/crons" ]; then
-    mkdir -p "$NEXO_HOME/crons"
-    cp -f "$SRC_DIR/crons/"*.json "$NEXO_HOME/crons/" 2>/dev/null
-    cp -f "$SRC_DIR/crons/"*.py "$NEXO_HOME/crons/" 2>/dev/null
-    log "Refreshed installed crons manifest."
-fi
-
-# --- Step 9: Sync shared client configs ---
-CLIENT_SYNC="$SRC_DIR/scripts/nexo-sync-clients.py"
-if [ -f "$CLIENT_SYNC" ]; then
-    log "Syncing shared client configs..."
-    CLIENT_SYNC_ARGS=()
-    if [ -f "$NEXO_HOME/config/schedule.json" ]; then
-        while IFS= read -r line; do
-            [ -n "$line" ] && CLIENT_SYNC_ARGS+=("--enabled-client" "$line")
-        done < <(
-            NEXO_HOME="$NEXO_HOME" NEXO_CODE="$SRC_DIR" python3 - <<'PY'
-import json
-import os
 import sys
-from pathlib import Path
 
-sys.path.insert(0, os.environ["NEXO_CODE"])
-from client_preferences import normalize_client_preferences
+from plugins.update import handle_update
 
-schedule_file = Path(os.environ["NEXO_HOME"]) / "config" / "schedule.json"
-schedule_payload = json.loads(schedule_file.read_text()) if schedule_file.exists() else {}
-prefs = normalize_client_preferences(schedule_payload)
-if prefs != {key: schedule_payload.get(key) for key in prefs}:
-    merged = dict(schedule_payload)
-    merged.update(prefs)
-    schedule_file.parent.mkdir(parents=True, exist_ok=True)
-    schedule_file.write_text(json.dumps(merged, indent=2, ensure_ascii=False) + "\n")
-enabled = [key for key, value in prefs.get("interactive_clients", {}).items() if value]
-if prefs.get("automation_enabled", True):
-    backend = prefs.get("automation_backend")
-    if backend and backend != "none" and backend not in enabled:
-        enabled.append(backend)
-for item in enabled:
-    print(item)
+
+remote = sys.argv[1]
+branch = sys.argv[2]
+result = handle_update(remote=remote, branch=branch)
+print(result)
+
+raise SystemExit(1 if result.startswith(("ABORTED", "UPDATE FAILED")) else 0)
 PY
-        )
-    fi
-    if NEXO_HOME="$NEXO_HOME" NEXO_CODE="$SRC_DIR" python3 "$CLIENT_SYNC" --nexo-home "$NEXO_HOME" --runtime-root "$SRC_DIR" "${CLIENT_SYNC_ARGS[@]}" --json >/dev/null 2>&1; then
-        log "Shared client configs synced."
-    else
-        warn "Client config sync failed (non-fatal). Run 'nexo clients sync' later."
-    fi
-fi
-
-# --- Done ---
-echo ""
-log "========================================="
-log " UPDATE SUCCESSFUL"
-if [ "$OLD_VERSION" != "$NEW_VERSION" ]; then
-    log " Version: ${OLD_VERSION} -> ${NEW_VERSION}"
-else
-    log " Version: ${OLD_VERSION} (unchanged)"
-fi
-log " Branch: ${REMOTE}/${BRANCH}"
-log " Backup: ${BACKUP_DIR}"
-log "========================================="
-echo ""
-warn "MCP server restart needed to load new code."

--- a/src/server.py
+++ b/src/server.py
@@ -72,6 +72,140 @@ def _shutdown_handler(signum, frame):
     sys.exit(0)
 
 
+def _resolved_nexo_home() -> str:
+    return os.environ.get("NEXO_HOME", os.path.join(os.path.expanduser("~"), ".nexo"))
+
+
+def _data_dir() -> str:
+    return os.path.join(_resolved_nexo_home(), "data")
+
+
+def _backup_dir() -> str:
+    return os.path.join(_resolved_nexo_home(), "backups")
+
+
+def _allow_fresh_db_on_corruption() -> bool:
+    value = str(os.environ.get("NEXO_ALLOW_FRESH_DB_ON_CORRUPTION", "") or "").strip().lower()
+    return value in {"1", "true", "yes", "on"}
+
+
+def _quarantine_corrupt_db_file(db_path: str) -> None:
+    if os.path.exists(db_path):
+        corrupt_path = db_path + ".corrupt"
+        os.rename(db_path, corrupt_path)
+        print(f"[NEXO] Corrupt DB moved to {os.path.basename(corrupt_path)}", file=sys.stderr)
+    for ext in (".db-wal", ".db-shm"):
+        wal_path = db_path.replace(".db", ext)
+        if os.path.exists(wal_path):
+            os.remove(wal_path)
+
+
+def _restore_valid_db_backup() -> bool:
+    import glob
+    import shutil
+    import sqlite3
+
+    from db._core import DB_PATH as db_path
+
+    backups = sorted(glob.glob(os.path.join(_backup_dir(), "nexo-*.db")), reverse=True)
+    for backup_path in backups:
+        try:
+            test_conn = sqlite3.connect(backup_path)
+            integrity = test_conn.execute("PRAGMA integrity_check").fetchone()
+            test_conn.close()
+            if not integrity or integrity[0] != "ok":
+                continue
+            try:
+                close_db()
+            except Exception:
+                pass
+            shutil.copy2(backup_path, db_path)
+            print(f"[NEXO] Restored DB from backup: {os.path.basename(backup_path)}", file=sys.stderr)
+            init_db()
+            return True
+        except Exception:
+            continue
+    return False
+
+
+def _init_db_or_exit() -> None:
+    import sqlite3
+
+    try:
+        init_db()
+        return
+    except sqlite3.DatabaseError as exc:
+        print(f"[NEXO] DB init failed: {exc}", file=sys.stderr)
+
+    restored = False
+    try:
+        restored = _restore_valid_db_backup()
+    except Exception as restore_exc:
+        print(f"[NEXO] Backup restore failed: {restore_exc}", file=sys.stderr)
+
+    if restored:
+        return
+
+    try:
+        close_db()
+    except Exception:
+        pass
+
+    try:
+        from db._core import DB_PATH as db_path
+        _quarantine_corrupt_db_file(db_path)
+    except Exception:
+        pass
+
+    if not _allow_fresh_db_on_corruption():
+        print(
+            "[NEXO] Refusing to create a fresh empty database automatically. "
+            "Restore a valid backup or set NEXO_ALLOW_FRESH_DB_ON_CORRUPTION=1 to override.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    try:
+        init_db()
+        print("[NEXO] Fresh database created because override is enabled.", file=sys.stderr)
+    except Exception as fresh_exc:
+        print(f"[NEXO] FATAL: Cannot initialize database: {fresh_exc}", file=sys.stderr)
+        print("[NEXO] Check permissions on NEXO_HOME/data/ and disk space.", file=sys.stderr)
+        sys.exit(1)
+
+
+def _emit_startup_preflight_messages(result: dict) -> None:
+    if result.get("updated"):
+        print("[NEXO] Startup update applied.", file=sys.stderr)
+    if result.get("deferred_reason"):
+        print(f"[NEXO] Startup update deferred: {result['deferred_reason']}", file=sys.stderr)
+    if result.get("git_update"):
+        print(f"[NEXO] {result['git_update']}", file=sys.stderr)
+    if result.get("npm_notice"):
+        print(f"[NEXO] {result['npm_notice']}", file=sys.stderr)
+    if result.get("claude_md_update"):
+        print(f"[NEXO] {result['claude_md_update']}", file=sys.stderr)
+    for message in result.get("client_bootstrap_updates", []):
+        if message != result.get("claude_md_update"):
+            print(f"[NEXO] {message}", file=sys.stderr)
+    for migration in result.get("migrations", []):
+        if migration.get("status") == "failed":
+            print(
+                f"[NEXO] Migration {migration.get('file', '?')} FAILED: {migration.get('message', '')}",
+                file=sys.stderr,
+            )
+
+
+def _run_startup_preflight_sync() -> None:
+    try:
+        from auto_update import startup_preflight
+
+        result = startup_preflight(entrypoint="server", interactive=False)
+        _emit_startup_preflight_messages(result)
+    except Exception as e:
+        print(f"[NEXO auto-update] error: {e}", file=sys.stderr)
+
+
 def _server_init():
     """Run all side effects: signals, PID, DB, auto-update, plugins.
 
@@ -81,110 +215,17 @@ def _server_init():
     signal.signal(signal.SIGINT, _shutdown_handler)
 
     # ── Write PID file for stale process detection ─────────────────
-    _data_dir = os.path.join(os.environ.get("NEXO_HOME", os.path.join(os.path.expanduser("~"), ".nexo")), "data")
-    os.makedirs(_data_dir, exist_ok=True)
-    _pid_file = os.path.join(_data_dir, "nexo.pid")
+    data_dir = _data_dir()
+    os.makedirs(data_dir, exist_ok=True)
+    _pid_file = os.path.join(data_dir, "nexo.pid")
     with open(_pid_file, "w") as f:
         f.write(str(os.getpid()))
 
     # ── Database initialization with recovery ─────────────────────
-    import sqlite3
-    try:
-        init_db()
-    except sqlite3.DatabaseError as exc:
-        # Corruption or unreadable DB — attempt restore from backup
-        print(f"[NEXO] DB init failed: {exc}", file=sys.stderr)
-        _recovered = False
-        try:
-            from db._core import DB_PATH as _db_path
-            import glob as _glob
-            _backup_dir = os.path.join(
-                os.environ.get("NEXO_HOME", os.path.join(os.path.expanduser("~"), ".nexo")),
-                "backups",
-            )
-            _backups = sorted(_glob.glob(os.path.join(_backup_dir, "nexo-*.db")), reverse=True)
-            for _bk in _backups:
-                try:
-                    _test = sqlite3.connect(_bk)
-                    _result = _test.execute("PRAGMA integrity_check").fetchone()
-                    _test.close()
-                    if _result and _result[0] == "ok":
-                        # Valid backup found — replace corrupt DB
-                        import shutil
-                        # Close any open connection before replacing
-                        try:
-                            close_db()
-                        except Exception:
-                            pass
-                        shutil.copy2(_bk, _db_path)
-                        print(f"[NEXO] Restored DB from backup: {os.path.basename(_bk)}", file=sys.stderr)
-                        init_db()
-                        _recovered = True
-                        break
-                except Exception:
-                    continue
-        except Exception as restore_exc:
-            print(f"[NEXO] Backup restore failed: {restore_exc}", file=sys.stderr)
+    _init_db_or_exit()
 
-        if not _recovered:
-            # No valid backup — nuke corrupt file and start fresh
-            try:
-                close_db()
-            except Exception:
-                pass
-            try:
-                from db._core import DB_PATH as _db_path
-                if os.path.exists(_db_path):
-                    _corrupt_path = _db_path + ".corrupt"
-                    os.rename(_db_path, _corrupt_path)
-                    print(f"[NEXO] Corrupt DB moved to {os.path.basename(_corrupt_path)}", file=sys.stderr)
-                # Remove WAL/SHM files too
-                for _ext in (".db-wal", ".db-shm"):
-                    _wal = _db_path.replace(".db", _ext)
-                    if os.path.exists(_wal):
-                        os.remove(_wal)
-            except Exception:
-                pass
-            try:
-                init_db()
-                print("[NEXO] Fresh database created.", file=sys.stderr)
-            except Exception as fresh_exc:
-                print(f"[NEXO] FATAL: Cannot initialize database: {fresh_exc}", file=sys.stderr)
-                print("[NEXO] Check permissions on NEXO_HOME/data/ and disk space.", file=sys.stderr)
-                sys.exit(1)
-
-    # ── Auto-update check (non-blocking, max 5s) ──────────────────
-    try:
-        from auto_update import startup_preflight
-        import threading
-
-        def _bg_update():
-            try:
-                result = startup_preflight(entrypoint="server", interactive=False)
-                if result.get("updated"):
-                    print("[NEXO] Startup update applied.", file=sys.stderr)
-                if result.get("deferred_reason"):
-                    print(f"[NEXO] Startup update deferred: {result['deferred_reason']}", file=sys.stderr)
-                if result.get("git_update"):
-                    print(f"[NEXO] {result['git_update']}", file=sys.stderr)
-                if result.get("npm_notice"):
-                    print(f"[NEXO] {result['npm_notice']}", file=sys.stderr)
-                if result.get("claude_md_update"):
-                    print(f"[NEXO] {result['claude_md_update']}", file=sys.stderr)
-                for message in result.get("client_bootstrap_updates", []):
-                    if message != result.get("claude_md_update"):
-                        print(f"[NEXO] {message}", file=sys.stderr)
-                for m in result.get("migrations", []):
-                    if m["status"] == "failed":
-                        print(f"[NEXO] Migration {m['file']} FAILED: {m['message']}", file=sys.stderr)
-            except Exception as e:
-                print(f"[NEXO auto-update] error: {e}", file=sys.stderr)
-
-        _update_thread = threading.Thread(target=_bg_update, daemon=True)
-        _update_thread.start()
-        _update_thread.join(timeout=5)  # Wait at most 5 seconds
-    except Exception:
-        pass  # Never break startup
+    # ── Auto-update / startup preflight (synchronous) ─────────────
+    _run_startup_preflight_sync()
 
     # ── Load plugins ───────────────────────────────────────────────
     load_all_plugins(mcp)

--- a/src/tree_hygiene.py
+++ b/src/tree_hygiene.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+"""Shared tree hygiene helpers for runtime/install/release flows."""
+
+import re
+from pathlib import Path
+
+
+_DUPLICATE_COPY_RE = re.compile(r"^(?P<base>.+) (?P<copy>[2-9]\d*)$")
+_IGNORED_DIRS = {
+    ".git",
+    ".hg",
+    ".svn",
+    ".venv",
+    "__pycache__",
+    ".pytest_cache",
+    ".mypy_cache",
+    "node_modules",
+    "dist",
+    "build",
+}
+
+
+def canonical_artifact_name(name: str) -> str | None:
+    """Return the canonical sibling name for a macOS-style duplicate copy."""
+    path = Path(name)
+    match = _DUPLICATE_COPY_RE.match(path.stem)
+    if not match:
+        return None
+    return f"{match.group('base')}{path.suffix}"
+
+
+def is_duplicate_artifact_name(path_like: str | Path) -> bool:
+    """True when the path looks like a duplicate copy and its canonical sibling exists."""
+    path = Path(path_like)
+    canonical_name = canonical_artifact_name(path.name)
+    if canonical_name is None:
+        return False
+    parent = path.parent
+    if str(parent) in {"", "."} and not path.is_absolute():
+        return False
+    return path.with_name(canonical_name).exists()
+
+
+def find_duplicate_artifact_paths(root: str | Path) -> list[Path]:
+    """Find duplicate copy artifacts under a tree, skipping generated/vendor directories."""
+    root_path = Path(root).resolve()
+    duplicates: list[Path] = []
+    for path in sorted(root_path.rglob("*")):
+        if any(part in _IGNORED_DIRS for part in path.parts):
+            continue
+        if not path.is_file():
+            continue
+        if is_duplicate_artifact_name(path):
+            duplicates.append(path)
+    return duplicates

--- a/tests/test_cron_wrapper_contract.py
+++ b/tests/test_cron_wrapper_contract.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WRAPPER = REPO_ROOT / "src" / "scripts" / "nexo-cron-wrapper.sh"
+
+
+def _create_cron_runs_db(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE cron_runs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            cron_id TEXT NOT NULL,
+            started_at TEXT NOT NULL,
+            ended_at TEXT,
+            exit_code INTEGER,
+            summary TEXT,
+            error TEXT,
+            duration_secs REAL
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_cron_wrapper_writes_completed_row(tmp_path):
+    nexo_home = tmp_path / "nexo"
+    db_dir = nexo_home / "data"
+    db_dir.mkdir(parents=True)
+    db_path = db_dir / "nexo.db"
+    _create_cron_runs_db(db_path)
+
+    result = subprocess.run(
+        ["bash", str(WRAPPER), "impact-scorer", "bash", "-lc", "echo cron-ok"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        env={**os.environ, "NEXO_HOME": str(nexo_home)},
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    conn = sqlite3.connect(db_path)
+    row = conn.execute(
+        "SELECT cron_id, ended_at, exit_code, summary, error, duration_secs FROM cron_runs"
+    ).fetchone()
+    conn.close()
+
+    assert row is not None
+    assert row[0] == "impact-scorer"
+    assert row[1] is not None
+    assert row[2] == 0
+    assert row[3] == "cron-ok"
+    assert row[4] == ""
+    assert row[5] is not None
+
+
+def test_cron_wrapper_spools_when_db_write_fails(tmp_path):
+    nexo_home = tmp_path / "nexo"
+    (nexo_home / "data").mkdir(parents=True)
+
+    result = subprocess.run(
+        ["bash", str(WRAPPER), "impact-scorer", "bash", "-lc", "echo spool-ok"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        env={**os.environ, "NEXO_HOME": str(nexo_home)},
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    spool_dir = nexo_home / "operations" / "cron-spool"
+    spool_files = sorted(spool_dir.glob("impact-scorer-*.json"))
+    assert len(spool_files) == 1
+
+    payload = json.loads(spool_files[0].read_text(encoding="utf-8"))
+    assert payload["cron_id"] == "impact-scorer"
+    assert payload["exit_code"] == 0
+    assert payload["summary"] == "spool-ok"
+    assert payload["ended_at"]

--- a/tests/test_packaged_update_runtime.py
+++ b/tests/test_packaged_update_runtime.py
@@ -86,7 +86,9 @@ def test_refresh_installed_manifest_writes_runtime_core_artifacts(tmp_path, monk
     (src_dir / "hooks").mkdir()
     (src_dir / "crons" / "manifest.json").write_text('{"crons":[]}\n')
     (src_dir / "scripts" / "nexo-catchup.py").write_text("print('ok')\n")
+    (src_dir / "scripts" / "nexo-catchup 2.py").write_text("print('old')\n")
     (src_dir / "hooks" / "capture-tool-logs.sh").write_text("#!/bin/bash\necho ok\n")
+    (src_dir / "hooks" / "capture-tool-logs 2.sh").write_text("#!/bin/bash\necho old\n")
 
     monkeypatch.setattr(update, "NEXO_HOME", runtime_home)
     monkeypatch.setattr(update, "SRC_DIR", src_dir)

--- a/tests/test_plugin_loader_baseline.py
+++ b/tests/test_plugin_loader_baseline.py
@@ -121,6 +121,27 @@ class TestListAndRemovePlugins:
         result = remove_plugin(_StubMCP(), "non_existent")
         assert result == []
 
+    def test_load_all_plugins_skips_duplicate_copy_filenames(self, isolated_db, monkeypatch, tmp_path):
+        import plugin_loader
+
+        repo_plugins = tmp_path / "repo-plugins"
+        personal_plugins = tmp_path / "personal-plugins"
+        repo_plugins.mkdir()
+        personal_plugins.mkdir()
+        (personal_plugins / "alpha.py").write_text("TOOLS = []\n", encoding="utf-8")
+        (personal_plugins / "alpha 2.py").write_text("TOOLS = []\n", encoding="utf-8")
+
+        loaded = []
+
+        monkeypatch.setattr(plugin_loader, "PLUGINS_DIR", str(repo_plugins))
+        monkeypatch.setattr(plugin_loader, "PERSONAL_PLUGINS_DIR", str(personal_plugins))
+        monkeypatch.setattr(plugin_loader, "load_plugin", lambda mcp, filename, plugins_dir=None: loaded.append(filename) or 0)
+
+        total = plugin_loader.load_all_plugins(_StubMCP())
+
+        assert total == 0
+        assert loaded == ["alpha.py"]
+
 
 # ── _PluginTimeout exception class ───────────────────────────────────────
 

--- a/tests/test_server_startup_contract.py
+++ b/tests/test_server_startup_contract.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import sqlite3
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REPO_SRC = REPO_ROOT / "src"
+
+if str(REPO_SRC) not in sys.path:
+    sys.path.insert(0, str(REPO_SRC))
+
+
+def test_allow_fresh_db_on_corruption_defaults_false(monkeypatch, isolated_db):
+    import server
+
+    monkeypatch.delenv("NEXO_ALLOW_FRESH_DB_ON_CORRUPTION", raising=False)
+
+    assert server._allow_fresh_db_on_corruption() is False
+
+
+def test_init_db_or_exit_refuses_fresh_db_without_override(monkeypatch, isolated_db):
+    import server
+
+    calls: list[str] = []
+    quarantined: list[str] = []
+
+    def fake_init_db():
+        calls.append("init")
+        raise sqlite3.DatabaseError("corrupt")
+
+    monkeypatch.setattr(server, "init_db", fake_init_db)
+    monkeypatch.setattr(server, "_restore_valid_db_backup", lambda: False)
+    monkeypatch.setattr(server, "_quarantine_corrupt_db_file", lambda db_path: quarantined.append(db_path))
+    monkeypatch.setattr(server, "_allow_fresh_db_on_corruption", lambda: False)
+
+    with pytest.raises(SystemExit):
+        server._init_db_or_exit()
+
+    assert calls == ["init"]
+    assert quarantined
+
+
+def test_init_db_or_exit_allows_override_for_fresh_db(monkeypatch, isolated_db):
+    import server
+
+    calls = {"count": 0}
+    quarantined: list[str] = []
+
+    def fake_init_db():
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise sqlite3.DatabaseError("corrupt")
+
+    monkeypatch.setattr(server, "init_db", fake_init_db)
+    monkeypatch.setattr(server, "_restore_valid_db_backup", lambda: False)
+    monkeypatch.setattr(server, "_quarantine_corrupt_db_file", lambda db_path: quarantined.append(db_path))
+    monkeypatch.setattr(server, "_allow_fresh_db_on_corruption", lambda: True)
+
+    server._init_db_or_exit()
+
+    assert calls["count"] == 2
+    assert quarantined
+
+
+def test_run_startup_preflight_sync_emits_messages(monkeypatch, capsys, isolated_db):
+    import server
+
+    fake_auto_update = types.SimpleNamespace(
+        startup_preflight=lambda **kwargs: {
+            "updated": True,
+            "git_update": "Auto-updated: 5.3.27 -> 5.3.28",
+            "client_bootstrap_updates": ["Codex bootstrap refreshed"],
+            "migrations": [{"file": "m41.py", "status": "failed", "message": "boom"}],
+        }
+    )
+    monkeypatch.setitem(sys.modules, "auto_update", fake_auto_update)
+
+    server._run_startup_preflight_sync()
+
+    stderr = capsys.readouterr().err
+    assert "Startup update applied." in stderr
+    assert "Auto-updated: 5.3.27 -> 5.3.28" in stderr
+    assert "Codex bootstrap refreshed" in stderr
+    assert "Migration m41.py FAILED: boom" in stderr

--- a/tests/test_update_shell_contract.py
+++ b/tests/test_update_shell_contract.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "src" / "scripts" / "nexo-update.sh"
+
+
+def test_nexo_update_shell_script_delegates_to_python_core():
+    text = SCRIPT_PATH.read_text(encoding="utf-8")
+
+    assert "from plugins.update import handle_update" in text
+    assert "handle_update(remote=remote, branch=branch)" in text
+    assert "git pull" not in text
+    assert "git reset --hard" not in text

--- a/tests/test_verify_release_readiness.py
+++ b/tests/test_verify_release_readiness.py
@@ -66,6 +66,50 @@ def _seed_closeout_db(
     conn.close()
 
 
+def _seed_public_surfaces(root: Path, version: str, *, include_well_known: bool = False):
+    version_slug = version.replace(".", "-")
+    version_anchor = version.replace(".", "")
+    (root / "README.md").write_text(
+        f"Version `{version}` is the current packaged-runtime line\n",
+        encoding="utf-8",
+    )
+    (root / "llms.txt").write_text(
+        f"> Open-source cognitive runtime with a shared brain (v{version}).\n\n"
+        f"v{version}: latest release summary\n",
+        encoding="utf-8",
+    )
+    (root / "index.html").write_text(
+        f'<span id="version-badge">v{version}</span>\n'
+        f'"softwareVersion": "{version}"\n',
+        encoding="utf-8",
+    )
+    blog_dir = root / "blog"
+    blog_dir.mkdir(exist_ok=True)
+    (blog_dir / "index.html").write_text(
+        f'<a href="/blog/nexo-{version_slug}-release/">Read latest release</a>\n'
+        f"<h2>NEXO {version}: Release</h2>\n",
+        encoding="utf-8",
+    )
+    changelog_dir = root / "changelog"
+    changelog_dir.mkdir(exist_ok=True)
+    (changelog_dir / "index.html").write_text(
+        f'<section id="v{version_anchor}">New in v{version}</section>\n',
+        encoding="utf-8",
+    )
+    (root / "sitemap.xml").write_text(
+        f"https://nexo-brain.com/blog/nexo-{version_slug}-release/\n",
+        encoding="utf-8",
+    )
+    if include_well_known:
+        well_known = root / ".well-known"
+        well_known.mkdir(exist_ok=True)
+        (well_known / "llms.txt").write_text(
+            f"> Open-source cognitive runtime with a shared brain (v{version}).\n\n"
+            f"v{version}: latest release summary\n",
+            encoding="utf-8",
+        )
+
+
 def test_check_contract_accepts_valid_contract(tmp_path):
     module = _load_module()
     website_root = tmp_path / "site"
@@ -182,6 +226,34 @@ def test_check_duplicate_artifacts_rejects_duplicate_copy(tmp_path):
 
     with pytest.raises(SystemExit, match="duplicate artifacts found"):
         module._check_duplicate_artifacts(tmp_path)
+
+
+def test_check_repo_public_surfaces_accepts_aligned_files(tmp_path):
+    module = _load_module()
+    _seed_public_surfaces(tmp_path, "5.3.29")
+
+    module._check_repo_public_surfaces("5.3.29", repo_root=tmp_path)
+
+
+def test_check_repo_public_surfaces_rejects_drift(tmp_path):
+    module = _load_module()
+    _seed_public_surfaces(tmp_path, "5.3.29")
+    (tmp_path / "README.md").write_text("Version `5.3.28` is the current packaged-runtime line\n", encoding="utf-8")
+
+    with pytest.raises(SystemExit, match="repo public surfaces drift"):
+        module._check_repo_public_surfaces("5.3.29", repo_root=tmp_path)
+
+
+def test_check_website_rejects_missing_current_release_markers(tmp_path):
+    module = _load_module()
+    _seed_public_surfaces(tmp_path, "5.3.29", include_well_known=True)
+    (tmp_path / "blog" / "index.html").write_text(
+        '<a href="/blog/nexo-5-3-24-model-defaults-and-headless-safe-update/">Read latest release</a>\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit, match="website drift"):
+        module._check_website("5.3.29", tmp_path)
 
 
 def test_check_protocol_closeout_accepts_done_task_with_change_log(tmp_path):

--- a/tests/test_verify_release_readiness.py
+++ b/tests/test_verify_release_readiness.py
@@ -168,6 +168,22 @@ def test_check_contract_requires_completion_when_requested(tmp_path):
         )
 
 
+def test_check_duplicate_artifacts_accepts_clean_tree(tmp_path):
+    module = _load_module()
+    (tmp_path / "alpha.py").write_text("print('ok')\n", encoding="utf-8")
+
+    module._check_duplicate_artifacts(tmp_path)
+
+
+def test_check_duplicate_artifacts_rejects_duplicate_copy(tmp_path):
+    module = _load_module()
+    (tmp_path / "alpha.py").write_text("print('ok')\n", encoding="utf-8")
+    (tmp_path / "alpha 2.py").write_text("print('old')\n", encoding="utf-8")
+
+    with pytest.raises(SystemExit, match="duplicate artifacts found"):
+        module._check_duplicate_artifacts(tmp_path)
+
+
 def test_check_protocol_closeout_accepts_done_task_with_change_log(tmp_path):
     module = _load_module()
     nexo_home = tmp_path / "nexo-home"


### PR DESCRIPTION
## Summary
- block duplicate  artifacts across loader, update, preflight and release-readiness paths
- unify the shell update entrypoint onto the canonical Python update core
- harden server startup DB recovery and cron wrapper traceability

## Validation
- pytest -q tests/test_startup_preflight.py tests/test_server_startup_contract.py tests/test_cron_wrapper_contract.py tests/test_update_shell_contract.py tests/test_update_path_and_reload.py tests/test_cron_sync.py tests/test_packaged_update_runtime.py tests/test_plugin_loader_baseline.py tests/test_verify_release_readiness.py
- bash scripts/nexo-preflight.sh
- python3 scripts/verify_release_readiness.py --ci