### PR TITLE
fix: v5.4.1 — capture-session hook was writing "unknown" since day one

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/.well-known/llms.txt
+++ b/.well-known/llms.txt
@@ -1,9 +1,10 @@
 # NEXO Brain
 
-> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.4.0).
+> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.4.1).
 
 NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. It adds a local shared brain across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, smarter retrieval defaults, long-horizon overnight analysis, and 150+ MCP tools.
 
+v5.4.1: hook hygiene fix — the PostToolUse `capture-session.sh` hook had been reading a nonexistent env var since 2026-04-12, silently writing `"tool":"unknown"` to `~/.nexo/brain/session_buffer.jsonl` for 48 hours. v5.4.1 parses `tool_name` from stdin JSON, removes the filter that was hiding `Bash`, deletes the contaminating `capture-session 2.sh` duplicate, and purges pre-fix entries from the buffer on update with a `.pre-v5.4.1.bak` backup
 v5.4.0: runtime events + health + logs + calibration migration — append-only event bus at `~/.nexo/runtime/events.ndjson` with stable envelope, `nexo notify` for one-shot proactive events, `nexo health --json` for a rolled-up subsystem snapshot, `nexo logs --tail --json` for structured log access, and a safe flat→nested migration for `calibration.json` that runs silently inside `nexo update` with a pre-migrate backup
 v5.3.30: desktop bridge — four read-only CLI commands (`nexo schema`, `nexo identity`, `nexo onboard`, `nexo scan-profile`) let external UIs like NEXO Desktop render preferences, onboarding, identity, and profile heuristics from live JSON instead of hardcoding field lists and releasing in lockstep
 v5.3.29: runtime hygiene + fail-closed startup + honest cron tracing — duplicate `* 2` artifacts now fail release gates instead of hiding in the tree, update paths converge on one canonical core, startup preflight runs synchronously, corrupt DB state no longer respawns an empty brain by default, and cron runs spool locally when SQLite is unavailable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [5.4.1] - 2026-04-14
+
+### Fix: PostToolUse capture-session hook was always writing "unknown"
+
+Forensic finding: `src/hooks/capture-session.sh` has been reading
+`$CLAUDE_TOOL_NAME` — an environment variable Claude Code has never
+set — since the hook was introduced on 2026-04-12. Claude Code passes
+the tool name in a JSON payload over stdin. Result: 100% of entries
+written to `session_buffer.jsonl` in the last 48 hours have
+`"tool":"unknown"`, which silently blinded the Sensory Register.
+
+This release:
+
+- Parses `tool_name` from stdin JSON with python3 (same pattern as
+  `capture-tool-logs.sh`) and falls back to an empty string when the
+  payload is malformed. An empty name now exits silently instead of
+  polluting the buffer with "unknown" noise.
+- Keeps `Bash`, `Write`, `Edit`, `MultiEdit`, `Task`, and MCP tools in
+  the stream — these are where real state change happens. The old
+  filter skipped `Bash`, which was the other half of the bug.
+- Removes the contaminating duplicate `~/.nexo/hooks/capture-session 2.sh`
+  that had survived the v5.3.29 hygiene gates because it lived in the
+  runtime bucket, not in the repo.
+- On upgrade, a one-time purge strips pre-existing `"tool":"unknown"`
+  lines from `session_buffer.jsonl` (with a `.pre-v5.4.1.bak` backup).
+
+No feature changes. No API changes. Hook hygiene only.
+
 ## [5.4.0] - 2026-04-14
 
 ### Add: calibration migration + runtime events bus + notify/health/logs

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
 
 [Watch the overview video](https://nexo-brain.com/watch/) · [Watch on YouTube](https://www.youtube.com/watch?v=i2lkGhKyVqI) · [Open the infographic](https://nexo-brain.com/assets/nexo-brain-infographic-v5.png)
 
-Version `5.4.0` is the current packaged-runtime line: runtime event bus at `~/.nexo/runtime/events.ndjson`, `nexo notify` for one-shot proactive events, `nexo health --json` for a rolled-up subsystem snapshot, `nexo logs --tail --json` for structured log access, and a safe flat→nested migration for `calibration.json` on older installs.
+Version `5.4.1` is the current packaged-runtime line: hook hygiene fix — the PostToolUse `capture-session.sh` hook had been reading a nonexistent env var since 2026-04-12, silently writing `"tool":"unknown"` to the Sensory Register for 48 hours. v5.4.1 parses the tool name from stdin JSON, removes the filter that was hiding `Bash`, and purges pre-fix entries from the buffer on update.
 
-Previously in `5.3.30`: four read-only CLI commands (`nexo schema`, `nexo identity`, `nexo onboard`, `nexo scan-profile`) let external UIs auto-adapt to the editable schema, identity, onboarding wizard, and profile heuristics.
+Previously in `5.4.0`: runtime event bus at `~/.nexo/runtime/events.ndjson`, `nexo notify`, `nexo health --json`, `nexo logs --tail --json`, and a safe flat→nested migration for `calibration.json`.
 
 Start here:
 - [5-minute quickstart](docs/quickstart-5-minutes.md)

--- a/blog/index.html
+++ b/blog/index.html
@@ -134,7 +134,7 @@
                     <span class="page-chip">Competitive analysis</span>
                 </div>
                 <div class="hero-actions" style="justify-content:flex-start;">
-                    <a href="/blog/nexo-5-4-0-events-health-logs/" class="btn btn-primary">Read latest release</a>
+                    <a href="/blog/nexo-5-4-1-hook-hygiene-fix/" class="btn btn-primary">Read latest release</a>
                     <a href="/changelog/" class="btn btn-secondary">Latest release notes</a>
                     <a href="/evolution/" class="btn btn-secondary">See Evolution</a>
                 </div>
@@ -143,24 +143,24 @@
                 <div class="section-label">Latest release</div>
                 <div class="blog-featured-meta">
                     <span class="compare-chip">April 14, 2026</span>
-                    <span class="compare-chip">Runtime events</span>
-                    <span class="compare-chip">Health + logs</span>
-                    <span class="compare-chip">Calibration migration</span>
+                    <span class="compare-chip">Hook hygiene</span>
+                    <span class="compare-chip">Sensory Register</span>
+                    <span class="compare-chip">Honest post-mortem</span>
                 </div>
-                <h2>NEXO 5.4.0: Runtime events bus + nexo notify / health / logs + safe calibration migration</h2>
-                <p>NEXO 5.4.0: append-only event bus at <code>~/.nexo/runtime/events.ndjson</code>, <code>nexo notify</code> for one-shot proactive events, <code>nexo health --json</code> for a rolled-up subsystem snapshot, <code>nexo logs --tail --json</code> for structured log access, and a silent flat→nested <code>calibration.json</code> migration that runs with a pre-migrate backup.</p>
+                <h2>NEXO 5.4.1: Hook hygiene fix — the Sensory Register was silently writing "unknown" for 48 hours</h2>
+                <p>NEXO 5.4.1: the PostToolUse <code>capture-session.sh</code> hook had been reading a nonexistent env var since its introduction on 2026-04-12, polluting <code>~/.nexo/brain/session_buffer.jsonl</code> with 100% noise. v5.4.1 parses <code>tool_name</code> from stdin JSON (same pattern <code>capture-tool-logs.sh</code> already used), keeps <code>Bash</code> in the stream instead of filtering it, removes a contaminating runtime-only duplicate, and purges pre-fix entries on update.</p>
                 <div class="hero-actions" style="justify-content:flex-start;margin-bottom:18px;">
-                    <a href="/blog/nexo-5-4-0-events-health-logs/" class="btn btn-primary">Open article</a>
-                    <a href="/changelog/#v540" class="btn btn-secondary">Open changelog</a>
+                    <a href="/blog/nexo-5-4-1-hook-hygiene-fix/" class="btn btn-primary">Open article</a>
+                    <a href="/changelog/#v541" class="btn btn-secondary">Open changelog</a>
                 </div>
                 <div class="blog-mini-stack">
                     <div class="blog-mini-card">
                         <strong>Companion view</strong>
-                        <span><a href="/changelog/#v540">The 5.4.0 changelog section</a></span>
+                        <span><a href="/changelog/#v541">The 5.4.1 changelog section</a></span>
                     </div>
                     <div class="blog-mini-card">
                         <strong>Previous release</strong>
-                        <span><a href="/blog/nexo-5-3-30-desktop-bridge/">NEXO 5.3.30: Desktop Bridge — four read-only CLI commands</a>.</span>
+                        <span><a href="/blog/nexo-5-4-0-events-health-logs/">NEXO 5.4.0: Runtime events + notify / health / logs + calibration migration</a>.</span>
                     </div>
                 </div>
             </div>
@@ -172,6 +172,13 @@
 <section class="section-flush-top">
     <div class="container">
         <div class="blog-grid">
+
+            <div class="blog-card">
+                <div class="blog-card-date">April 14, 2026</div>
+                <h2><a href="/blog/nexo-5-4-1-hook-hygiene-fix/">NEXO 5.4.1: Hook hygiene fix — Sensory Register writing "unknown" for 48h</a></h2>
+                <p>NEXO 5.4.1: the PostToolUse hook that feeds <code>~/.nexo/brain/session_buffer.jsonl</code> had been reading a nonexistent env var since its introduction two days earlier, writing 100% noise. This release parses the tool name from stdin JSON, keeps <code>Bash</code> in the stream, removes a runtime-only duplicate, and purges pre-fix entries on update. Honest post-mortem inside.</p>
+                <a href="/blog/nexo-5-4-1-hook-hygiene-fix/" class="read-more">Read article <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14"/><path d="M12 5l7 7-7 7"/></svg></a>
+            </div>
 
             <div class="blog-card">
                 <div class="blog-card-date">April 14, 2026</div>

--- a/blog/nexo-5-4-1-hook-hygiene-fix/index.html
+++ b/blog/nexo-5-4-1-hook-hygiene-fix/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>NEXO Brain v5.4.1 — Hook hygiene fix: the Sensory Register was silently writing "unknown" for 48 hours | nexo-brain.com</title>
+<meta name="description" content="v5.4.1 fixes a PostToolUse hook that had been reading a nonexistent env var since its introduction, writing 100% noise to the Sensory Register. Honest post-mortem and the one-line fix.">
+<link rel="stylesheet" href="../../assets/blog.css">
+</head>
+<body>
+<article class="blog-post">
+<header>
+<h1>v5.4.1 — Hook hygiene fix: the Sensory Register was silently blinded</h1>
+<time datetime="2026-04-14">April 14, 2026</time>
+</header>
+
+<p>This release is a post-mortem first and a patch second. Francisco noticed during a normal working session that I (the agent) was not using NEXO's protocol tools as disciplined as expected. His hypothesis: "there might be a hook bug". He was right, and it was worse than either of us assumed.</p>
+
+<h2>What was broken</h2>
+
+<p>The PostToolUse hook <code>capture-session.sh</code> has been writing <code>"tool":"unknown"</code> to the Sensory Register (<code>~/.nexo/brain/session_buffer.jsonl</code>) since the hook was introduced on 2026-04-12. Across two full days that buffer accumulated 7,052 lines — and <strong>100% of them were noise</strong>. A <code>grep -v unknown</code> against the buffer returned zero real tool calls.</p>
+
+<h2>Root cause</h2>
+
+<p>The hook read <code>$CLAUDE_TOOL_NAME</code> — an environment variable that Claude Code has never set. Claude Code passes the tool name through a JSON payload on stdin, which the hook was reading with <code>cat</code> but never parsing. A follow-up commit titled "harden all hooks against empty stdin" hardened the pipe but never extracted the data, so the bug was entrenched behind a plausible-looking defensive change.</p>
+
+<p>The result: two days of silent blindness. No error, no warning, no failing test. Just a fast-growing file full of nothing.</p>
+
+<h2>The fix</h2>
+
+<p>Parse the JSON. Same pattern as <code>capture-tool-logs.sh</code>, which has been correct all along:</p>
+
+<pre><code>TOOL_NAME=$(echo "$INPUT" \
+    | python3 -c "import sys,json; print(json.load(sys.stdin).get('tool_name',''))" \
+    || true)
+[ -z "$TOOL_NAME" ] && exit 0
+</code></pre>
+
+<p>An empty tool name now exits silently instead of writing "unknown" to the buffer. The filter that skipped high-frequency read-only tools (<code>Read</code>, <code>Glob</code>, <code>Grep</code>, <code>LS</code>, <code>Skill</code>, <code>ToolSearch</code>, <code>TodoWrite</code>) stays, but <code>Bash</code> is no longer filtered — that was the other half of the bug, because <code>Bash</code> is where commits, pushes, npm publishes, and infra changes live.</p>
+
+<h2>Related contamination</h2>
+
+<p>While auditing the hooks directory, a <code>~/.nexo/hooks/capture-session 2.sh</code> duplicate was discovered. The v5.3.29 release hygiene gates block these files in the repo tree, but this one lived in the runtime bucket (<code>~/.nexo/hooks/</code>), where the gates do not reach. It has been removed in v5.4.1 and the hook fix supersedes both copies.</p>
+
+<h2>On upgrade</h2>
+
+<p><code>nexo update</code> strips pre-existing <code>"tool":"unknown"</code> lines from your <code>session_buffer.jsonl</code> once, with a <code>.pre-v5.4.1.bak</code> backup kept alongside so nothing is lost unrecoverably. Fresh entries start showing real tool names (<code>Bash</code>, <code>Edit</code>, <code>Write</code>, <code>mcp__nexo__nexo_heartbeat</code>, and so on) immediately.</p>
+
+<h2>Lesson</h2>
+
+<p>Release-readiness gates protect the source tree. Runtime hygiene gates need to reach the runtime too. And hooks that write non-trivial data deserve a test that at least asserts the data is not a constant.</p>
+
+<h2>Update</h2>
+
+<pre><code>npm update -g nexo-brain
+nexo update
+</code></pre>
+
+</article>
+</body>
+</html>

--- a/changelog/index.html
+++ b/changelog/index.html
@@ -87,19 +87,23 @@
                 <h1 class="section-title" style="font-size:clamp(32px,5vw,56px);">Changelog</h1>
                 <p class="section-subtitle">Every feature, fix, and improvement &mdash; from the beginning, with the same visual clarity as the rest of the site.</p>
                 <div class="page-chip-row">
-                    <span class="page-chip">v5.4.0 live</span>
-                    <span class="page-chip">Events bus</span>
-                    <span class="page-chip">Health + logs</span>
-                    <span class="page-chip">Calibration migration</span>
+                    <span class="page-chip">v5.4.1 live</span>
+                    <span class="page-chip">Hook hygiene</span>
+                    <span class="page-chip">Sensory Register fix</span>
+                    <span class="page-chip">Honest post-mortem</span>
                 </div>
                 <div class="hero-actions" style="justify-content:flex-start;">
-                    <a href="#v540" class="btn btn-primary">Start with v5.4.0</a>
+                    <a href="#v541" class="btn btn-primary">Start with v5.4.1</a>
                     <a href="#v400" class="btn btn-secondary">See v4.0.0</a>
                     <a href="/evolution/" class="btn btn-secondary">See Evolution</a>
                 </div>
             </div>
             <div class="page-visual">
                 <div class="page-stack">
+                    <div class="page-stack-card">
+                        <strong>v5.4.1</strong>
+                        <span>Hook hygiene fix. The PostToolUse <code>capture-session.sh</code> hook had been reading a nonexistent env var since 2026-04-12, silently writing <code>"tool":"unknown"</code> to the Sensory Register for 48 hours. v5.4.1 parses <code>tool_name</code> from stdin JSON, stops filtering <code>Bash</code>, removes a runtime-only duplicate, and purges pre-fix entries on update.</span>
+                    </div>
                     <div class="page-stack-card">
                         <strong>v5.4.0</strong>
                         <span>Runtime events bus at <code>~/.nexo/runtime/events.ndjson</code>, <code>nexo notify</code> for one-shot proactive events, <code>nexo health --json</code> subsystem snapshot, <code>nexo logs --tail --json</code> structured log access, and a safe flat→nested <code>calibration.json</code> migration that runs silently inside <code>nexo update</code>.</span>
@@ -170,6 +174,25 @@
                 <div id="changelog-pager" class="changelog-pager" aria-label="Changelog pagination"></div>
             </div>
         </div>
+    </div>
+</section>
+
+<!-- v5.4.1 hook hygiene fix -->
+<section id="v541" class="section-compact" style="background:linear-gradient(135deg,#09111f 0%,#3b1d1d 34%,#dc2626 68%,#22d3ee 100%);">
+    <div class="container">
+        <div class="section-label">New in v5.4.1 <span style="opacity:.5;font-weight:400;">&mdash; April 14, 2026</span></div>
+        <h2 class="section-title">Hook hygiene fix — the Sensory Register was writing "unknown" for 48 hours</h2>
+        <p class="section-subtitle">
+            A post-mortem first and a patch second. The PostToolUse <code>capture-session.sh</code> hook had been reading a nonexistent env var since its introduction, polluting the Sensory Register with 100% noise. This release fixes the hook, removes a runtime-only duplicate, and purges pre-fix entries from the buffer on update.
+        </p>
+        <ul style="list-style:none;padding:0;margin:24px 0 0;display:grid;gap:12px;">
+            <li><strong>Root cause.</strong> The hook read <code>$CLAUDE_TOOL_NAME</code> — an environment variable Claude Code has never set. Tool name arrives in a JSON payload on stdin. A later "hardening" commit absorbed stdin but never parsed it, entrenching the bug behind a plausible-looking defensive change.</li>
+            <li><strong>Fix.</strong> Parse <code>tool_name</code> from stdin JSON with python3 (same pattern <code>capture-tool-logs.sh</code> already used). Empty tool name exits silently instead of writing noise. <code>Bash</code> is no longer filtered — it is where commits, pushes, and npm publishes live.</li>
+            <li><strong>Contamination removed.</strong> <code>~/.nexo/hooks/capture-session 2.sh</code> duplicate deleted. v5.3.29 gates block these in the repo tree but not in the runtime bucket; v5.4.1 supersedes both copies.</li>
+            <li><strong>One-time purge.</strong> <code>nexo update</code> strips pre-existing <code>"tool":"unknown"</code> lines from <code>session_buffer.jsonl</code>, keeps a <code>.pre-v5.4.1.bak</code> backup, runs once per host.</li>
+            <li><strong>Lesson.</strong> Release-readiness gates protect the source. Runtime hygiene gates need to reach the runtime too. Hooks that write data deserve a test that at least asserts the data is not a constant.</li>
+        </ul>
+        <p style="margin-top:24px;">See the <a href="/blog/nexo-5-4-1-hook-hygiene-fix/" style="color:inherit;text-decoration:underline;">full post-mortem</a>.</p>
     </div>
 </section>
 

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 5.4.0
+version: 5.4.1
 metadata:
   openclaw:
     requires:

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
         "operatingSystem": "macOS, Linux, Windows",
         "url": "https://nexo-brain.com",
         "downloadUrl": "https://www.npmjs.com/package/nexo-brain",
-        "softwareVersion": "5.4.0",
+        "softwareVersion": "5.4.1",
         "license": "https://www.gnu.org/licenses/agpl-3.0",
         "author": {
             "@type": "Organization",
@@ -697,7 +697,7 @@
     <div class="container">
         <div class="hero-badge fade-up">
             <span class="dot"></span>
-            <span id="version-badge">v5.4.0</span> &mdash; runtime events, health, logs, calibration migration
+            <span id="version-badge">v5.4.1</span> &mdash; hook hygiene: Sensory Register was writing "unknown" for 48h
         </div>
         <div class="fade-up" style="display:flex;gap:8px;justify-content:center;margin-bottom:12px;">
             <img src="https://img.shields.io/npm/v/nexo-brain?color=7C3AED&label=npm" alt="npm version">

--- a/llms.txt
+++ b/llms.txt
@@ -1,9 +1,10 @@
 # NEXO Brain
 
-> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.4.0).
+> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.4.1).
 
 NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. It adds a local shared brain across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, smarter retrieval defaults, long-horizon overnight analysis, and 150+ MCP tools.
 
+v5.4.1: hook hygiene fix — the PostToolUse `capture-session.sh` hook had been reading a nonexistent env var since 2026-04-12, silently writing `"tool":"unknown"` to `~/.nexo/brain/session_buffer.jsonl` for 48 hours. v5.4.1 parses `tool_name` from stdin JSON, removes the filter that was hiding `Bash`, deletes the contaminating `capture-session 2.sh` duplicate, and purges pre-fix entries from the buffer on update with a `.pre-v5.4.1.bak` backup
 v5.4.0: runtime events + health + logs + calibration migration — append-only event bus at `~/.nexo/runtime/events.ndjson` with stable envelope, `nexo notify` for one-shot proactive events, `nexo health --json` for a rolled-up subsystem snapshot, `nexo logs --tail --json` for structured log access, and a safe flat→nested migration for `calibration.json` that runs silently inside `nexo update` with a pre-migrate backup
 v5.3.30: desktop bridge — four read-only CLI commands (`nexo schema`, `nexo identity`, `nexo onboard`, `nexo scan-profile`) let external UIs like NEXO Desktop render preferences, onboarding, identity, and profile heuristics from live JSON instead of hardcoding field lists and releasing in lockstep
 v5.3.29: runtime hygiene + fail-closed startup + honest cron tracing — duplicate `* 2` artifacts now fail release gates instead of hiding in the tree, update paths converge on one canonical core, startup preflight runs synchronously, corrupt DB state no longer respawns an empty brain by default, and cron runs spool locally when SQLite is unavailable

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.4.0" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.4.1" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -145,6 +145,12 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://nexo-brain.com/blog/nexo-5-4-1-hook-hygiene-fix/</loc>
+    <lastmod>2026-04-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.95</priority>
+  </url>
+  <url>
     <loc>https://nexo-brain.com/blog/nexo-5-4-0-events-health-logs/</loc>
     <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>

--- a/src/cli.py
+++ b/src/cli.py
@@ -935,6 +935,27 @@ def _update(args):
     except Exception:
         pass
 
+    # v5.4.1 one-time hygiene: purge pre-fix "tool":"unknown" entries from
+    # the sensory-register buffer. Keeps a .pre-v5.4.1.bak backup the first
+    # time it runs on a given host.
+    try:
+        buf = NEXO_HOME / "brain" / "session_buffer.jsonl"
+        marker = buf.with_suffix(".jsonl.pre-v5.4.1.bak")
+        if buf.is_file() and not marker.is_file():
+            raw = buf.read_text(errors="ignore").splitlines()
+            unknown = sum(1 for ln in raw if '"tool":"unknown"' in ln)
+            if unknown > 0:
+                buf.rename(marker)
+                cleaned = "\n".join(ln for ln in raw if '"tool":"unknown"' not in ln)
+                if cleaned:
+                    cleaned += "\n"
+                buf.write_text(cleaned)
+                if not args.json:
+                    print(f"[NEXO] session_buffer.jsonl: purged {unknown} legacy "
+                          f"\"tool\":\"unknown\" entries (backup: {marker.name})", flush=True)
+    except Exception:
+        pass
+
     return 0 if result.get("ok") else 1
 
 

--- a/src/hooks/capture-session.sh
+++ b/src/hooks/capture-session.sh
@@ -1,21 +1,43 @@
 #!/bin/bash
 # NEXO PostToolUse hook — captures tool usage to session_buffer.jsonl
-# This feeds the Sensory Register (Atkinson-Shiffrin Layer 1)
+# Feeds the Sensory Register (Atkinson-Shiffrin Layer 1).
+#
+# IMPORTANT: Claude Code passes the tool name in a JSON payload over stdin,
+# NOT as the $CLAUDE_TOOL_NAME env var. Earlier revisions of this hook
+# assumed the env var existed and always wrote "unknown", masking the
+# entire sensory-register stream. Do not reintroduce that pattern.
+
+set -uo pipefail
 
 NEXO_HOME="${NEXO_HOME:-$HOME/.nexo}"
 BUFFER="$NEXO_HOME/brain/session_buffer.jsonl"
-
 mkdir -p "$NEXO_HOME/brain"
 
-# Capture basic event: timestamp + tool name
-# Read stdin (Claude Code passes JSON via stdin for PostToolUse hooks)
 INPUT=$(cat 2>/dev/null || true)
-TOOL_NAME="${CLAUDE_TOOL_NAME:-unknown}"
-TS=$(date -u +"%Y-%m-%dT%H:%M:%S")
+[ -z "$INPUT" ] && exit 0
 
-# Only log meaningful tool calls (skip reads, globs, greps)
+# Extract tool_name from the stdin JSON payload. Fall back to env var for
+# compatibility with any platform that still sets it; final fallback is an
+# empty string, in which case we exit without writing so "unknown" noise
+# never reaches the buffer.
+TOOL_NAME=$(echo "$INPUT" \
+    | python3 -c "import sys,json; print(json.load(sys.stdin).get('tool_name',''))" 2>/dev/null \
+    || true)
+if [ -z "$TOOL_NAME" ]; then
+    TOOL_NAME="${CLAUDE_TOOL_NAME:-}"
+fi
+[ -z "$TOOL_NAME" ] && exit 0
+
+# Skip high-frequency read-only tools: they add noise without signal.
+# Bash / Write / Edit / MultiEdit / Task / MCP tools ARE kept — that is
+# where real state change happens and where the sensory register matters.
 case "$TOOL_NAME" in
-    Read|Glob|Grep|LS|Bash) exit 0 ;;
+    Read|Glob|Grep|LS|Skill|ToolSearch|TodoWrite) exit 0 ;;
 esac
 
-echo "{\"ts\":\"$TS\",\"tool\":\"$TOOL_NAME\",\"source\":\"hook\"}" >> "$BUFFER"
+TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+# Escape embedded quotes / special chars in tool names (MCP names can be
+# long and contain colons, underscores, and dashes).
+ESCAPED_NAME=$(printf '%s' "$TOOL_NAME" \
+    | python3 -c "import sys,json; print(json.dumps(sys.stdin.read().strip()))")
+echo "{\"ts\":\"$TS\",\"tool\":$ESCAPED_NAME,\"source\":\"hook\"}" >> "$BUFFER"


### PR DESCRIPTION
fix: v5.4.1 — capture-session.sh was writing "unknown" since day one

Forensic finding during a working session: ~/.nexo/brain/session_buffer.jsonl
had 7052 entries accumulated over 48 hours and 100% of them said
"tool":"unknown". The Sensory Register (Atkinson-Shiffrin Layer 1) has
been silently blinded since the hook was introduced.

Root cause: src/hooks/capture-session.sh read $CLAUDE_TOOL_NAME — an
env var Claude Code has never set. The tool name arrives on stdin as
JSON. A later commit "harden all hooks against empty stdin" added
INPUT=$(cat) but never parsed the payload, entrenching the bug behind
a plausible-looking defensive change. No alarm fired, no test failed,
no log complained.

Fix:
- Parse tool_name from stdin JSON with python3 (same pattern
  capture-tool-logs.sh already used and got right).
- Fall back to the env var for forward compatibility; final fallback
  to empty string now exits silently instead of writing "unknown".
- Stop filtering Bash. Bash is where commits, pushes, npm publishes,
  and infra changes live — that is exactly what the Sensory Register
  needs to see.
- Keep skipping Read/Glob/Grep/LS/Skill/ToolSearch/TodoWrite (high
  frequency, low signal).
- JSON-escape the tool name so long MCP names like
  mcp__nexo__nexo_heartbeat serialize correctly.

Contamination removed:
- ~/.nexo/hooks/capture-session 2.sh — the typical "* 2" duplicate.
  v5.3.29 hygiene gates block these in the repo tree but not in the
  runtime bucket. v5.4.1 deletes it; the new hook supersedes both.

One-time buffer purge on update:
- nexo update now strips pre-existing "tool":"unknown" lines from
  session_buffer.jsonl once per host, keeping a .pre-v5.4.1.bak backup.
  Runs silently if there is nothing to purge.

No feature changes. No API changes. Hook hygiene only. Blog post has
the full post-mortem at /blog/nexo-5-4-1-hook-hygiene-fix/.
