### PR TITLE
Auto-install Claude Code when update/doctor need it

### DIFF
--- a/src/auto_update.py
+++ b/src/auto_update.py
@@ -2115,6 +2115,7 @@ def _run_runtime_post_sync(dest: Path = NEXO_HOME, progress_fn=None) -> tuple[bo
             nexo_home=dest,
             runtime_root=dest,
             preferences=normalized_preferences,
+            auto_install_missing_claude=True,
         )
         if client_sync_result.get("ok"):
             actions.append("client-sync")

--- a/src/client_sync.py
+++ b/src/client_sync.py
@@ -24,6 +24,7 @@ try:
     from client_preferences import (
         BACKEND_NONE,
         INTERACTIVE_CLIENT_KEYS,
+        detect_installed_clients,
         normalize_backend_key,
         normalize_client_key,
         normalize_client_preferences,
@@ -67,6 +68,16 @@ except Exception:
             "codex": {"model": _default_model, "reasoning_effort": ""},
         }
         return dict(defaults.get(client, {}))
+
+    def detect_installed_clients(user_home: str | os.PathLike[str] | None = None) -> dict[str, dict]:
+        return {
+            "claude_code": {"installed": False, "path": "", "detected_by": "missing"},
+            "codex": {"installed": False, "path": "", "detected_by": "missing"},
+            "claude_desktop": {"installed": False, "path": "", "detected_by": "missing"},
+        }
+
+
+CLAUDE_CODE_NPM_PACKAGE = "@anthropic-ai/claude-code"
 
 
 
@@ -131,6 +142,108 @@ def _resolve_python(nexo_home: Path, explicit: str = "") -> str:
         if candidate and Path(candidate).exists():
             return str(Path(candidate))
     return explicit or sys.executable
+
+
+def _cli_install_env(user_home: Path | None = None) -> dict[str, str]:
+    env = os.environ.copy()
+    if user_home is not None:
+        env["HOME"] = str(user_home)
+    return env
+
+
+def _installed_client_path(client_key: str, *, user_home: Path | None = None) -> str:
+    info = detect_installed_clients(user_home=user_home).get(client_key, {})
+    if info.get("installed"):
+        return str(info.get("path") or "")
+    return ""
+
+
+def ensure_claude_code_installed(*, user_home: str | os.PathLike[str] | None = None) -> dict:
+    home_path = Path(user_home).expanduser() if user_home else _user_home()
+    existing = _installed_client_path("claude_code", user_home=home_path)
+    if existing:
+        return {
+            "ok": True,
+            "client": "claude_code",
+            "installed": True,
+            "changed": False,
+            "action": "already_installed",
+            "path": existing,
+            "attempts": [],
+        }
+
+    attempts: list[str] = []
+    env = _cli_install_env(home_path)
+
+    try:
+        probe = subprocess.run(
+            ["npx", "-y", CLAUDE_CODE_NPM_PACKAGE, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env=env,
+        )
+        if probe.returncode != 0:
+            attempts.append((probe.stderr or probe.stdout or "npx probe failed").strip())
+    except Exception as exc:
+        attempts.append(f"npx probe failed: {exc}")
+
+    installed_after_probe = _installed_client_path("claude_code", user_home=home_path)
+    if installed_after_probe:
+        return {
+            "ok": True,
+            "client": "claude_code",
+            "installed": True,
+            "changed": True,
+            "action": "installed_via_npx",
+            "path": installed_after_probe,
+            "attempts": attempts,
+        }
+
+    install_cmd = (
+        ["sudo", "npm", "install", "-g", CLAUDE_CODE_NPM_PACKAGE]
+        if sys.platform == "linux"
+        else ["npm", "install", "-g", CLAUDE_CODE_NPM_PACKAGE]
+    )
+    install_error = ""
+    try:
+        install = subprocess.run(
+            install_cmd,
+            capture_output=True,
+            text=True,
+            timeout=180,
+            env=env,
+        )
+        if install.returncode != 0:
+            install_error = (install.stderr or install.stdout or "npm install failed").strip()
+            attempts.append(install_error)
+    except Exception as exc:
+        install_error = f"npm install failed: {exc}"
+        attempts.append(install_error)
+
+    installed_path = _installed_client_path("claude_code", user_home=home_path)
+    if installed_path:
+        return {
+            "ok": True,
+            "client": "claude_code",
+            "installed": True,
+            "changed": True,
+            "action": "installed",
+            "path": installed_path,
+            "attempts": attempts,
+        }
+
+    error = install_error or "Claude Code install did not produce a `claude` binary in PATH"
+    return {
+        "ok": False,
+        "client": "claude_code",
+        "installed": False,
+        "changed": False,
+        "action": "failed",
+        "path": "",
+        "attempts": attempts,
+        "error": error,
+    }
 
 
 def build_server_config(
@@ -856,6 +969,7 @@ def sync_all_clients(
     user_home: str | os.PathLike[str] | None = None,
     enabled_clients: list[str] | tuple[str, ...] | set[str] | None = None,
     preferences: dict | None = None,
+    auto_install_missing_claude: bool = False,
 ) -> dict:
     if enabled_clients is None:
         if preferences is None:
@@ -876,6 +990,10 @@ def sync_all_clients(
         enabled_set = {normalize_client_key(item) for item in enabled_clients if normalize_client_key(item)}
         if not enabled_set:
             enabled_set = {"claude_code"}
+
+    install_results: dict[str, dict] = {}
+    if auto_install_missing_claude and "claude_code" in enabled_set:
+        install_results["claude_code"] = ensure_claude_code_installed(user_home=user_home)
 
     def _safe(label: str, fn) -> dict:
         if label not in enabled_set:
@@ -902,7 +1020,10 @@ def sync_all_clients(
         "claude_desktop": _safe("claude_desktop", sync_claude_desktop),
         "codex": _safe("codex", sync_codex),
     }
-    ok = all(item.get("ok") or item.get("skipped") for item in results.values())
+    ok = (
+        all(item.get("ok") or item.get("skipped") for item in results.values())
+        and all(item.get("ok") for item in install_results.values())
+    )
     return {
         "ok": ok,
         "nexo_home": str(Path(nexo_home).expanduser() if nexo_home else _default_nexo_home()),
@@ -911,6 +1032,7 @@ def sync_all_clients(
             runtime_root,
         )),
         "enabled_clients": sorted(enabled_set),
+        "install_results": install_results,
         "clients": results,
     }
 

--- a/src/doctor/providers/runtime.py
+++ b/src/doctor/providers/runtime.py
@@ -1773,7 +1773,7 @@ def check_personal_script_registry(fix: bool = False) -> DoctorCheck:
     )
 
 
-def check_client_backend_preferences() -> DoctorCheck:
+def check_client_backend_preferences(fix: bool = False) -> DoctorCheck:
     schedule = {}
     try:
         if SCHEDULE_FILE.is_file():
@@ -1828,7 +1828,28 @@ def check_client_backend_preferences() -> DoctorCheck:
             repair_plan.append(f"Install {automation_backend} or disable automation in schedule.json")
 
     if not repair_plan and status != "healthy":
-        repair_plan.append("Run `nexo update` or `nexo clients sync` after installing the selected client/backend")
+        repair_plan.append(
+            "Run `nexo doctor --tier runtime --fix` or `nexo update` so the selected client/backend is installed and re-synced where possible"
+        )
+
+    if fix and status != "healthy":
+        try:
+            from client_sync import sync_all_clients
+
+            sync_all_clients(
+                nexo_home=NEXO_HOME,
+                runtime_root=NEXO_CODE,
+                user_home=Path.home(),
+                preferences=prefs,
+                auto_install_missing_claude=True,
+            )
+        except Exception:
+            pass
+        post = check_client_backend_preferences(fix=False)
+        if post.status == "healthy":
+            post.fixed = True
+            post.summary += " (fixed)"
+        return post
 
     def _profile_label(client_key: str, profile: dict[str, str]) -> str:
         bits = [client_key]
@@ -3151,7 +3172,7 @@ def run_runtime_checks(fix: bool = False) -> list[DoctorCheck]:
         safe_check(check_watchdog_status),
         safe_check(check_stale_sessions),
         safe_check(check_cron_freshness),
-        safe_check(check_client_backend_preferences),
+        safe_check(check_client_backend_preferences, fix=fix),
         safe_check(check_client_bootstrap_parity, fix=fix),
         safe_check(check_codex_session_parity),
         safe_check(check_codex_conditioned_file_discipline),

--- a/src/plugins/update.py
+++ b/src/plugins/update.py
@@ -479,6 +479,7 @@ def _sync_packaged_clients() -> tuple[bool, str | None]:
             runtime_root=NEXO_HOME,
             operator_name=os.environ.get("NEXO_NAME", ""),
             preferences=preferences,
+            auto_install_missing_claude=True,
         )
     except Exception as e:
         return False, f"client sync failed: {e}"

--- a/tests/test_client_sync.py
+++ b/tests/test_client_sync.py
@@ -333,6 +333,7 @@ def test_sync_all_clients_auto_installs_selected_claude_code_when_missing(tmp_pa
 
     monkeypatch.setattr(client_sync, "detect_installed_clients", fake_detect)
     monkeypatch.setattr(client_sync.subprocess, "run", fake_run)
+    monkeypatch.setattr(client_sync.sys, "platform", "darwin")
 
     result = client_sync.sync_all_clients(
         nexo_home=runtime,

--- a/tests/test_client_sync.py
+++ b/tests/test_client_sync.py
@@ -306,6 +306,59 @@ def test_sync_all_clients_treats_missing_codex_as_non_fatal(tmp_path, monkeypatc
     assert "[mcp_servers.nexo]" in (home / ".codex" / "config.toml").read_text()
 
 
+def test_sync_all_clients_auto_installs_selected_claude_code_when_missing(tmp_path, monkeypatch):
+    import client_sync
+
+    runtime = _make_runtime(tmp_path)
+    home = tmp_path / "home"
+    attempts = []
+    install_state = {"installed": False}
+
+    def fake_detect(user_home=None):
+        return {
+            "claude_code": {
+                "installed": install_state["installed"],
+                "path": "/tmp/fake-claude" if install_state["installed"] else "",
+                "detected_by": "binary" if install_state["installed"] else "missing",
+            },
+            "codex": {"installed": False, "path": "", "detected_by": "missing"},
+            "claude_desktop": {"installed": False, "path": "", "detected_by": "missing"},
+        }
+
+    def fake_run(cmd, **kwargs):
+        attempts.append(cmd)
+        if cmd[:2] == ["npm", "install"]:
+            install_state["installed"] = True
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(client_sync, "detect_installed_clients", fake_detect)
+    monkeypatch.setattr(client_sync.subprocess, "run", fake_run)
+
+    result = client_sync.sync_all_clients(
+        nexo_home=runtime,
+        runtime_root=runtime,
+        operator_name="Atlas",
+        user_home=home,
+        preferences={
+            "interactive_clients": {
+                "claude_code": True,
+                "codex": False,
+                "claude_desktop": False,
+            },
+            "default_terminal_client": "claude_code",
+            "automation_enabled": True,
+            "automation_backend": "claude_code",
+        },
+        auto_install_missing_claude=True,
+    )
+
+    assert result["ok"] is True
+    assert attempts[0] == ["npx", "-y", "@anthropic-ai/claude-code", "--version"]
+    assert attempts[1] == ["npm", "install", "-g", "@anthropic-ai/claude-code"]
+    assert result["install_results"]["claude_code"]["action"] == "installed"
+    assert result["install_results"]["claude_code"]["path"] == "/tmp/fake-claude"
+
+
 def test_sync_codex_defaults_operator_name_when_runtime_version_has_blank_value(tmp_path, monkeypatch):
     import client_sync
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -787,6 +787,54 @@ class TestRuntimeChecks:
         assert any("default terminal client `codex`" in item for item in check.evidence)
         assert any("automation backend `codex`" in item for item in check.evidence)
 
+    def test_client_backend_preferences_fix_installs_selected_claude(self, nexo_home, monkeypatch):
+        from doctor.providers import runtime
+        import client_sync
+
+        schedule_file = nexo_home / "config" / "schedule.json"
+        schedule_file.parent.mkdir(parents=True, exist_ok=True)
+        schedule_file.write_text(json.dumps({
+            "interactive_clients": {
+                "claude_code": True,
+                "codex": False,
+                "claude_desktop": False,
+            },
+            "default_terminal_client": "claude_code",
+            "automation_enabled": True,
+            "automation_backend": "claude_code",
+        }))
+
+        install_state = {"installed": False}
+        sync_kwargs = {}
+
+        monkeypatch.setattr(runtime, "SCHEDULE_FILE", schedule_file)
+        monkeypatch.setattr(runtime.Path, "home", lambda: nexo_home)
+
+        def fake_detect(user_home=None):
+            return {
+                "claude_code": {"installed": install_state["installed"]},
+                "codex": {"installed": False},
+                "claude_desktop": {"installed": False},
+            }
+
+        def fake_sync_all_clients(**kwargs):
+            sync_kwargs.update(kwargs)
+            install_state["installed"] = True
+            return {
+                "ok": True,
+                "install_results": {"claude_code": {"ok": True, "action": "installed"}},
+                "clients": {},
+            }
+
+        monkeypatch.setattr(runtime, "detect_installed_clients", fake_detect)
+        monkeypatch.setattr(client_sync, "sync_all_clients", fake_sync_all_clients)
+
+        check = runtime.check_client_backend_preferences(fix=True)
+
+        assert check.status == "healthy"
+        assert check.fixed is True
+        assert sync_kwargs["auto_install_missing_claude"] is True
+
     def test_client_bootstrap_parity_warns_when_codex_bootstrap_missing(self, nexo_home, monkeypatch):
         from doctor.providers import runtime
 

--- a/tests/test_packaged_update_runtime.py
+++ b/tests/test_packaged_update_runtime.py
@@ -71,6 +71,7 @@ def test_sync_packaged_clients_normalizes_preferences_and_targets_runtime_home(t
     assert err is None
     assert captured["nexo_home"] == runtime_home
     assert captured["runtime_root"] == runtime_home
+    assert captured["auto_install_missing_claude"] is True
     updated_schedule = json.loads(schedule_path.read_text())
     assert "interactive_clients" in updated_schedule
     assert "automation_enabled" in updated_schedule

--- a/tests/test_startup_preflight.py
+++ b/tests/test_startup_preflight.py
@@ -164,6 +164,7 @@ def test_run_runtime_post_sync_uses_reconcile_personal_scripts(tmp_path, monkeyp
     (runtime_home / "crons" / "sync.py").write_text("print('ok')\n")
 
     calls = []
+    captured = {}
 
     def fake_run(cmd, **kwargs):
         calls.append(cmd)
@@ -172,7 +173,11 @@ def test_run_runtime_post_sync_uses_reconcile_personal_scripts(tmp_path, monkeyp
     monkeypatch.setattr(auto_update, "NEXO_HOME", runtime_home)
     monkeypatch.setattr(auto_update, "_reinstall_runtime_pip_deps", lambda dest: True)
     monkeypatch.setattr(auto_update.subprocess, "run", fake_run)
-    monkeypatch.setattr(client_sync, "sync_all_clients", lambda **kwargs: {"ok": True, "clients": {}})
+    def fake_sync_all_clients(**kwargs):
+        captured.update(kwargs)
+        return {"ok": True, "clients": {}}
+
+    monkeypatch.setattr(client_sync, "sync_all_clients", fake_sync_all_clients)
 
     import runtime_power
 
@@ -187,6 +192,7 @@ def test_run_runtime_post_sync_uses_reconcile_personal_scripts(tmp_path, monkeyp
     assert "client-sync" in actions
     init_call = next(cmd for cmd in calls if isinstance(cmd, list) and len(cmd) >= 3 and cmd[1] == "-c")
     assert "reconcile_personal_scripts" in init_call[2]
+    assert captured["auto_install_missing_claude"] is True
 
 
 def test_run_runtime_post_sync_reports_personal_schedule_heal(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary\n- auto-install Claude Code with the canonical @anthropic-ai/claude-code package when selected clients need it\n- wire the self-heal into nexo update and nexo doctor --tier runtime --fix\n- cover the repair path with client sync, packaged update, startup preflight, and doctor tests\n\n## Verification\n- python3 -m pytest -q tests/test_client_sync.py tests/test_doctor.py tests/test_packaged_update_runtime.py tests/test_startup_preflight.py\n- git diff --check\n\n## Notes\n- keeps Claude-assisted paths intact; this only repairs missing Claude Code installs\n- ignores unrelated local change in tests/test_cli_scripts.py