### PR TITLE
fix: v5.4.2 traceability truth and buffer close-loop

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.4.1",
+  "version": "5.4.2",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## [5.4.2] - 2026-04-14
+
+### Fix: traceability truth + Sensory Register buffer close-loop
+
+This release closes two low-level integrity gaps around the Sensory Register
+without changing the product boundary or removing any Claude/Opus/Codex-assisted
+path.
+
+- `src/plugins/episodic_memory.py` now distinguishes repo-tracked changes from
+  local/runtime/server-side operations when warning about missing
+  `commit_ref`. The diary warning no longer inflates every operational edit into
+  "repo debt", and `handle_change_log` now tells callers to use a real git hash
+  only for repo files while allowing markers such as `server-direct` or
+  `local-uncommitted` for local-side changes.
+- `src/scripts/nexo-postmortem-consolidator.py` now treats
+  `session_buffer.jsonl` as a real pending queue: it renders useful hook/tool
+  activity into the Sensory Register, processes all pending entries instead of
+  only "today", and prunes only the lines that were actually ingested.
+- The postmortem consumer now rewrites `session_buffer.jsonl` atomically, so a
+  partial write cannot leave the pending-event queue truncated.
+- Public and internal docs are aligned again: the README and
+  `nexo-reflection.py` no longer describe the stop hook as if it auto-triggered
+  the standalone reflection engine.
+- Added regression coverage for repo-vs-local `commit_ref` classification and
+  for pending-buffer ingestion/pruning in the postmortem consolidator.
+
+No feature removals. No model-path downgrade. Claude/Opus-assisted
+consolidation stays intact; this patch only hardens the mechanical loop around
+it.
+
 ## [5.4.1] - 2026-04-14
 
 ### Fix: PostToolUse capture-session hook was always writing "unknown"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [Watch the overview video](https://nexo-brain.com/watch/) · [Watch on YouTube](https://www.youtube.com/watch?v=i2lkGhKyVqI) · [Open the infographic](https://nexo-brain.com/assets/nexo-brain-infographic-v5.png)
 
-Version `5.4.1` is the current packaged-runtime line: hook hygiene fix — the PostToolUse `capture-session.sh` hook had been reading a nonexistent env var since 2026-04-12, silently writing `"tool":"unknown"` to the Sensory Register for 48 hours. v5.4.1 parses the tool name from stdin JSON, removes the filter that was hiding `Bash`, and purges pre-fix entries from the buffer on update.
+Version `5.4.2` is the current packaged-runtime line: traceability truth + Sensory Register buffer close-loop — release warnings now distinguish repo `commit_ref` debt from local/server-side operational changes, the nocturnal postmortem drains pending `session_buffer.jsonl` events and rewrites the buffer atomically, and docs now state honestly that `nexo-reflection.py` is standalone rather than auto-triggered by the stop hook.
 
 Previously in `5.4.0`: runtime event bus at `~/.nexo/runtime/events.ndjson`, `nexo notify`, `nexo health --json`, `nexo logs --tail --json`, and a safe flat→nested migration for `calibration.json`.
 

--- a/README.md
+++ b/README.md
@@ -630,20 +630,21 @@ PreCompact hook saves full checkpoint if conversation is compressed
     ↓
 PostCompact hook re-injects Core Memory Block → session continues seamlessly
     ↓
-Stop hook triggers mandatory post-mortem:
-  - Self-critique: 5 questions about what could be better
-  - Session buffer: structured entry for the reflection engine
-  - Followups: anything promised gets scheduled
-  - Proactive seeds: what can the next session do without being asked?
+Stop hook refreshes the diary draft and approves immediately:
+  - Latest changes and decisions stay attached to the active session
+  - Session buffer keeps structured tool activity for downstream processing
+  - Followups and closing synthesis happen inline when the agent detects real closing intent
+  - No mid-conversation blocking from the hook itself
     ↓
-Reflection engine processes buffer (after 3+ sessions)
+Nocturnal post-mortem consolidator processes the buffer mechanically
     ↓
 Nocturnal processes: decay, consolidation, self-audit, dreaming
 ```
 
 ### Reflection Engine
 
-After 3+ sessions accumulate, the stop hook triggers `nexo-reflection.py`:
+NEXO still ships `nexo-reflection.py` as a standalone analyzer for `session_buffer.jsonl`.
+It is not currently auto-triggered by the stop hook:
 - Extracts recurring tasks, error patterns, mood trends
 - Updates `user_model.json` with observed behavior
 - No LLM required — runs as pure Python

--- a/blog/index.html
+++ b/blog/index.html
@@ -134,7 +134,7 @@
                     <span class="page-chip">Competitive analysis</span>
                 </div>
                 <div class="hero-actions" style="justify-content:flex-start;">
-                    <a href="/blog/nexo-5-4-1-hook-hygiene-fix/" class="btn btn-primary">Read latest release</a>
+                    <a href="/blog/nexo-5-4-2-traceability-and-buffer-close-loop/" class="btn btn-primary">Read latest release</a>
                     <a href="/changelog/" class="btn btn-secondary">Latest release notes</a>
                     <a href="/evolution/" class="btn btn-secondary">See Evolution</a>
                 </div>
@@ -143,24 +143,24 @@
                 <div class="section-label">Latest release</div>
                 <div class="blog-featured-meta">
                     <span class="compare-chip">April 14, 2026</span>
-                    <span class="compare-chip">Hook hygiene</span>
+                    <span class="compare-chip">Traceability truth</span>
                     <span class="compare-chip">Sensory Register</span>
-                    <span class="compare-chip">Honest post-mortem</span>
+                    <span class="compare-chip">Close-loop</span>
                 </div>
-                <h2>NEXO 5.4.1: Hook hygiene fix — the Sensory Register was silently writing "unknown" for 48 hours</h2>
-                <p>NEXO 5.4.1: the PostToolUse <code>capture-session.sh</code> hook had been reading a nonexistent env var since its introduction on 2026-04-12, polluting <code>~/.nexo/brain/session_buffer.jsonl</code> with 100% noise. v5.4.1 parses <code>tool_name</code> from stdin JSON (same pattern <code>capture-tool-logs.sh</code> already used), keeps <code>Bash</code> in the stream instead of filtering it, removes a contaminating runtime-only duplicate, and purges pre-fix entries on update.</p>
+                <h2>NEXO 5.4.2: Traceability truth + Sensory Register buffer close-loop</h2>
+                <p>NEXO 5.4.2 stops inflating local/runtime operations into fake repo <code>commit_ref</code> debt, drains pending <code>session_buffer.jsonl</code> events through the nocturnal postmortem instead of looking only at "today", rewrites the buffer atomically, and aligns docs with the real stop-hook / reflection boundary. No Claude/Opus-assisted path was removed.</p>
                 <div class="hero-actions" style="justify-content:flex-start;margin-bottom:18px;">
-                    <a href="/blog/nexo-5-4-1-hook-hygiene-fix/" class="btn btn-primary">Open article</a>
-                    <a href="/changelog/#v541" class="btn btn-secondary">Open changelog</a>
+                    <a href="/blog/nexo-5-4-2-traceability-and-buffer-close-loop/" class="btn btn-primary">Open article</a>
+                    <a href="/changelog/#v542" class="btn btn-secondary">Open changelog</a>
                 </div>
                 <div class="blog-mini-stack">
                     <div class="blog-mini-card">
                         <strong>Companion view</strong>
-                        <span><a href="/changelog/#v541">The 5.4.1 changelog section</a></span>
+                        <span><a href="/changelog/#v542">The 5.4.2 changelog section</a></span>
                     </div>
                     <div class="blog-mini-card">
                         <strong>Previous release</strong>
-                        <span><a href="/blog/nexo-5-4-0-events-health-logs/">NEXO 5.4.0: Runtime events + notify / health / logs + calibration migration</a>.</span>
+                        <span><a href="/blog/nexo-5-4-1-hook-hygiene-fix/">NEXO 5.4.1: Hook hygiene fix — Sensory Register writing "unknown" for 48h</a>.</span>
                     </div>
                 </div>
             </div>
@@ -172,6 +172,13 @@
 <section class="section-flush-top">
     <div class="container">
         <div class="blog-grid">
+
+            <div class="blog-card">
+                <div class="blog-card-date">April 14, 2026</div>
+                <h2><a href="/blog/nexo-5-4-2-traceability-and-buffer-close-loop/">NEXO 5.4.2: Traceability truth + Sensory Register buffer close-loop</a></h2>
+                <p>NEXO 5.4.2 stops treating every local/runtime operation as fake repo <code>commit_ref</code> debt, lets the nocturnal postmortem drain pending <code>session_buffer.jsonl</code> events as a real queue, rewrites the buffer atomically, and aligns the docs with the real stop-hook / reflection boundary. No downgrade of the Claude/Opus-assisted layer.</p>
+                <a href="/blog/nexo-5-4-2-traceability-and-buffer-close-loop/" class="read-more">Read article <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14"/><path d="M12 5l7 7-7 7"/></svg></a>
+            </div>
 
             <div class="blog-card">
                 <div class="blog-card-date">April 14, 2026</div>

--- a/blog/nexo-5-4-2-traceability-and-buffer-close-loop/index.html
+++ b/blog/nexo-5-4-2-traceability-and-buffer-close-loop/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>NEXO Brain v5.4.2 — Traceability truth + Sensory Register buffer close-loop | nexo-brain.com</title>
+<meta name="description" content="v5.4.2 stops inflating local/runtime operations into fake repo commit debt, drains pending session_buffer events through the nocturnal postmortem, rewrites the buffer atomically, and aligns the docs with the real hook/runtime boundary.">
+<link rel="stylesheet" href="../../assets/blog.css">
+</head>
+<body>
+<article class="blog-post">
+<header>
+<h1>v5.4.2 — Traceability truth + Sensory Register buffer close-loop</h1>
+<time datetime="2026-04-14">April 14, 2026</time>
+</header>
+
+<p>This release is about making the low-level truth match the story again. It does not remove any Claude/Opus/Codex-assisted path. It hardens the mechanical layer around that assisted intelligence so warnings, queues, and docs stop lying by accident.</p>
+
+<h2>What was misleading</h2>
+
+<p>The diary warning for missing <code>commit_ref</code> was counting too much. Repo edits, local runtime writes, server-side operations, and other out-of-band changes were all being collapsed into one scary number. That made the release traceability signal noisier than the underlying reality.</p>
+
+<p>At the same time, <code>session_buffer.jsonl</code> was behaving more like a leaky bucket than a queue: the nocturnal postmortem only looked at "today", ignored older pending events, and did not actually prune the lines it had already consumed.</p>
+
+<h2>What changed in v5.4.2</h2>
+
+<ul>
+<li><strong>Traceability warnings are honest again.</strong> Repo-tracked files still require a real git hash. Local/runtime/server-side operations can now be recorded with explicit markers such as <code>server-direct</code> or <code>local-uncommitted</code> instead of being treated as if they were missing repo commits.</li>
+<li><strong>The Sensory Register buffer now closes its loop.</strong> The nocturnal postmortem consumes pending events from <code>session_buffer.jsonl</code>, renders useful hook/tool activity into the Sensory Register, and removes only the lines that were actually ingested.</li>
+<li><strong>Pending means pending, not "today only".</strong> If an event stayed in the buffer from an earlier run, it no longer gets stranded forever just because the calendar day changed.</li>
+<li><strong>Buffer rewrite is atomic.</strong> The queue is now rewritten through a temp file + replace step so a partial write cannot leave the file truncated mid-drain.</li>
+<li><strong>Docs now describe the real boundary.</strong> README and the reflection script both say plainly that <code>nexo-reflection.py</code> is a standalone analyzer, not something the stop hook auto-triggers today.</li>
+</ul>
+
+<h2>What did not change</h2>
+
+<p>The assisted layer stays. Nightly consolidation can still use Claude/Opus/Codex-backed intelligence where the product expects it. This patch does not replace that with "dumb Python". It only makes the purely mechanical edges more trustworthy.</p>
+
+<h2>Why this matters</h2>
+
+<p>Shared-brain systems degrade when low-level evidence becomes noisy. A warning that overcounts debt teaches the operator to ignore warnings. A queue that never quite drains teaches the operator to distrust the memory pipeline. A doc that describes an old trigger path teaches the next session the wrong architecture. v5.4.2 closes those gaps without changing the higher-level product promise.</p>
+
+<h2>Update</h2>
+
+<pre><code>npm update -g nexo-brain
+nexo update
+</code></pre>
+
+</article>
+</body>
+</html>

--- a/changelog/index.html
+++ b/changelog/index.html
@@ -87,19 +87,23 @@
                 <h1 class="section-title" style="font-size:clamp(32px,5vw,56px);">Changelog</h1>
                 <p class="section-subtitle">Every feature, fix, and improvement &mdash; from the beginning, with the same visual clarity as the rest of the site.</p>
                 <div class="page-chip-row">
-                    <span class="page-chip">v5.4.1 live</span>
-                    <span class="page-chip">Hook hygiene</span>
-                    <span class="page-chip">Sensory Register fix</span>
-                    <span class="page-chip">Honest post-mortem</span>
+                    <span class="page-chip">v5.4.2 live</span>
+                    <span class="page-chip">Traceability truth</span>
+                    <span class="page-chip">Sensory Register close-loop</span>
+                    <span class="page-chip">Doc alignment</span>
                 </div>
                 <div class="hero-actions" style="justify-content:flex-start;">
-                    <a href="#v541" class="btn btn-primary">Start with v5.4.1</a>
+                    <a href="#v542" class="btn btn-primary">Start with v5.4.2</a>
                     <a href="#v400" class="btn btn-secondary">See v4.0.0</a>
                     <a href="/evolution/" class="btn btn-secondary">See Evolution</a>
                 </div>
             </div>
             <div class="page-visual">
                 <div class="page-stack">
+                    <div class="page-stack-card">
+                        <strong>v5.4.2</strong>
+                        <span>Traceability truth + Sensory Register close-loop. Repo commit-ref warnings stop inflating local/runtime ops into fake git debt, the nocturnal postmortem drains pending <code>session_buffer.jsonl</code> events as a real queue, and docs now match the real stop-hook / reflection boundary.</span>
+                    </div>
                     <div class="page-stack-card">
                         <strong>v5.4.1</strong>
                         <span>Hook hygiene fix. The PostToolUse <code>capture-session.sh</code> hook had been reading a nonexistent env var since 2026-04-12, silently writing <code>"tool":"unknown"</code> to the Sensory Register for 48 hours. v5.4.1 parses <code>tool_name</code> from stdin JSON, stops filtering <code>Bash</code>, removes a runtime-only duplicate, and purges pre-fix entries on update.</span>
@@ -174,6 +178,25 @@
                 <div id="changelog-pager" class="changelog-pager" aria-label="Changelog pagination"></div>
             </div>
         </div>
+    </div>
+</section>
+
+<!-- v5.4.2 traceability truth + buffer close-loop -->
+<section id="v542" class="section-compact" style="background:linear-gradient(135deg,#09111f 0%,#12324a 34%,#0f766e 68%,#22d3ee 100%);">
+    <div class="container">
+        <div class="section-label">New in v5.4.2 <span style="opacity:.5;font-weight:400;">&mdash; April 14, 2026</span></div>
+        <h2 class="section-title">Traceability truth + Sensory Register buffer close-loop</h2>
+        <p class="section-subtitle">
+            A low-level integrity patch: release warnings now distinguish repo git debt from local/runtime operations, the nocturnal postmortem drains pending <code>session_buffer.jsonl</code> events instead of looking only at "today", and docs now describe the real stop-hook / reflection boundary honestly.
+        </p>
+        <ul style="list-style:none;padding:0;margin:24px 0 0;display:grid;gap:12px;">
+            <li><strong>Traceability warning fixed.</strong> Missing <code>commit_ref</code> warnings now count repo-tracked changes only. Local/runtime/server-side operations can be linked explicitly without pretending they should have a repo hash.</li>
+            <li><strong>Queue lifecycle closed.</strong> The nocturnal postmortem now treats <code>session_buffer.jsonl</code> as a real pending queue, ingests useful hook/tool events, and prunes only the lines that were actually consumed.</li>
+            <li><strong>No stranded leftovers.</strong> Older pending events are processed too; they no longer get stuck forever because the consumer only looked at the current day.</li>
+            <li><strong>Atomic rewrite.</strong> The buffer is rewritten through a temp file + replace step so partial writes cannot silently truncate the queue.</li>
+            <li><strong>No product downgrade.</strong> Claude/Opus/Codex-assisted consolidation stays. This patch hardens the mechanical edge around it; it does not replace the assisted path with a weaker local-only substitute.</li>
+        </ul>
+        <p style="margin-top:24px;">See the <a href="/blog/nexo-5-4-2-traceability-and-buffer-close-loop/" style="color:inherit;text-decoration:underline;">full release post</a>.</p>
     </div>
 </section>
 

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 5.4.1
+version: 5.4.2
 metadata:
   openclaw:
     requires:

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents</title>
-    <meta name="description" content="Libre/open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.29 hardens runtime hygiene, fail-closed startup, and honest cron tracing so packaged and repo releases stop drifting from operational truth.">
+    <meta name="description" content="Libre/open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.4.2 makes release traceability honest again, closes the Sensory Register buffer loop, and aligns the public docs with the real stop-hook/runtime behavior.">
     <meta name="keywords" content="AI memory, cognitive architecture, MCP, Claude Code, Codex, Claude Desktop, agent memory, vector search, AI agents, shared brain, open source">
     <meta name="author" content="WAzion">
     <meta name="robots" content="index, follow">
@@ -14,7 +14,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://nexo-brain.com">
     <meta property="og:title" content="NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents">
-    <meta property="og:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.29 hardens runtime hygiene, fail-closed startup, and honest cron tracing so packaged and repo releases stop drifting from operational truth.">
+    <meta property="og:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.4.2 makes release traceability honest again, closes the Sensory Register buffer loop, and aligns the public docs with the real stop-hook/runtime behavior.">
     <meta property="og:image" content="https://nexo-brain.com/assets/og/og-home.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -22,7 +22,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents">
-    <meta name="twitter:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.29 hardens runtime hygiene, fail-closed startup, and honest cron tracing so packaged and repo releases stop drifting from operational truth.">
+    <meta name="twitter:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.4.2 makes release traceability honest again, closes the Sensory Register buffer loop, and aligns the public docs with the real stop-hook/runtime behavior.">
     <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-home.png">
 
     <!-- Google Analytics (GA4) -->
@@ -46,12 +46,12 @@
         "@context": "https://schema.org",
         "@type": "SoftwareApplication",
         "name": "NEXO Brain",
-        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.29 hardens runtime hygiene, fail-closed startup, and honest cron tracing so packaged and repo releases stop drifting from operational truth.",
+        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.4.2 makes release traceability honest again, closes the Sensory Register buffer loop, and aligns the public docs with the real stop-hook/runtime behavior.",
         "applicationCategory": "DeveloperApplication",
         "operatingSystem": "macOS, Linux, Windows",
         "url": "https://nexo-brain.com",
         "downloadUrl": "https://www.npmjs.com/package/nexo-brain",
-        "softwareVersion": "5.4.1",
+        "softwareVersion": "5.4.2",
         "license": "https://www.gnu.org/licenses/agpl-3.0",
         "author": {
             "@type": "Organization",
@@ -88,7 +88,7 @@
         "@type": "WebSite",
         "name": "NEXO Brain",
         "url": "https://nexo-brain.com",
-        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.3.29 hardens runtime hygiene, fail-closed startup, and honest cron tracing so packaged and repo releases stop drifting from operational truth.",
+        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.4.2 makes release traceability honest again, closes the Sensory Register buffer loop, and aligns the public docs with the real stop-hook/runtime behavior.",
         "publisher": {
             "@type": "Organization",
             "name": "WAzion",
@@ -697,7 +697,7 @@
     <div class="container">
         <div class="hero-badge fade-up">
             <span class="dot"></span>
-            <span id="version-badge">v5.4.1</span> &mdash; hook hygiene: Sensory Register was writing "unknown" for 48h
+            <span id="version-badge">v5.4.2</span> &mdash; traceability truth + Sensory Register buffer close-loop
         </div>
         <div class="fade-up" style="display:flex;gap:8px;justify-content:center;margin-bottom:12px;">
             <img src="https://img.shields.io/npm/v/nexo-brain?color=7C3AED&label=npm" alt="npm version">

--- a/llms.txt
+++ b/llms.txt
@@ -1,9 +1,10 @@
 # NEXO Brain
 
-> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.4.1).
+> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.4.2).
 
 NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. It adds a local shared brain across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, smarter retrieval defaults, long-horizon overnight analysis, and 150+ MCP tools.
 
+v5.4.2: traceability truth + Sensory Register buffer close-loop — diary warnings now distinguish repo `commit_ref` debt from local/server-side operational changes, the nocturnal postmortem drains pending `session_buffer.jsonl` events instead of looking only at "today", rewrites the buffer atomically, and the docs now say honestly that `nexo-reflection.py` is a standalone analyzer rather than something auto-triggered by the stop hook
 v5.4.1: hook hygiene fix — the PostToolUse `capture-session.sh` hook had been reading a nonexistent env var since 2026-04-12, silently writing `"tool":"unknown"` to `~/.nexo/brain/session_buffer.jsonl` for 48 hours. v5.4.1 parses `tool_name` from stdin JSON, removes the filter that was hiding `Bash`, deletes the contaminating `capture-session 2.sh` duplicate, and purges pre-fix entries from the buffer on update with a `.pre-v5.4.1.bak` backup
 v5.4.0: runtime events + health + logs + calibration migration — append-only event bus at `~/.nexo/runtime/events.ndjson` with stable envelope, `nexo notify` for one-shot proactive events, `nexo health --json` for a rolled-up subsystem snapshot, `nexo logs --tail --json` for structured log access, and a safe flat→nested migration for `calibration.json` that runs silently inside `nexo update` with a pre-migrate backup
 v5.3.30: desktop bridge — four read-only CLI commands (`nexo schema`, `nexo identity`, `nexo onboard`, `nexo scan-profile`) let external UIs like NEXO Desktop render preferences, onboarding, identity, and profile heuristics from live JSON instead of hardcoding field lists and releasing in lockstep

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "5.4.1",
+  "version": "5.4.2",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.4.1" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.4.2" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.4.1",
+  "version": "5.4.2",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/release-contracts/v5.4.2.json
+++ b/release-contracts/v5.4.2.json
@@ -1,0 +1,83 @@
+{
+  "release_line": "v5.4",
+  "target_version": "5.4.2",
+  "scope_owner": "NEXO",
+  "distribution": {
+    "git_updates_on": "merge_to_main",
+    "packaged_release_on": "tag_publish"
+  },
+  "required_repo_files": [
+    "package.json",
+    "CHANGELOG.md",
+    "README.md",
+    "llms.txt",
+    "sitemap.xml",
+    "index.html",
+    "blog/index.html",
+    "blog/nexo-5-4-2-traceability-and-buffer-close-loop/index.html",
+    "changelog/index.html",
+    "release-contracts/v5.4.2.json",
+    "scripts/sync_release_artifacts.py",
+    "scripts/verify_release_readiness.py",
+    ".claude-plugin/plugin.json",
+    "clawhub-skill/SKILL.md",
+    "openclaw-plugin/package.json",
+    "openclaw-plugin/src/mcp-bridge.ts",
+    "src/plugins/episodic_memory.py",
+    "src/scripts/nexo-postmortem-consolidator.py",
+    "src/scripts/nexo-reflection.py",
+    "tests/test_episodic_memory.py",
+    "tests/test_postmortem_consolidator.py"
+  ],
+  "required_website_files": [
+    "index.html",
+    "blog/index.html",
+    "blog/nexo-5-4-2-traceability-and-buffer-close-loop/index.html",
+    "changelog/index.html",
+    "llms.txt",
+    ".well-known/llms.txt",
+    "sitemap.xml"
+  ],
+  "gates": [
+    {
+      "id": "commit_ref_warning_counts_repo_only",
+      "title": "Release traceability warnings distinguish repo git debt from local/runtime operations",
+      "status": "complete",
+      "evidence_required": [
+        "Episodic-memory diary warnings count only repo-tracked missing commit_ref rows",
+        "Change-log guidance allows server-direct/local-uncommitted markers for non-repo edits",
+        "Regression coverage locks repo-vs-local classification"
+      ]
+    },
+    {
+      "id": "session_buffer_drains_as_pending_queue",
+      "title": "Nocturnal postmortem consumes pending Sensory Register events and prunes only what it ingests",
+      "status": "complete",
+      "evidence_required": [
+        "Postmortem consolidator processes pending session_buffer.jsonl entries instead of only current-day rows",
+        "Processed events are removed while malformed or unrenderable lines are retained",
+        "Buffer rewrite is atomic so partial writes cannot truncate the queue"
+      ]
+    },
+    {
+      "id": "reflection_boundary_docs_match_runtime",
+      "title": "Public/docs copy now matches the real stop-hook and reflection-engine boundary",
+      "status": "complete",
+      "evidence_required": [
+        "README no longer describes the stop hook as auto-triggering nexo-reflection.py",
+        "nexo-reflection.py self-description says it is standalone today",
+        "Release post and changelog state that Claude/Opus-assisted consolidation remains intact"
+      ]
+    },
+    {
+      "id": "public_release_surfaces_stay_aligned",
+      "title": "Repo copy, website copy, and packaged release line all reflect v5.4.2 before tag publish",
+      "status": "complete",
+      "evidence_required": [
+        "README, llms, homepage, blog index, blog post, changelog page, and sitemap reference v5.4.2",
+        "Website worktree contains the same v5.4.2 public surfaces including .well-known/llms.txt",
+        "sync_release_artifacts.py and verify_release_readiness.py pass for the v5.4.2 contract"
+      ]
+    }
+  ]
+}

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -145,6 +145,12 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://nexo-brain.com/blog/nexo-5-4-2-traceability-and-buffer-close-loop/</loc>
+    <lastmod>2026-04-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.95</priority>
+  </url>
+  <url>
     <loc>https://nexo-brain.com/blog/nexo-5-4-1-hook-hygiene-fix/</loc>
     <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>

--- a/src/plugins/episodic_memory.py
+++ b/src/plugins/episodic_memory.py
@@ -3,12 +3,30 @@
 import datetime
 import json
 import time
+from pathlib import Path
 from db import (
     log_decision, update_decision_outcome, search_decisions,
     write_session_diary, read_session_diary,
     log_change, search_changes, update_change_commit,
     recall, get_db, set_linked_outcomes_met,
 )
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_REPO_ABS_PREFIX = str(REPO_ROOT) + "/"
+_REPO_IGNORED_TOP_LEVEL = {
+    ".git",
+    ".venv",
+    ".pytest_cache",
+    ".ruff_cache",
+    "__pycache__",
+}
+try:
+    _REPO_TOP_LEVEL_ENTRIES = {
+        path.name for path in REPO_ROOT.iterdir()
+        if path.name not in _REPO_IGNORED_TOP_LEVEL
+    }
+except OSError:
+    _REPO_TOP_LEVEL_ENTRIES = set()
 
 
 def _cognitive_ingest_safe(content, source_type, source_id="", source_title="", domain=""):
@@ -18,6 +36,37 @@ def _cognitive_ingest_safe(content, source_type, source_id="", source_title="", 
         cognitive.ingest(content, source_type, source_id, source_title, domain)
     except Exception:
         pass  # Cognitive is optional — never block operational writes
+
+
+def _iter_change_paths(files: str) -> list[str]:
+    parts = []
+    for chunk in str(files or "").replace("\n", ",").split(","):
+        item = chunk.strip()
+        if item:
+            parts.append(item)
+    return parts
+
+
+def _change_requires_git_commit_ref(files: str) -> bool:
+    for item in _iter_change_paths(files):
+        normalized = item.replace("\\", "/").strip()
+        while normalized.startswith("./"):
+            normalized = normalized[2:]
+        if normalized.startswith(_REPO_ABS_PREFIX):
+            return True
+        top_level = normalized.split("/", 1)[0]
+        if top_level in _REPO_TOP_LEVEL_ENTRIES:
+            return True
+    return False
+
+
+def _format_change_count(count: int) -> str:
+    return f"{count} cambio" if count == 1 else f"{count} cambios"
+
+
+def _recent_change_phrase(count: int) -> str:
+    base = _format_change_count(count)
+    return f"{base} reciente" if count == 1 else f"{base} recientes"
 
 
 def handle_decision_log(domain: str, decision: str, alternatives: str = '',
@@ -226,23 +275,35 @@ def handle_session_diary_write(decisions: str, summary: str,
     # Episodic memory audit — warn about gaps
     warnings = []
     conn = __import__('db').get_db()
-    orphan_changes = conn.execute(
-        "SELECT COUNT(*) FROM change_log WHERE (commit_ref IS NULL OR commit_ref = '')"
-    ).fetchone()[0]
-    recent_orphan_changes = conn.execute(
-        """SELECT COUNT(*) FROM change_log
-           WHERE (commit_ref IS NULL OR commit_ref = '')
-             AND created_at >= datetime('now', '-7 days')"""
-    ).fetchone()[0]
-    if orphan_changes > 0:
-        if recent_orphan_changes > 0 and recent_orphan_changes != orphan_changes:
+    orphan_change_rows = conn.execute(
+        """SELECT files, created_at FROM change_log
+           WHERE (commit_ref IS NULL OR commit_ref = '')"""
+    ).fetchall()
+    repo_orphan_changes = 0
+    recent_repo_orphan_changes = 0
+    recent_cutoff = conn.execute("SELECT datetime('now', '-7 days')").fetchone()[0]
+    for row in orphan_change_rows:
+        files = row["files"] if hasattr(row, "keys") else row[0]
+        created_at = row["created_at"] if hasattr(row, "keys") else row[1]
+        if not _change_requires_git_commit_ref(files):
+            continue
+        repo_orphan_changes += 1
+        if created_at >= recent_cutoff:
+            recent_repo_orphan_changes += 1
+    if repo_orphan_changes > 0:
+        if recent_repo_orphan_changes > 0 and recent_repo_orphan_changes != repo_orphan_changes:
             warnings.append(
-                f"{recent_orphan_changes} changes recientes sin commit_ref ({orphan_changes} históricas total)"
+                f"{_recent_change_phrase(recent_repo_orphan_changes)} de repo sin commit_ref "
+                f"({_format_change_count(repo_orphan_changes)} de repo total)"
             )
-        elif recent_orphan_changes > 0:
-            warnings.append(f"{recent_orphan_changes} changes recientes sin commit_ref")
+        elif recent_repo_orphan_changes > 0:
+            warnings.append(
+                f"{_recent_change_phrase(recent_repo_orphan_changes)} de repo sin commit_ref"
+            )
         else:
-            warnings.append(f"{orphan_changes} changes históricas sin commit_ref")
+            warnings.append(
+                f"{_format_change_count(repo_orphan_changes)} históricos de repo sin commit_ref"
+            )
     orphan_decisions = conn.execute(
         "SELECT COUNT(*) FROM decisions WHERE (outcome IS NULL OR outcome = '') AND created_at < datetime('now', '-7 days')"
     ).fetchone()[0]
@@ -342,7 +403,16 @@ def handle_change_log(files: str, what_changed: str, why: str,
         pass
     msg = f"Change #{change_id} recorded: {files[:60]} — {what_changed[:60]}"
     if not commit_ref:
-        msg += f"\n⚠ NO COMMIT. Use nexo_change_commit({change_id}, 'hash') after push, or 'server-direct' if it was a direct server edit."
+        if _change_requires_git_commit_ref(files):
+            msg += (
+                f"\n⚠ NO COMMIT. Use nexo_change_commit({change_id}, 'hash') after push."
+            )
+        else:
+            msg += (
+                f"\n⚠ NO COMMIT GIT. If this was a local/server-side change, link a marker "
+                f"with nexo_change_commit({change_id}, 'server-direct') or "
+                f"'local-uncommitted'."
+            )
     return msg
 
 

--- a/src/scripts/nexo-postmortem-consolidator.py
+++ b/src/scripts/nexo-postmortem-consolidator.py
@@ -87,6 +87,41 @@ def log(msg: str):
         f.write(line + "\n")
 
 
+def _render_sensory_event_content(event: dict) -> str:
+    source = event.get("source", "")
+    if source == "hook-fallback":
+        task_str = " ".join(event.get("tasks", []))
+        if len(task_str) < 50 or "," in task_str:
+            return ""
+
+    parts = []
+    tool_name = str(event.get("tool") or "").strip()
+    if source == "hook" and tool_name:
+        parts.append(f"Tool activity via hook: {tool_name}")
+
+    for key, label in [("tasks", "Tasks"), ("decisions", "Decisions"),
+                       ("errors_resolved", "Errors"), ("user_patterns", "the user")]:
+        val = event.get(key, [])
+        if val:
+            parts.append(f"{label}: {'; '.join(str(v) for v in val[:3])}")
+
+    critique = event.get("self_critique", "")
+    if critique and "hook-fallback" not in critique:
+        parts.append(f"Self-critique: {critique[:200]}")
+
+    return " | ".join(parts)
+
+
+def _rewrite_session_buffer(lines: list[str]) -> None:
+    payload = "\n".join(lines)
+    if payload:
+        payload += "\n"
+
+    tmp_path = SESSION_BUFFER.with_suffix(SESSION_BUFFER.suffix + ".tmp")
+    tmp_path.write_text(payload)
+    tmp_path.replace(SESSION_BUFFER)
+
+
 # ─── Stage 1: Data Collection (Pure Python) ─────────────────────────────────
 
 def collect_data() -> dict:
@@ -257,28 +292,29 @@ def process_sensory_register():
         log("  No session_buffer.jsonl found, skipping")
         return
 
-    today_events = []
+    pending_events = []
+    retained_lines = []
     try:
         with open(SESSION_BUFFER) as f:
             for line in f:
-                line = line.strip()
+                raw_line = line.rstrip("\n")
+                line = raw_line.strip()
                 if not line:
                     continue
                 try:
                     event = json.loads(line)
-                    if event.get("ts", "").startswith(TODAY_STR):
-                        today_events.append(event)
+                    pending_events.append((event, line))
                 except json.JSONDecodeError:
-                    continue
+                    retained_lines.append(raw_line)
     except Exception as e:
         log(f"  Error reading session_buffer: {e}")
         return
 
-    if not today_events:
-        log("  No events from today")
+    if not pending_events:
+        log("  No pending events")
         return
 
-    log(f"  Found {len(today_events)} events")
+    log(f"  Found {len(pending_events)} pending events")
 
     try:
         import cognitive
@@ -287,30 +323,16 @@ def process_sensory_register():
         return
 
     ingested = 0
-    for event in today_events:
-        source = event.get("source", "")
-        if source == "hook-fallback":
-            task_str = " ".join(event.get("tasks", []))
-            if len(task_str) < 50 or "," in task_str:
-                continue
-
-        parts = []
-        for key, label in [("tasks", "Tasks"), ("decisions", "Decisions"),
-                           ("errors_resolved", "Errors"), ("user_patterns", "the user")]:
-            val = event.get(key, [])
-            if val:
-                parts.append(f"{label}: {'; '.join(str(v) for v in val[:3])}")
-
-        critique = event.get("self_critique", "")
-        if critique and "hook-fallback" not in critique:
-            parts.append(f"Self-critique: {critique[:200]}")
-
-        content = " | ".join(parts)
+    processed_events = 0
+    kept_events = 0
+    for event, raw_line in pending_events:
+        content = _render_sensory_event_content(event)
         if not content or len(content) < 20:
+            retained_lines.append(raw_line)
+            kept_events += 1
             continue
 
         try:
-            vec = cognitive.embed(content)
             domain = ""
             lower = content.lower()
             # Add your project keywords for domain detection
@@ -324,10 +346,20 @@ def process_sensory_register():
                 domain=domain, created_at=event.get("ts", "")
             )
             ingested += 1
+            processed_events += 1
         except Exception as e:
             log(f"  Error embedding: {e}")
+            retained_lines.append(raw_line)
 
-    log(f"  Ingested {ingested} sensory events into STM")
+    try:
+        _rewrite_session_buffer(retained_lines)
+    except Exception as e:
+        log(f"  Error rewriting session_buffer: {e}")
+
+    log(
+        f"  Ingested {ingested} sensory events into STM "
+        f"(processed: {processed_events}, retained: {len(retained_lines)} incl kept={kept_events})"
+    )
 
 
 def analyze_force_events():

--- a/src/scripts/nexo-reflection.py
+++ b/src/scripts/nexo-reflection.py
@@ -2,8 +2,8 @@
 """
 NEXO Reflection Engine — Processes session_buffer.jsonl entries.
 
-Triggered by the stop hook when >=3 sessions have accumulated and
-the last reflection was >4 hours ago.
+The runtime still ships this as a standalone analyzer, but it is not
+currently auto-triggered by the stop hook.
 
 What it does:
 1. Reads all entries from session_buffer.jsonl

--- a/tests/test_episodic_memory.py
+++ b/tests/test_episodic_memory.py
@@ -20,9 +20,11 @@ def test_session_diary_write_distinguishes_recent_and_historical_commit_ref_gaps
 
     db_path = tmp_path / "nexo.db"
     conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
     conn.execute(
         """CREATE TABLE change_log (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
+            files TEXT DEFAULT '',
             commit_ref TEXT DEFAULT '',
             created_at TEXT DEFAULT (datetime('now'))
         )"""
@@ -35,10 +37,13 @@ def test_session_diary_write_distinguishes_recent_and_historical_commit_ref_gaps
         )"""
     )
     conn.execute(
-        "INSERT INTO change_log (commit_ref, created_at) VALUES ('', datetime('now', '-1 day'))"
+        "INSERT INTO change_log (files, commit_ref, created_at) VALUES ('src/plugins/protocol.py', '', datetime('now', '-1 day'))"
     )
     conn.execute(
-        "INSERT INTO change_log (commit_ref, created_at) VALUES ('', datetime('now', '-20 days'))"
+        "INSERT INTO change_log (files, commit_ref, created_at) VALUES ('src/plugins/protocol.py', '', datetime('now', '-20 days'))"
+    )
+    conn.execute(
+        "INSERT INTO change_log (files, commit_ref, created_at) VALUES ('/Users/franciscoc/.nexo/operations/orchestrator-state.json', '', datetime('now', '-1 day'))"
     )
     conn.commit()
 
@@ -60,4 +65,41 @@ def test_session_diary_write_distinguishes_recent_and_historical_commit_ref_gaps
     )
     conn.close()
 
-    assert "1 changes recientes sin commit_ref (2 históricas total)" in result
+    assert "1 cambio reciente de repo sin commit_ref (2 cambios de repo total)" in result
+
+
+def test_change_log_message_distinguishes_repo_and_local_commit_refs(monkeypatch):
+    from plugins import episodic_memory
+
+    captured = []
+
+    def _fake_log_change(session_id, files, what_changed, why, triggered_by, affects, risks, verify, commit_ref):
+        captured.append((session_id, files, commit_ref))
+        return {"id": len(captured)}
+
+    monkeypatch.setattr(episodic_memory, "log_change", _fake_log_change)
+    monkeypatch.setattr(episodic_memory, "_cognitive_ingest_safe", lambda *args, **kwargs: None)
+
+    repo_msg = episodic_memory.handle_change_log(
+        files="src/plugins/protocol.py",
+        what_changed="Ajuste de validación",
+        why="Corregir warning engañoso",
+        session_id="sid-test",
+    )
+    local_msg = episodic_memory.handle_change_log(
+        files="/Users/franciscoc/.nexo/operations/orchestrator-state.json",
+        what_changed="Checkpoint local",
+        why="Persistir continuidad",
+        session_id="sid-test",
+    )
+    benchmark_msg = episodic_memory.handle_change_log(
+        files="benchmarks/README.md",
+        what_changed="Actualizar benchmark",
+        why="Documentar comparativa",
+        session_id="sid-test",
+    )
+
+    assert "nexo_change_commit(1, 'hash')" in repo_msg
+    assert "'server-direct'" in local_msg
+    assert "'local-uncommitted'" in local_msg
+    assert "nexo_change_commit(3, 'hash')" in benchmark_msg

--- a/tests/test_postmortem_consolidator.py
+++ b/tests/test_postmortem_consolidator.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = REPO_ROOT / "src" / "scripts" / "nexo-postmortem-consolidator.py"
+
+
+def _load_module(monkeypatch):
+    agent_runner = types.SimpleNamespace(
+        AutomationBackendUnavailableError=RuntimeError,
+        run_automation_prompt=lambda *args, **kwargs: None,
+    )
+    client_preferences = types.SimpleNamespace(resolve_user_model=lambda: "")
+    monkeypatch.setitem(sys.modules, "agent_runner", agent_runner)
+    monkeypatch.setitem(sys.modules, "client_preferences", client_preferences)
+
+    spec = importlib.util.spec_from_file_location("test_postmortem_consolidator_module", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_process_sensory_register_ingests_pending_events_and_prunes_processed_lines(monkeypatch, tmp_path):
+    module = _load_module(monkeypatch)
+
+    ingested = []
+    fake_cognitive = types.SimpleNamespace(
+        ingest_sensory=lambda **kwargs: ingested.append(kwargs),
+    )
+    monkeypatch.setitem(sys.modules, "cognitive", fake_cognitive)
+
+    buffer_path = tmp_path / "session_buffer.jsonl"
+    buffer_path.write_text(
+        "\n".join(
+            [
+                '{"ts":"2026-04-14T10:00:00Z","tool":"Bash","source":"hook"}',
+                '{"ts":"2026-04-14T11:00:00Z","source":"claude","tasks":["Investigate C9 pipeline"]}',
+                '{"ts":"2026-04-13T09:00:00Z","tool":"Bash","source":"hook"}',
+                "not-json",
+            ]
+        )
+        + "\n"
+    )
+
+    monkeypatch.setattr(module, "SESSION_BUFFER", buffer_path)
+    monkeypatch.setattr(module, "TODAY_STR", "2026-04-14")
+    monkeypatch.setattr(module, "log", lambda msg: None)
+
+    module.process_sensory_register()
+
+    assert len(ingested) == 3
+    assert any("Tool activity via hook: Bash" in item["content"] for item in ingested)
+    assert any("Tasks: Investigate C9 pipeline" in item["content"] for item in ingested)
+    assert any(item["created_at"] == "2026-04-13T09:00:00Z" for item in ingested)
+
+    remaining = buffer_path.read_text().splitlines()
+    assert "not-json" in remaining
+    assert '{"ts":"2026-04-14T10:00:00Z","tool":"Bash","source":"hook"}' not in remaining
+    assert '{"ts":"2026-04-14T11:00:00Z","source":"claude","tasks":["Investigate C9 pipeline"]}' not in remaining
+    assert '{"ts":"2026-04-13T09:00:00Z","tool":"Bash","source":"hook"}' not in remaining


### PR DESCRIPTION
## Summary\n- tighten commit_ref warnings so repo git debt is counted separately from local/runtime/server-side operations\n- close the session_buffer lifecycle in the nocturnal postmortem, including pending-event draining and atomic rewrites\n- prepare the v5.4.2 public surfaces and sync release-facing integration artifacts\n\n## Verification\n- pytest -q tests/test_episodic_memory.py tests/test_postmortem_consolidator.py tests/test_verify_release_readiness.py\n- python3 scripts/verify_release_readiness.py --ci --contract release-contracts/v5.4.2.json --require-contract-complete --website-root /Users/franciscoc/Documents/_PhpstormProjects/nexo-gh-pages\n- git diff --check