### PR TITLE
feat: v5.4.0 — runtime events bus + notify/health/logs + calibration migration

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.3.30",
+  "version": "5.4.0",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/.well-known/llms.txt
+++ b/.well-known/llms.txt
@@ -1,9 +1,10 @@
 # NEXO Brain
 
-> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.3.30).
+> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.4.0).
 
 NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. It adds a local shared brain across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, smarter retrieval defaults, long-horizon overnight analysis, and 150+ MCP tools.
 
+v5.4.0: runtime events + health + logs + calibration migration — append-only event bus at `~/.nexo/runtime/events.ndjson` with stable envelope, `nexo notify` for one-shot proactive events, `nexo health --json` for a rolled-up subsystem snapshot, `nexo logs --tail --json` for structured log access, and a safe flat→nested migration for `calibration.json` that runs silently inside `nexo update` with a pre-migrate backup
 v5.3.30: desktop bridge — four read-only CLI commands (`nexo schema`, `nexo identity`, `nexo onboard`, `nexo scan-profile`) let external UIs like NEXO Desktop render preferences, onboarding, identity, and profile heuristics from live JSON instead of hardcoding field lists and releasing in lockstep
 v5.3.29: runtime hygiene + fail-closed startup + honest cron tracing — duplicate `* 2` artifacts now fail release gates instead of hiding in the tree, update paths converge on one canonical core, startup preflight runs synchronously, corrupt DB state no longer respawns an empty brain by default, and cron runs spool locally when SQLite is unavailable
 v5.3.11: protocol + cortex contract hardening — malformed `outcome`, `task_type`, and `impact_level` values now fail explicitly instead of being silently coerced into other valid states, so persisted task/debt/context/decision data stays trustworthy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## [5.4.0] - 2026-04-14
+
+### Add: calibration migration + runtime events bus + notify/health/logs
+
+Second iteration of the NEXO Desktop integration plan. External UIs can
+now react to live Brain state, not just read a static schema.
+
+- `src/calibration_migration.py` — detects flat `calibration.json` from
+  older installs and migrates to nested (user/personality/preferences/meta)
+  with a pre-migrate backup. Unknown keys go to `legacy_unmapped`. Reverts
+  automatically on write failure.
+- `src/user_context.py` — loader accepts both flat and nested shapes so
+  no upgrade race breaks existing users.
+- `nexo doctor --migrate-calibration [--calibration-dry-run]` — explicit
+  knob for the migration. Also runs implicitly with `nexo doctor --fix`.
+- `nexo update` — migrates once per user after the code sync. Silent no-op
+  if already nested.
+
+- `src/events_bus.py` — append-only NDJSON stream at
+  `~/.nexo/runtime/events.ndjson` with monotonic `id`, locked writes,
+  5 MB rotation, and a stable envelope
+  `{id, ts, type, priority, text, reason, source, extra}`.
+  Event types: `attention_required`, `proactive_message`, `followup_alert`,
+  `health_alert`, `info`. Priorities: `low|normal|high|urgent`.
+- `nexo notify <type> [--text] [--reason] [--priority] [--source] [--json]`
+  — one-shot emitter. Lets Brain internals (recovery, followup runner,
+  health watchers) wake up a UI without polling.
+- `src/health_check.py` + `nexo health --json` — snapshot of runtime,
+  database integrity, crons, MCP wiring, recent errors, and events.
+  Top-level `status` rolls up to `ok|degraded|error`.
+- `nexo logs --tail [--lines N] [--source all|events|operations|<file>]
+  [--json]` — single entry point to tail the event bus or
+  `~/.nexo/operations/*.log` without opening a terminal.
+
+No existing commands changed behavior. Pure additive surface plus a safe,
+idempotent calibration migration that runs in the background of `update`.
+
 ## [5.3.30] - 2026-04-14
 
 ### Add: Desktop bridge — read-only commands for external UIs

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
 
 [Watch the overview video](https://nexo-brain.com/watch/) · [Watch on YouTube](https://www.youtube.com/watch?v=i2lkGhKyVqI) · [Open the infographic](https://nexo-brain.com/assets/nexo-brain-infographic-v5.png)
 
-Version `5.3.30` is the current packaged-runtime line: four read-only CLI commands (`nexo schema`, `nexo identity`, `nexo onboard`, `nexo scan-profile`) let external UIs like NEXO Desktop auto-adapt to the editable schema, canonical identity, onboarding wizard, and profile heuristics without hardcoding fields.
+Version `5.4.0` is the current packaged-runtime line: runtime event bus at `~/.nexo/runtime/events.ndjson`, `nexo notify` for one-shot proactive events, `nexo health --json` for a rolled-up subsystem snapshot, `nexo logs --tail --json` for structured log access, and a safe flat→nested migration for `calibration.json` on older installs.
 
-Previously in `5.3.29`: duplicate `* 2` artifacts now fail hygiene gates instead of hiding in the tree, packaged/runtime update paths converge on one canonical core, startup preflight runs synchronously, corrupt DB state no longer respawns an empty brain by default, and cron runs spool locally when SQLite is unavailable.
+Previously in `5.3.30`: four read-only CLI commands (`nexo schema`, `nexo identity`, `nexo onboard`, `nexo scan-profile`) let external UIs auto-adapt to the editable schema, identity, onboarding wizard, and profile heuristics.
 
 Start here:
 - [5-minute quickstart](docs/quickstart-5-minutes.md)

--- a/blog/index.html
+++ b/blog/index.html
@@ -134,7 +134,7 @@
                     <span class="page-chip">Competitive analysis</span>
                 </div>
                 <div class="hero-actions" style="justify-content:flex-start;">
-                    <a href="/blog/nexo-5-3-30-desktop-bridge/" class="btn btn-primary">Read latest release</a>
+                    <a href="/blog/nexo-5-4-0-events-health-logs/" class="btn btn-primary">Read latest release</a>
                     <a href="/changelog/" class="btn btn-secondary">Latest release notes</a>
                     <a href="/evolution/" class="btn btn-secondary">See Evolution</a>
                 </div>
@@ -143,24 +143,24 @@
                 <div class="section-label">Latest release</div>
                 <div class="blog-featured-meta">
                     <span class="compare-chip">April 14, 2026</span>
-                    <span class="compare-chip">Desktop bridge</span>
-                    <span class="compare-chip">Read-only CLI</span>
-                    <span class="compare-chip">Auto-adaptive UI</span>
+                    <span class="compare-chip">Runtime events</span>
+                    <span class="compare-chip">Health + logs</span>
+                    <span class="compare-chip">Calibration migration</span>
                 </div>
-                <h2>NEXO 5.3.30: Desktop Bridge — four read-only CLI commands that let any UI auto-adapt</h2>
-                <p>NEXO 5.3.30: exposes editable schema, canonical identity, onboarding wizard, and profile heuristics as JSON over the CLI. External UIs like NEXO Desktop can render preferences and first-run wizards from live data instead of hardcoding field lists and releasing in lockstep with the runtime.</p>
+                <h2>NEXO 5.4.0: Runtime events bus + nexo notify / health / logs + safe calibration migration</h2>
+                <p>NEXO 5.4.0: append-only event bus at <code>~/.nexo/runtime/events.ndjson</code>, <code>nexo notify</code> for one-shot proactive events, <code>nexo health --json</code> for a rolled-up subsystem snapshot, <code>nexo logs --tail --json</code> for structured log access, and a silent flat→nested <code>calibration.json</code> migration that runs with a pre-migrate backup.</p>
                 <div class="hero-actions" style="justify-content:flex-start;margin-bottom:18px;">
-                    <a href="/blog/nexo-5-3-30-desktop-bridge/" class="btn btn-primary">Open article</a>
-                    <a href="/changelog/#v5330" class="btn btn-secondary">Open changelog</a>
+                    <a href="/blog/nexo-5-4-0-events-health-logs/" class="btn btn-primary">Open article</a>
+                    <a href="/changelog/#v540" class="btn btn-secondary">Open changelog</a>
                 </div>
                 <div class="blog-mini-stack">
                     <div class="blog-mini-card">
                         <strong>Companion view</strong>
-                        <span><a href="/changelog/#v5330">The 5.3.30 changelog section</a></span>
+                        <span><a href="/changelog/#v540">The 5.4.0 changelog section</a></span>
                     </div>
                     <div class="blog-mini-card">
                         <strong>Previous release</strong>
-                        <span><a href="/blog/nexo-5-3-29-runtime-hygiene-and-fail-closed-startup/">NEXO 5.3.29: Runtime Hygiene, Fail-Closed Startup, and Honest Cron Tracing</a>.</span>
+                        <span><a href="/blog/nexo-5-3-30-desktop-bridge/">NEXO 5.3.30: Desktop Bridge — four read-only CLI commands</a>.</span>
                     </div>
                 </div>
             </div>
@@ -172,6 +172,13 @@
 <section class="section-flush-top">
     <div class="container">
         <div class="blog-grid">
+
+            <div class="blog-card">
+                <div class="blog-card-date">April 14, 2026</div>
+                <h2><a href="/blog/nexo-5-4-0-events-health-logs/">NEXO 5.4.0: Runtime events + notify / health / logs + calibration migration</a></h2>
+                <p>NEXO 5.4.0: append-only event bus at <code>~/.nexo/runtime/events.ndjson</code>, <code>nexo notify</code> for proactive events, <code>nexo health --json</code> for subsystem status, <code>nexo logs --tail --json</code> for structured log access, plus a safe flat→nested <code>calibration.json</code> migration that runs silently inside <code>nexo update</code>.</p>
+                <a href="/blog/nexo-5-4-0-events-health-logs/" class="read-more">Read article <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14"/><path d="M12 5l7 7-7 7"/></svg></a>
+            </div>
 
             <div class="blog-card">
                 <div class="blog-card-date">April 14, 2026</div>

--- a/blog/nexo-5-4-0-events-health-logs/index.html
+++ b/blog/nexo-5-4-0-events-health-logs/index.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>NEXO Brain v5.4.0 — Calibration Migration + Runtime Events + notify/health/logs | nexo-brain.com</title>
+<meta name="description" content="v5.4.0 adds a real-time event bus, a one-shot health snapshot, structured log tailing, and a safe calibration.json migration. External UIs stop polling and start reacting to live Brain state.">
+<link rel="stylesheet" href="../../assets/blog.css">
+</head>
+<body>
+<article class="blog-post">
+<header>
+<h1>v5.4.0 — Calibration migration + runtime events + <code>notify</code>, <code>health</code>, <code>logs</code></h1>
+<time datetime="2026-04-14">April 14, 2026</time>
+</header>
+
+<p>v5.3.30 gave external UIs a static description of the Brain — schema, identity, onboarding, profile. That unblocks rendering, but it does not let a UI <em>react</em> to anything. A user interface that can only read configuration is still a waiting room.</p>
+
+<p>v5.4.0 closes that gap. There is now a runtime event bus, a snapshot of subsystem health, a single way to tail logs, and a migration that quietly cleans up older installs before they ossify around a legacy shape.</p>
+
+<h2>1. Calibration migration, silent and reversible</h2>
+
+<p>Older NEXO installs wrote <code>calibration.json</code> with flat top-level keys — <code>user_name</code>, <code>autonomy</code>, <code>role</code>, and so on. Newer installs nest those inside <code>user.*</code>, <code>personality.*</code>, <code>preferences.*</code>, and <code>meta.*</code>. Both shapes worked, but every downstream client had to re-implement the probe — and some wrote back to the wrong place.</p>
+
+<p>v5.4.0 ships a migration that runs automatically inside <code>nexo update</code>, once per user, with a pre-migrate backup (<code>calibration.json.pre-migrate-5.4.0</code>). Unknown keys are preserved under <code>legacy_unmapped</code>. If the write step fails, the backup is restored. If the shape is already nested, the migration is a no-op. You can also run it explicitly with <code>nexo doctor --migrate-calibration</code>, or preview it with <code>--calibration-dry-run</code>.</p>
+
+<p>The loader in <code>user_context.py</code> still reads both shapes, so nothing breaks during the release window. The flat shape just goes extinct naturally.</p>
+
+<h2>2. <code>~/.nexo/runtime/events.ndjson</code> — an append-only runtime bus</h2>
+
+<p>The new event bus is deliberately simple: one JSON object per line, monotonic <code>id</code>, unix <code>ts</code>, a stable envelope <code>{id, ts, type, priority, text, reason, source, extra}</code>. Writes are protected by an <code>fcntl</code> lock; the file rotates automatically at 5 MB. Any UI can tail it the same way <code>tail -f</code> does.</p>
+
+<p>Event types are intentionally few and stable:</p>
+
+<ul>
+  <li><code>attention_required</code> — the user should look at something</li>
+  <li><code>proactive_message</code> — Brain wants to initiate dialogue</li>
+  <li><code>followup_alert</code> — overdue or urgent followup</li>
+  <li><code>health_alert</code> — a core subsystem is degraded</li>
+  <li><code>info</code> — general update, no attention needed</li>
+</ul>
+
+<p>Priorities are <code>low | normal | high | urgent</code>. That is the whole contract.</p>
+
+<h2>3. <code>nexo notify</code> — one-shot emitter</h2>
+
+<p><code>nexo notify proactive_message --text "An important email from Maria just arrived, should we look?" --reason "email-alerts" --priority high --json</code> returns the full event. That is what a recovery script or followup runner calls when it needs the user's attention, instead of silently modifying state and hoping someone notices.</p>
+
+<h2>4. <code>nexo health --json</code> — one snapshot, all subsystems</h2>
+
+<p>Runtime, database, crons, MCP wiring, recent errors, and the event bus — rolled up into a single <code>status: ok | degraded | error</code>. A panel in NEXO Desktop can render that in red/yellow/green without stack traces. A CI cron can diff successive snapshots without teaching itself where every log lives.</p>
+
+<h2>5. <code>nexo logs --tail</code> — structured log access</h2>
+
+<p>Last N entries across the event bus and <code>~/.nexo/operations/*.log</code>, JSON by default. Point at a specific file with <code>--source</code>. This is the line between "Maria asks Francisco to open a terminal" and "Maria reads the error herself from Desktop." One command, two consumers.</p>
+
+<h2>What stays the same</h2>
+
+<p>No existing commands changed behavior. The MCP server, crons, hooks, and startup contract are untouched. This release is additive surface plus one quiet, safe migration that brings older installs into line with the canonical schema.</p>
+
+<h2>Update</h2>
+
+<pre><code>npm update -g nexo-brain
+nexo update
+</code></pre>
+
+<p>If the install was already on the nested calibration shape, <code>update</code> stays boring. If it was on the flat shape, you will see one extra line: <code>calibration.json migrated flat → nested</code>. Boring is the feature.</p>
+
+</article>
+</body>
+</html>

--- a/changelog/index.html
+++ b/changelog/index.html
@@ -87,19 +87,23 @@
                 <h1 class="section-title" style="font-size:clamp(32px,5vw,56px);">Changelog</h1>
                 <p class="section-subtitle">Every feature, fix, and improvement &mdash; from the beginning, with the same visual clarity as the rest of the site.</p>
                 <div class="page-chip-row">
-                    <span class="page-chip">v5.3.30 live</span>
-                    <span class="page-chip">Desktop bridge</span>
-                    <span class="page-chip">Read-only CLI</span>
-                    <span class="page-chip">Auto-adaptive UI</span>
+                    <span class="page-chip">v5.4.0 live</span>
+                    <span class="page-chip">Events bus</span>
+                    <span class="page-chip">Health + logs</span>
+                    <span class="page-chip">Calibration migration</span>
                 </div>
                 <div class="hero-actions" style="justify-content:flex-start;">
-                    <a href="#v5330" class="btn btn-primary">Start with v5.3.30</a>
+                    <a href="#v540" class="btn btn-primary">Start with v5.4.0</a>
                     <a href="#v400" class="btn btn-secondary">See v4.0.0</a>
                     <a href="/evolution/" class="btn btn-secondary">See Evolution</a>
                 </div>
             </div>
             <div class="page-visual">
                 <div class="page-stack">
+                    <div class="page-stack-card">
+                        <strong>v5.4.0</strong>
+                        <span>Runtime events bus at <code>~/.nexo/runtime/events.ndjson</code>, <code>nexo notify</code> for one-shot proactive events, <code>nexo health --json</code> subsystem snapshot, <code>nexo logs --tail --json</code> structured log access, and a safe flat→nested <code>calibration.json</code> migration that runs silently inside <code>nexo update</code>.</span>
+                    </div>
                     <div class="page-stack-card">
                         <strong>v5.3.30</strong>
                         <span>Desktop bridge: four read-only CLI commands (<code>nexo schema</code>, <code>nexo identity</code>, <code>nexo onboard</code>, <code>nexo scan-profile</code>) expose editable schema, identity, onboarding wizard, and profile heuristics as JSON so external UIs auto-adapt.</span>
@@ -166,6 +170,25 @@
                 <div id="changelog-pager" class="changelog-pager" aria-label="Changelog pagination"></div>
             </div>
         </div>
+    </div>
+</section>
+
+<!-- v5.4.0 events + health + logs + calibration migration -->
+<section id="v540" class="section-compact" style="background:linear-gradient(135deg,#09111f 0%,#1b2a4e 34%,#f97316 68%,#22d3ee 100%);">
+    <div class="container">
+        <div class="section-label">New in v5.4.0 <span style="opacity:.5;font-weight:400;">&mdash; April 14, 2026</span></div>
+        <h2 class="section-title">Runtime events + <code>nexo notify</code> / <code>health</code> / <code>logs</code> + calibration migration</h2>
+        <p class="section-subtitle">
+            External UIs stop polling and start reacting. NEXO Brain now exposes a stable runtime event stream, a subsystem health snapshot, structured log tailing, and a safe silent migration for older <code>calibration.json</code> files.
+        </p>
+        <ul style="list-style:none;padding:0;margin:24px 0 0;display:grid;gap:12px;">
+            <li><strong>Events bus</strong> — append-only NDJSON at <code>~/.nexo/runtime/events.ndjson</code>, monotonic <code>id</code>, stable envelope, 5 MB rotation, fcntl-locked writes. Event types: <code>attention_required</code>, <code>proactive_message</code>, <code>followup_alert</code>, <code>health_alert</code>, <code>info</code>.</li>
+            <li><code>nexo notify TYPE --text ... --reason ... --priority low|normal|high|urgent</code> — one-shot emitter for recovery scripts, followup runners, and health watchers.</li>
+            <li><code>nexo health --json</code> — rolled up <code>status: ok|degraded|error</code> across runtime, database, crons, MCP wiring, recent errors, and the event bus.</li>
+            <li><code>nexo logs --tail [--lines N] [--source all|events|operations|&lt;file&gt;] [--json]</code> — single entry point for Desktop to read logs without opening a terminal.</li>
+            <li><code>nexo doctor --migrate-calibration [--calibration-dry-run]</code> plus implicit migration inside <code>nexo update</code>: <code>calibration.json</code> moves from flat to nested with a pre-migrate backup. Reverts on failure. No-op if already nested.</li>
+        </ul>
+        <p style="margin-top:24px;">Pure additive surface. See the <a href="/blog/nexo-5-4-0-events-health-logs/" style="color:inherit;text-decoration:underline;">release post</a>.</p>
     </div>
 </section>
 

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 5.3.30
+version: 5.4.0
 metadata:
   openclaw:
     requires:

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
         "operatingSystem": "macOS, Linux, Windows",
         "url": "https://nexo-brain.com",
         "downloadUrl": "https://www.npmjs.com/package/nexo-brain",
-        "softwareVersion": "5.3.30",
+        "softwareVersion": "5.4.0",
         "license": "https://www.gnu.org/licenses/agpl-3.0",
         "author": {
             "@type": "Organization",
@@ -697,7 +697,7 @@
     <div class="container">
         <div class="hero-badge fade-up">
             <span class="dot"></span>
-            <span id="version-badge">v5.3.30</span> &mdash; desktop bridge: read-only CLI for external UIs
+            <span id="version-badge">v5.4.0</span> &mdash; runtime events, health, logs, calibration migration
         </div>
         <div class="fade-up" style="display:flex;gap:8px;justify-content:center;margin-bottom:12px;">
             <img src="https://img.shields.io/npm/v/nexo-brain?color=7C3AED&label=npm" alt="npm version">

--- a/llms.txt
+++ b/llms.txt
@@ -1,9 +1,10 @@
 # NEXO Brain
 
-> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.3.30).
+> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.4.0).
 
 NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. It adds a local shared brain across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, smarter retrieval defaults, long-horizon overnight analysis, and 150+ MCP tools.
 
+v5.4.0: runtime events + health + logs + calibration migration — append-only event bus at `~/.nexo/runtime/events.ndjson` with stable envelope, `nexo notify` for one-shot proactive events, `nexo health --json` for a rolled-up subsystem snapshot, `nexo logs --tail --json` for structured log access, and a safe flat→nested migration for `calibration.json` that runs silently inside `nexo update` with a pre-migrate backup
 v5.3.30: desktop bridge — four read-only CLI commands (`nexo schema`, `nexo identity`, `nexo onboard`, `nexo scan-profile`) let external UIs like NEXO Desktop render preferences, onboarding, identity, and profile heuristics from live JSON instead of hardcoding field lists and releasing in lockstep
 v5.3.29: runtime hygiene + fail-closed startup + honest cron tracing — duplicate `* 2` artifacts now fail release gates instead of hiding in the tree, update paths converge on one canonical core, startup preflight runs synchronously, corrupt DB state no longer respawns an empty brain by default, and cron runs spool locally when SQLite is unavailable
 v5.3.11: protocol + cortex contract hardening — malformed `outcome`, `task_type`, and `impact_level` values now fail explicitly instead of being silently coerced into other valid states, so persisted task/debt/context/decision data stays trustworthy

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "5.3.30",
+  "version": "5.4.0",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.3.30" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.4.0" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.3.30",
+  "version": "5.4.0",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -145,6 +145,12 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://nexo-brain.com/blog/nexo-5-4-0-events-health-logs/</loc>
+    <lastmod>2026-04-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.95</priority>
+  </url>
+  <url>
     <loc>https://nexo-brain.com/blog/nexo-5-3-30-desktop-bridge/</loc>
     <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>

--- a/src/calibration_migration.py
+++ b/src/calibration_migration.py
@@ -1,0 +1,242 @@
+"""Calibration migration — flat → nested schema for calibration.json.
+
+Older NEXO installations wrote calibration.json with flat top-level keys
+(user_name, autonomy, role…). The canonical shape is nested
+(user.name, personality.autonomy, meta.role). This module detects the
+flat shape and migrates to nested with a backup.
+
+Design:
+  - Backup lives at calibration.json.pre-migrate-<version>
+  - Unknown fields are preserved verbatim under `legacy_unmapped`
+  - Revert is just: cp backup → calibration.json
+  - Idempotent: if already nested, returns OK without touching the file
+
+No network, no DB. Pure file I/O so it can run from any runtime.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import time
+from pathlib import Path
+from typing import Any
+
+
+FLAT_TO_NESTED = {
+    # user.*
+    "user_name": ("user", "name"),
+    "name": ("user", "name"),
+    "language": ("user", "language"),
+    "lang": ("user", "language"),
+    "timezone": ("user", "timezone"),
+    "tz": ("user", "timezone"),
+    "assistant_name": ("user", "assistant_name"),
+    # personality.*
+    "autonomy": ("personality", "autonomy"),
+    "communication": ("personality", "communication"),
+    "honesty": ("personality", "honesty"),
+    "proactivity": ("personality", "proactivity"),
+    "error_handling": ("personality", "error_handling"),
+    # preferences.*
+    "menu_on_demand": ("preferences", "menu_on_demand"),
+    "show_pending_items": ("preferences", "show_pending_items"),
+    "execution_first": ("preferences", "execution_first"),
+    "report_style": ("preferences", "report_style"),
+    # meta.*
+    "role": ("meta", "role"),
+    "technical_level": ("meta", "technical_level"),
+}
+
+# Keys that always live at the top level regardless of shape
+TOP_LEVEL_KEYS = {"version", "created", "mood_history", "operator_name"}
+
+
+def _calibration_path(nexo_home: Path | None = None) -> Path:
+    home = nexo_home or Path(os.environ.get("NEXO_HOME", str(Path.home() / ".nexo")))
+    return home / "brain" / "calibration.json"
+
+
+def _is_nested(cal: dict) -> bool:
+    """Nested shape has at least one of {user, personality, preferences, meta} as dict."""
+    for key in ("user", "personality", "preferences", "meta"):
+        if isinstance(cal.get(key), dict):
+            return True
+    return False
+
+
+def _has_flat_markers(cal: dict) -> bool:
+    """Flat shape has top-level keys that normally belong inside nested groups."""
+    for flat_key in FLAT_TO_NESTED:
+        if flat_key in cal:
+            return True
+    return False
+
+
+def detect(cal: dict | None = None, *, path: Path | None = None) -> dict:
+    """Return {'shape': 'nested'|'flat'|'mixed'|'empty', 'reason': str}."""
+    if cal is None:
+        target = path or _calibration_path()
+        if not target.is_file():
+            return {"shape": "empty", "reason": "file does not exist"}
+        try:
+            cal = json.loads(target.read_text())
+        except Exception as exc:
+            return {"shape": "empty", "reason": f"unreadable: {exc}"}
+    if not isinstance(cal, dict) or not cal:
+        return {"shape": "empty", "reason": "empty or not an object"}
+
+    nested = _is_nested(cal)
+    flat = _has_flat_markers(cal)
+    if nested and flat:
+        return {"shape": "mixed", "reason": "both nested groups and flat keys present"}
+    if nested:
+        return {"shape": "nested", "reason": "already canonical"}
+    if flat:
+        return {"shape": "flat", "reason": "top-level flat keys, no nested groups"}
+    return {"shape": "empty", "reason": "no recognizable keys"}
+
+
+def migrate(
+    cal: dict,
+    *,
+    preserve_unmapped: bool = True,
+) -> dict:
+    """Convert a flat calibration payload to nested. Returns a new dict."""
+    if _is_nested(cal) and not _has_flat_markers(cal):
+        return dict(cal)
+
+    result: dict[str, Any] = {}
+    legacy_unmapped: dict[str, Any] = {}
+
+    # Preserve nested groups already present
+    for group in ("user", "personality", "preferences", "meta"):
+        if isinstance(cal.get(group), dict):
+            result[group] = dict(cal[group])
+
+    # Preserve top-level metadata
+    for key in TOP_LEVEL_KEYS:
+        if key in cal:
+            result[key] = cal[key]
+
+    # Walk flat keys
+    for key, value in cal.items():
+        if key in ("user", "personality", "preferences", "meta"):
+            continue
+        if key in TOP_LEVEL_KEYS:
+            continue
+        if key in FLAT_TO_NESTED:
+            group, leaf = FLAT_TO_NESTED[key]
+            result.setdefault(group, {})
+            # Nested value wins over flat if both exist
+            if leaf not in result[group]:
+                result[group][leaf] = value
+        else:
+            legacy_unmapped[key] = value
+
+    if legacy_unmapped and preserve_unmapped:
+        result["legacy_unmapped"] = legacy_unmapped
+
+    # Bump version marker if present
+    if "version" not in result:
+        result["version"] = 1
+
+    return result
+
+
+def backup_path(path: Path, version: str = "5.4.0") -> Path:
+    return path.with_name(path.name + f".pre-migrate-{version}")
+
+
+def apply_migration(
+    path: Path | None = None,
+    *,
+    version: str = "5.4.0",
+    dry_run: bool = False,
+) -> dict:
+    """Migrate calibration.json on disk. Returns a status dict."""
+    target = path or _calibration_path()
+    if not target.is_file():
+        return {"status": "skipped", "reason": "calibration.json not found", "path": str(target)}
+
+    try:
+        original = json.loads(target.read_text())
+    except Exception as exc:
+        return {"status": "error", "reason": f"unreadable: {exc}", "path": str(target)}
+
+    shape = detect(original)
+    if shape["shape"] in ("nested", "empty"):
+        return {
+            "status": "noop",
+            "reason": f"already {shape['shape']}",
+            "path": str(target),
+            "shape": shape["shape"],
+        }
+
+    migrated = migrate(original)
+    if dry_run:
+        return {
+            "status": "preview",
+            "reason": "dry run",
+            "path": str(target),
+            "shape": shape["shape"],
+            "original": original,
+            "migrated": migrated,
+            "backup_would_be": str(backup_path(target, version)),
+        }
+
+    backup = backup_path(target, version)
+    try:
+        shutil.copy2(target, backup)
+    except Exception as exc:
+        return {"status": "error", "reason": f"backup failed: {exc}", "path": str(target)}
+
+    try:
+        target.write_text(json.dumps(migrated, ensure_ascii=False, indent=2))
+    except Exception as exc:
+        # Attempt revert
+        try:
+            shutil.copy2(backup, target)
+        except Exception:
+            pass
+        return {"status": "error", "reason": f"write failed: {exc}", "path": str(target)}
+
+    # Re-detect to confirm
+    post = detect(migrated)
+    if post["shape"] != "nested":
+        # Revert
+        try:
+            shutil.copy2(backup, target)
+        except Exception:
+            pass
+        return {
+            "status": "error",
+            "reason": f"post-migration shape is {post['shape']}",
+            "path": str(target),
+        }
+
+    return {
+        "status": "migrated",
+        "reason": "flat → nested",
+        "path": str(target),
+        "backup": str(backup),
+        "shape": post["shape"],
+        "migrated_at": time.time(),
+    }
+
+
+def revert(
+    path: Path | None = None,
+    *,
+    version: str = "5.4.0",
+) -> dict:
+    """Revert calibration.json to the most recent pre-migrate backup."""
+    target = path or _calibration_path()
+    backup = backup_path(target, version)
+    if not backup.is_file():
+        return {"status": "error", "reason": f"no backup found at {backup}", "path": str(target)}
+    try:
+        shutil.copy2(backup, target)
+    except Exception as exc:
+        return {"status": "error", "reason": f"copy failed: {exc}", "path": str(target)}
+    return {"status": "reverted", "from": str(backup), "path": str(target)}

--- a/src/cli.py
+++ b/src/cli.py
@@ -922,6 +922,19 @@ def _update(args):
                 print(f"  Model recommendation check skipped: {exc}", file=sys.stderr)
         else:
             print(f"UPDATE FAILED: {result.get('error', 'sync failed')}", file=sys.stderr)
+
+    # Auto-migrate calibration.json flat → nested once per user. Silent on
+    # no-op; logs a line if an actual migration happened.
+    try:
+        from calibration_migration import detect as _cal_detect, apply_migration as _cal_apply
+        if _cal_detect()["shape"] == "flat":
+            mig = _cal_apply()
+            if mig.get("status") == "migrated" and not args.json:
+                print(f"[NEXO] calibration.json migrated flat → nested (backup: {mig.get('backup')})",
+                      flush=True)
+    except Exception:
+        pass
+
     return 0 if result.get("ok") else 1
 
 
@@ -1295,6 +1308,105 @@ def _chat(args):
     return int(result.returncode)
 
 
+def _notify(args):
+    """Emit an event to the runtime events bus (events.ndjson)."""
+    from events_bus import emit
+    try:
+        event = emit(
+            args.type,
+            text=getattr(args, "text", "") or "",
+            reason=getattr(args, "reason", "") or "",
+            priority=getattr(args, "priority", "normal"),
+            source=getattr(args, "source", "nexo-brain"),
+        )
+    except ValueError as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}), file=sys.stderr)
+        return 2
+    if args.json:
+        print(json.dumps({"ok": True, "event": event}, ensure_ascii=False, indent=2))
+    else:
+        print(f"notify: id={event['id']} type={event['type']} priority={event['priority']}")
+    return 0
+
+
+def _health(args):
+    """Collect a health snapshot and print it."""
+    from health_check import collect
+    report = collect()
+    if getattr(args, "json", True) is False:
+        # minimal text mode
+        print(f"status: {report.get('status', 'unknown')}")
+        for name, sub in report.get("subsystems", {}).items():
+            print(f"  {name:10s} {sub.get('status', '?')}")
+        return 0 if report.get("status") == "ok" else 1
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    return 0 if report.get("status") == "ok" else 1
+
+
+def _logs(args):
+    """Tail recent logs: events bus + operations/*.log."""
+    import glob as _glob
+    lines_want = max(1, int(getattr(args, "lines", 100)))
+    source = (getattr(args, "source", "all") or "all").lower()
+
+    results: dict = {"source": source, "lines": lines_want, "entries": []}
+    home = Path(os.environ.get("NEXO_HOME", str(Path.home() / ".nexo")))
+
+    def _collect_events(n: int) -> list[dict]:
+        try:
+            from events_bus import tail as _tail
+            return _tail(lines=n)
+        except Exception as exc:
+            return [{"error": f"events tail failed: {exc}"}]
+
+    def _collect_ops(n: int) -> list[dict]:
+        ops_dir = home / "operations"
+        if not ops_dir.is_dir():
+            return []
+        files = sorted(
+            ops_dir.glob("*.log"),
+            key=lambda p: p.stat().st_mtime if p.exists() else 0,
+            reverse=True,
+        )[:5]
+        out: list[dict] = []
+        for log in files:
+            try:
+                text = log.read_text(errors="ignore").splitlines()[-n:]
+            except Exception as exc:
+                out.append({"file": str(log), "error": str(exc)})
+                continue
+            for line in text:
+                out.append({"file": log.name, "line": line})
+        return out[-n:]
+
+    if source in ("all", "events"):
+        results["entries"].extend({"kind": "event", **e} for e in _collect_events(lines_want))
+    if source in ("all", "operations"):
+        results["entries"].extend({"kind": "log", **e} for e in _collect_ops(lines_want))
+    if source not in ("all", "events", "operations"):
+        # Treat as filename match inside operations/
+        specific = home / "operations" / source
+        if specific.is_file():
+            try:
+                text = specific.read_text(errors="ignore").splitlines()[-lines_want:]
+                results["entries"] = [{"kind": "log", "file": specific.name, "line": ln} for ln in text]
+            except Exception as exc:
+                results["error"] = str(exc)
+        else:
+            results["error"] = f"unknown log source: {source}"
+
+    if args.json:
+        print(json.dumps(results, ensure_ascii=False, indent=2))
+    else:
+        for entry in results["entries"][-lines_want:]:
+            if entry.get("kind") == "event":
+                print(f"[event] id={entry.get('id')} {entry.get('type')} "
+                      f"{entry.get('priority')} {entry.get('text','')}")
+            else:
+                print(f"[{entry.get('file','?')}] {entry.get('line','')}")
+    return 0
+
+
 def _doctor(args):
     """Run unified doctor diagnostics."""
     try:
@@ -1306,6 +1418,22 @@ def _doctor(args):
         return 1
 
     init_db()
+
+    # Calibration migration hook — runs before the orchestrator so the rest
+    # of doctor sees the canonical nested shape.
+    want_migrate = getattr(args, "migrate_calibration", False) or args.fix
+    dry = getattr(args, "calibration_dry_run", False)
+    if want_migrate or dry:
+        from calibration_migration import detect, apply_migration
+        shape = detect()
+        if shape["shape"] == "flat":
+            mig = apply_migration(dry_run=dry)
+            if args.json:
+                print(json.dumps({"calibration_migration": mig}, ensure_ascii=False, indent=2))
+            else:
+                print(f"[NEXO] calibration migration: {mig.get('status')} — {mig.get('reason','')}",
+                      file=sys.stderr, flush=True)
+
     tier_label = getattr(args, "tier", "boot") or "boot"
     print(f"[NEXO] Inspecting {tier_label} diagnostics... please wait.", file=sys.stderr, flush=True)
     report = run_doctor(tier=args.tier, fix=args.fix, plane=getattr(args, "plane", ""))
@@ -1855,6 +1983,10 @@ def main():
     )
     doctor_parser.add_argument("--json", action="store_true", help="JSON output")
     doctor_parser.add_argument("--fix", action="store_true", help="Apply deterministic fixes")
+    doctor_parser.add_argument("--migrate-calibration", action="store_true",
+                               help="Force calibration.json flat → nested migration")
+    doctor_parser.add_argument("--calibration-dry-run", action="store_true",
+                               help="Preview the calibration migration without writing")
 
     # -- contributor --
     contributor_parser = sub.add_parser("contributor", help="Public Draft PR contribution mode")
@@ -1959,6 +2091,28 @@ def main():
     scan_profile_parser.add_argument("--apply", action="store_true", help="Write profile.json (default is preview)")
     scan_profile_parser.add_argument("--force", action="store_true", help="Overwrite existing profile.json on --apply")
 
+    # -- runtime events bus + operational observability --
+    notify_parser = sub.add_parser("notify", help="Emit an event to the runtime event bus")
+    notify_parser.add_argument("type", choices=[
+        "attention_required", "proactive_message", "followup_alert",
+        "health_alert", "info",
+    ], help="Event type")
+    notify_parser.add_argument("--text", default="", help="Short user-facing message")
+    notify_parser.add_argument("--reason", default="", help="Internal reason / trigger")
+    notify_parser.add_argument("--priority", choices=["low", "normal", "high", "urgent"], default="normal")
+    notify_parser.add_argument("--source", default="nexo-brain", help="Who emitted this event")
+    notify_parser.add_argument("--json", action="store_true", help="JSON output")
+
+    health_parser = sub.add_parser("health", help="Snapshot of NEXO Brain subsystem health")
+    health_parser.add_argument("--json", action="store_true", help="JSON output (default)")
+
+    logs_parser = sub.add_parser("logs", help="Tail recent operational logs")
+    logs_parser.add_argument("--tail", action="store_true", help="Tail mode (default)")
+    logs_parser.add_argument("--lines", type=int, default=100, help="How many lines to return")
+    logs_parser.add_argument("--source", default="all",
+                             help="Log source: all | events | operations | <logname>")
+    logs_parser.add_argument("--json", action="store_true", help="JSON output")
+
     args = parser.parse_args()
 
     if args.help or (not args.command and not args.version):
@@ -2060,6 +2214,12 @@ def main():
             "onboard": cmd_onboard,
             "scan-profile": cmd_scan_profile,
         }[args.command](args)
+    elif args.command == "notify":
+        return _notify(args)
+    elif args.command == "health":
+        return _health(args)
+    elif args.command == "logs":
+        return _logs(args)
     else:
         _print_help()
         return 0

--- a/src/events_bus.py
+++ b/src/events_bus.py
@@ -1,0 +1,155 @@
+"""Runtime events bus — append-only NDJSON stream at ~/.nexo/runtime/events.ndjson.
+
+NEXO Brain writes events that external UIs (NEXO Desktop, mobile, web)
+can tail for real-time attention signals, proactive messages, health
+alerts, and general notifications.
+
+Contract:
+  - One JSON object per line. No multi-line JSON.
+  - Monotonic `id` (integer) and `ts` (unix seconds, float).
+  - Stable event envelope keys: id, ts, type, priority, text, reason,
+    source, extra. Unknown keys are preserved.
+  - File is append-only. Rotation happens at 5 MB: current file is
+    renamed to events-<ts>.ndjson and a fresh empty file is created.
+  - Readers tail the current file; rotation is transparent because the
+    file is reopened after rename detection.
+
+Event types (stable):
+  attention_required  — user should look at something
+  proactive_message   — Brain wants to initiate dialogue
+  followup_alert      — overdue or urgent followup
+  health_alert        — a core system is degraded
+  info                — general update, no attention needed
+
+Priorities: "low" | "normal" | "high" | "urgent"
+"""
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+EVENT_TYPES = {
+    "attention_required",
+    "proactive_message",
+    "followup_alert",
+    "health_alert",
+    "info",
+}
+PRIORITIES = {"low", "normal", "high", "urgent"}
+ROTATION_BYTES = 5 * 1024 * 1024  # 5 MB
+
+
+def _nexo_home() -> Path:
+    return Path(os.environ.get("NEXO_HOME", str(Path.home() / ".nexo")))
+
+
+def events_path() -> Path:
+    return _nexo_home() / "runtime" / "events.ndjson"
+
+
+def _next_id(path: Path) -> int:
+    """Return the next monotonic id by reading the last line's id, or 1."""
+    if not path.is_file():
+        return 1
+    try:
+        # Read last 4 KB — more than enough for the tail line
+        with path.open("rb") as fh:
+            fh.seek(0, os.SEEK_END)
+            size = fh.tell()
+            fh.seek(max(0, size - 4096))
+            tail = fh.read().decode("utf-8", errors="ignore")
+        lines = [ln for ln in tail.splitlines() if ln.strip()]
+        if not lines:
+            return 1
+        last = json.loads(lines[-1])
+        return int(last.get("id", 0)) + 1
+    except Exception:
+        return int(time.time())
+
+
+def _rotate_if_needed(path: Path) -> None:
+    try:
+        if path.is_file() and path.stat().st_size > ROTATION_BYTES:
+            stamp = int(time.time())
+            rotated = path.with_name(f"events-{stamp}.ndjson")
+            path.rename(rotated)
+    except Exception:
+        # Rotation failure is non-fatal; worst case the file grows
+        pass
+
+
+def emit(
+    event_type: str,
+    *,
+    text: str = "",
+    reason: str = "",
+    priority: str = "normal",
+    source: str = "nexo-brain",
+    extra: dict[str, Any] | None = None,
+) -> dict:
+    """Append a new event to the bus. Returns the full event dict."""
+    if event_type not in EVENT_TYPES:
+        raise ValueError(f"unknown event_type: {event_type}")
+    if priority not in PRIORITIES:
+        raise ValueError(f"unknown priority: {priority}")
+
+    path = events_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _rotate_if_needed(path)
+
+    event = {
+        "id": _next_id(path),
+        "ts": time.time(),
+        "type": event_type,
+        "priority": priority,
+        "text": text,
+        "reason": reason,
+        "source": source,
+        "extra": extra or {},
+    }
+
+    line = json.dumps(event, ensure_ascii=False) + "\n"
+    # fcntl flock for cross-process safety on macOS/Linux
+    with path.open("a", encoding="utf-8") as fh:
+        try:
+            fcntl.flock(fh, fcntl.LOCK_EX)
+            fh.write(line)
+            fh.flush()
+        finally:
+            try:
+                fcntl.flock(fh, fcntl.LOCK_UN)
+            except Exception:
+                pass
+
+    return event
+
+
+def tail(lines: int = 50, since_id: int | None = None) -> list[dict]:
+    """Return the most recent events, newest last. Optionally filter by id."""
+    path = events_path()
+    if not path.is_file():
+        return []
+    try:
+        with path.open("r", encoding="utf-8", errors="ignore") as fh:
+            raw = fh.readlines()
+    except Exception:
+        return []
+
+    events: list[dict] = []
+    for ln in raw[-max(lines, 1) * 4:]:  # generous buffer for malformed lines
+        ln = ln.strip()
+        if not ln:
+            continue
+        try:
+            evt = json.loads(ln)
+        except Exception:
+            continue
+        if since_id is not None and int(evt.get("id", 0)) <= since_id:
+            continue
+        events.append(evt)
+
+    return events[-lines:]

--- a/src/health_check.py
+++ b/src/health_check.py
@@ -1,0 +1,195 @@
+"""Health check — one-shot snapshot of NEXO Brain subsystems.
+
+Output is stable JSON consumable by any UI or monitoring tool.
+No side effects, no network, no mutation.
+
+Subsystems reported:
+  - runtime     : NEXO_HOME exists, version.json readable, version string
+  - database    : SQLite reachable, integrity check, basic row counts
+  - crons       : count of active personal LaunchAgents (macOS) or unknown
+  - mcp         : Claude Code MCP config present and mentions nexo-brain
+  - errors      : count of recent errors in ~/.nexo/operations/*.log (24h)
+  - events      : count of events emitted in last 24h
+
+Top-level `status` is "ok" | "degraded" | "error".
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sqlite3
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+
+def _nexo_home() -> Path:
+    return Path(os.environ.get("NEXO_HOME", str(Path.home() / ".nexo")))
+
+
+def _check_runtime() -> dict:
+    home = _nexo_home()
+    ver_file = home / "version.json"
+    out: dict[str, Any] = {"nexo_home": str(home), "exists": home.is_dir()}
+    if ver_file.is_file():
+        try:
+            payload = json.loads(ver_file.read_text())
+            out["version"] = payload.get("version", "unknown")
+        except Exception as exc:
+            out["version"] = "unreadable"
+            out["error"] = str(exc)
+    else:
+        out["version"] = "missing"
+    out["status"] = "ok" if out["exists"] and out.get("version") not in ("missing", "unreadable") else "degraded"
+    return out
+
+
+def _check_database() -> dict:
+    db_path = _nexo_home() / "data" / "nexo.db"
+    out: dict[str, Any] = {"path": str(db_path), "exists": db_path.is_file()}
+    if not out["exists"]:
+        out["status"] = "error"
+        return out
+    try:
+        conn = sqlite3.connect(str(db_path), timeout=2.0)
+        try:
+            cur = conn.execute("PRAGMA integrity_check")
+            row = cur.fetchone()
+            out["integrity"] = row[0] if row else "unknown"
+        finally:
+            conn.close()
+        out["status"] = "ok" if out["integrity"] == "ok" else "degraded"
+    except Exception as exc:
+        out["status"] = "error"
+        out["error"] = str(exc)
+    return out
+
+
+def _check_crons() -> dict:
+    out: dict[str, Any] = {}
+    # macOS LaunchAgents
+    agents_dir = Path.home() / "Library" / "LaunchAgents"
+    if agents_dir.is_dir():
+        try:
+            plists = [p for p in agents_dir.glob("com.nexo.*.plist")]
+            out["launch_agents"] = len(plists)
+            out["platform"] = "macos"
+        except Exception as exc:
+            out["error"] = str(exc)
+    else:
+        out["platform"] = "unknown"
+    out["status"] = "ok"
+    return out
+
+
+def _check_mcp() -> dict:
+    out: dict[str, Any] = {}
+    candidates = [
+        Path.home() / ".claude.json",
+        Path.home() / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json",
+    ]
+    found = []
+    for path in candidates:
+        if not path.is_file():
+            continue
+        try:
+            text = path.read_text(errors="ignore")
+        except Exception:
+            continue
+        if "nexo" in text.lower():
+            found.append(str(path))
+    out["configs_with_nexo"] = found
+    out["status"] = "ok" if found else "degraded"
+    if not found:
+        out["reason"] = "no client config mentions nexo-brain"
+    return out
+
+
+def _check_errors(hours: int = 24) -> dict:
+    ops_dir = _nexo_home() / "operations"
+    out: dict[str, Any] = {"dir": str(ops_dir)}
+    if not ops_dir.is_dir():
+        out["recent_errors"] = 0
+        out["status"] = "ok"
+        return out
+
+    cutoff = time.time() - hours * 3600
+    recent = 0
+    sample: list[str] = []
+    error_re = re.compile(r"(?i)\b(error|traceback|exception|fail(ed)?)\b")
+
+    for log in ops_dir.glob("*.log"):
+        try:
+            if log.stat().st_mtime < cutoff:
+                continue
+            with log.open("r", errors="ignore") as fh:
+                for line in fh:
+                    if error_re.search(line):
+                        recent += 1
+                        if len(sample) < 5:
+                            sample.append(line.strip()[:200])
+        except Exception:
+            continue
+
+    out["recent_errors"] = recent
+    out["sample"] = sample
+    out["status"] = "ok" if recent < 20 else "degraded"
+    return out
+
+
+def _check_events(hours: int = 24) -> dict:
+    events_file = _nexo_home() / "runtime" / "events.ndjson"
+    out: dict[str, Any] = {"path": str(events_file), "exists": events_file.is_file()}
+    if not events_file.is_file():
+        out["recent_events"] = 0
+        out["status"] = "ok"
+        return out
+    cutoff = time.time() - hours * 3600
+    count = 0
+    urgent = 0
+    try:
+        with events_file.open("r", errors="ignore") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    evt = json.loads(line)
+                except Exception:
+                    continue
+                if float(evt.get("ts", 0)) < cutoff:
+                    continue
+                count += 1
+                if evt.get("priority") == "urgent":
+                    urgent += 1
+    except Exception as exc:
+        out["error"] = str(exc)
+    out["recent_events"] = count
+    out["urgent"] = urgent
+    out["status"] = "degraded" if urgent > 0 else "ok"
+    return out
+
+
+def collect() -> dict:
+    """Run every subsystem check and return a unified report."""
+    report: dict[str, Any] = {
+        "ts": time.time(),
+        "subsystems": {
+            "runtime": _check_runtime(),
+            "database": _check_database(),
+            "crons": _check_crons(),
+            "mcp": _check_mcp(),
+            "errors": _check_errors(),
+            "events": _check_events(),
+        },
+    }
+    statuses = [sub.get("status", "unknown") for sub in report["subsystems"].values()]
+    if "error" in statuses:
+        report["status"] = "error"
+    elif "degraded" in statuses:
+        report["status"] = "degraded"
+    else:
+        report["status"] = "ok"
+    return report

--- a/src/user_context.py
+++ b/src/user_context.py
@@ -18,14 +18,32 @@ class UserContext:
         self.user_name = ""
         self.user_language = "en"
 
-        # calibration.json has operator_name + user info
+        # calibration.json has operator_name + user info.
+        # v5.4.0+: tolerate both nested ({user:{name,language}}) and legacy flat
+        # ({user_name, language}) shapes. Nested wins when both exist.
         if cal_path.exists():
             try:
                 cal = json.loads(cal_path.read_text())
-                self.assistant_name = cal.get("operator_name", "") or \
-                    cal.get("user", {}).get("assistant_name", "") or "NEXO"
-                self.user_name = cal.get("user", {}).get("name", "")
-                self.user_language = cal.get("user", {}).get("language", "en")
+                user_block = cal.get("user") if isinstance(cal.get("user"), dict) else {}
+
+                self.assistant_name = (
+                    user_block.get("assistant_name", "")
+                    or cal.get("operator_name", "")
+                    or cal.get("assistant_name", "")
+                    or "NEXO"
+                )
+                self.user_name = (
+                    user_block.get("name", "")
+                    or cal.get("user_name", "")
+                    or cal.get("name", "")
+                    or ""
+                )
+                self.user_language = (
+                    user_block.get("language", "")
+                    or cal.get("language", "")
+                    or cal.get("lang", "")
+                    or "en"
+                )
             except Exception:
                 pass
 


### PR DESCRIPTION
feat: v5.4.0 — runtime events bus, notify/health/logs, calibration migration

Second iteration of NEXO Desktop integration. v5.3.30 let external UIs
read the Brain's schema. v5.4.0 lets them react to live state.

Fase 2 — Calibration migration:
- src/calibration_migration.py — detect + migrate flat -> nested with
  pre-migrate backup and automatic revert on failure. Unknown keys go
  to legacy_unmapped. No-op if already nested.
- src/user_context.py — loader tolerates both shapes.
- nexo doctor --migrate-calibration [--calibration-dry-run] for explicit
  control. nexo doctor --fix runs it implicitly. nexo update runs it
  once per user after the code sync.

Fase 3 — Runtime events bus + notify + health + logs:
- src/events_bus.py — append-only NDJSON at ~/.nexo/runtime/events.ndjson,
  monotonic id, stable envelope {id, ts, type, priority, text, reason,
  source, extra}, 5MB rotation, fcntl-locked writes. Event types:
  attention_required, proactive_message, followup_alert, health_alert,
  info. Priorities: low|normal|high|urgent.
- nexo notify TYPE [--text] [--reason] [--priority] [--source] [--json]
  — one-shot emitter for recovery, followup runner, health watchers.
- src/health_check.py + nexo health --json — runtime, DB integrity,
  crons, MCP wiring, recent errors, events. status rolls up to
  ok|degraded|error.
- nexo logs --tail [--lines N] [--source all|events|operations|NAME]
  [--json] — single entry point for tailing. Desktop can surface
  diagnostics without opening a terminal.

Release surfaces: blog post, README, llms.txt, .well-known/llms.txt,
index.html, blog/index.html, changelog/index.html section v540,
sitemap.xml. Artifacts synced via sync_release_artifacts.py.

No existing commands change behavior. Pure additive surface plus a
reversible migration that runs in the background of update.
