### PR TITLE
fix: v5.4.3 — test isolation for tree_hygiene module

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.4.2",
+  "version": "5.4.3",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [5.4.3] - 2026-04-14
+
+### Fix: test isolation for tree_hygiene module
+
+- Fixed 2 test failures in `TestRuntimeUpdate` that broke the v5.4.2 publish
+  workflow. Both `test_installed_runtime_update_repairs_missing_public_contribution_module`
+  and `test_packaged_update_reads_runtime_version_from_version_json` set up
+  isolated runtime directories but did not copy `tree_hygiene.py`, causing
+  `ModuleNotFoundError` when `auto_update.py` and `plugins/update.py` imported it.
+
 ## [5.4.2] - 2026-04-14
 
 ### Fix: traceability truth + Sensory Register buffer close-loop

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [Watch the overview video](https://nexo-brain.com/watch/) · [Watch on YouTube](https://www.youtube.com/watch?v=i2lkGhKyVqI) · [Open the infographic](https://nexo-brain.com/assets/nexo-brain-infographic-v5.png)
 
-Version `5.4.2` is the current packaged-runtime line: traceability truth + Sensory Register buffer close-loop — release warnings now distinguish repo `commit_ref` debt from local/server-side operational changes, the nocturnal postmortem drains pending `session_buffer.jsonl` events and rewrites the buffer atomically, and docs now state honestly that `nexo-reflection.py` is standalone rather than auto-triggered by the stop hook.
+Version `5.4.3` is the current packaged-runtime line: test isolation fix for tree_hygiene module — 2 tests that broke the v5.4.2 publish workflow now correctly copy `tree_hygiene.py` into their isolated runtime directories.
 
 Previously in `5.4.0`: runtime event bus at `~/.nexo/runtime/events.ndjson`, `nexo notify`, `nexo health --json`, `nexo logs --tail --json`, and a safe flat→nested migration for `calibration.json`.
 

--- a/blog/index.html
+++ b/blog/index.html
@@ -134,7 +134,7 @@
                     <span class="page-chip">Competitive analysis</span>
                 </div>
                 <div class="hero-actions" style="justify-content:flex-start;">
-                    <a href="/blog/nexo-5-4-2-traceability-and-buffer-close-loop/" class="btn btn-primary">Read latest release</a>
+                    <a href="/blog/nexo-5-4-3-test-isolation-fix/" class="btn btn-primary">Read latest release</a>
                     <a href="/changelog/" class="btn btn-secondary">Latest release notes</a>
                     <a href="/evolution/" class="btn btn-secondary">See Evolution</a>
                 </div>
@@ -143,24 +143,23 @@
                 <div class="section-label">Latest release</div>
                 <div class="blog-featured-meta">
                     <span class="compare-chip">April 14, 2026</span>
-                    <span class="compare-chip">Traceability truth</span>
-                    <span class="compare-chip">Sensory Register</span>
-                    <span class="compare-chip">Close-loop</span>
+                    <span class="compare-chip">Hotfix</span>
+                    <span class="compare-chip">CI / tests</span>
                 </div>
-                <h2>NEXO 5.4.2: Traceability truth + Sensory Register buffer close-loop</h2>
-                <p>NEXO 5.4.2 stops inflating local/runtime operations into fake repo <code>commit_ref</code> debt, drains pending <code>session_buffer.jsonl</code> events through the nocturnal postmortem instead of looking only at "today", rewrites the buffer atomically, and aligns docs with the real stop-hook / reflection boundary. No Claude/Opus-assisted path was removed.</p>
+                <h2>NEXO 5.4.3: Test Isolation Fix for tree_hygiene Module</h2>
+                <p>Hotfix: 2 tests that broke the v5.4.2 publish workflow now correctly copy <code>tree_hygiene.py</code> into their isolated runtime directories, resolving the <code>ModuleNotFoundError</code> that prevented the CI publish job from completing.</p>
                 <div class="hero-actions" style="justify-content:flex-start;margin-bottom:18px;">
-                    <a href="/blog/nexo-5-4-2-traceability-and-buffer-close-loop/" class="btn btn-primary">Open article</a>
-                    <a href="/changelog/#v542" class="btn btn-secondary">Open changelog</a>
+                    <a href="/blog/nexo-5-4-3-test-isolation-fix/" class="btn btn-primary">Open article</a>
+                    <a href="/changelog/#v543" class="btn btn-secondary">Open changelog</a>
                 </div>
                 <div class="blog-mini-stack">
                     <div class="blog-mini-card">
                         <strong>Companion view</strong>
-                        <span><a href="/changelog/#v542">The 5.4.2 changelog section</a></span>
+                        <span><a href="/changelog/#v543">The 5.4.3 changelog section</a></span>
                     </div>
                     <div class="blog-mini-card">
                         <strong>Previous release</strong>
-                        <span><a href="/blog/nexo-5-4-1-hook-hygiene-fix/">NEXO 5.4.1: Hook hygiene fix — Sensory Register writing "unknown" for 48h</a>.</span>
+                        <span><a href="/blog/nexo-5-4-2-traceability-and-buffer-close-loop/">NEXO 5.4.2: Traceability truth + Sensory Register buffer close-loop</a>.</span>
                     </div>
                 </div>
             </div>
@@ -172,6 +171,13 @@
 <section class="section-flush-top">
     <div class="container">
         <div class="blog-grid">
+
+            <div class="blog-card">
+                <div class="blog-card-date">April 14, 2026</div>
+                <h2><a href="/blog/nexo-5-4-3-test-isolation-fix/">NEXO 5.4.3: Test Isolation Fix for tree_hygiene Module</a></h2>
+                <p>Hotfix: 2 tests that broke the v5.4.2 publish workflow now correctly copy <code>tree_hygiene.py</code> into their isolated runtime directories.</p>
+                <a href="/blog/nexo-5-4-3-test-isolation-fix/" class="read-more">Read more &rarr;</a>
+            </div>
 
             <div class="blog-card">
                 <div class="blog-card-date">April 14, 2026</div>

--- a/blog/nexo-5-4-3-test-isolation-fix/index.html
+++ b/blog/nexo-5-4-3-test-isolation-fix/index.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <title>NEXO 5.4.3: Test Isolation Fix for tree_hygiene Module</title>
+    <meta name="description" content="NEXO 5.4.3 fixes 2 test failures that broke the v5.4.2 publish workflow by copying tree_hygiene.py into isolated runtime directories used by TestRuntimeUpdate.">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://nexo-brain.com/blog/nexo-5-4-3-test-isolation-fix/">
+
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://nexo-brain.com/blog/nexo-5-4-3-test-isolation-fix/">
+    <meta property="og:title" content="NEXO 5.4.3: Test Isolation Fix for tree_hygiene Module">
+    <meta property="og:description" content="Hotfix: 2 tests that broke the v5.4.2 publish workflow now correctly copy tree_hygiene.py into their isolated runtime directories.">
+    <meta property="og:image" content="https://nexo-brain.com/assets/og/og-blog.png">
+    <meta property="article:published_time" content="2026-04-14">
+    <meta property="article:author" content="Francisco Cerda Puigserver">
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="NEXO 5.4.3: Test Isolation Fix for tree_hygiene Module">
+    <meta name="twitter:description" content="Hotfix: 2 tests that broke the v5.4.2 publish workflow now correctly copy tree_hygiene.py into their isolated runtime directories.">
+    <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-blog.png">
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-1LNEMCJMS7"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-1LNEMCJMS7');
+    </script>
+
+    <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicon-32.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
+    <link rel="stylesheet" href="/assets/style.css">
+
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "NEXO 5.4.3: Test Isolation Fix for tree_hygiene Module",
+        "description": "NEXO 5.4.3 fixes 2 test failures that broke the v5.4.2 publish workflow by copying tree_hygiene.py into isolated runtime directories used by TestRuntimeUpdate.",
+        "datePublished": "2026-04-14",
+        "dateModified": "2026-04-14",
+        "author": {
+            "@type": "Person",
+            "name": "Francisco Cerda Puigserver"
+        },
+        "publisher": {
+            "@type": "Organization",
+            "name": "WAzion",
+            "url": "https://www.wazion.com"
+        },
+        "mainEntityOfPage": {
+            "@type": "WebPage",
+            "@id": "https://nexo-brain.com/blog/nexo-5-4-3-test-isolation-fix/"
+        },
+        "url": "https://nexo-brain.com/blog/nexo-5-4-3-test-isolation-fix/",
+        "image": "https://nexo-brain.com/assets/og/og-blog.png",
+        "keywords": ["NEXO 5.4.3", "test isolation", "tree_hygiene", "CI fix", "publish workflow"]
+    }
+    </script>
+
+    <style>
+        .article-header { padding-top: 128px; padding-bottom: 40px; text-align: center; }
+        .article-meta { font-size: 14px; color: var(--text-muted); margin-bottom: 16px; }
+        .article-body {
+            max-width: 720px; margin: 0 auto; padding: 0 24px 80px;
+            font-size: 17px; line-height: 1.8; color: var(--text);
+        }
+        .article-body h2 { font-size: 28px; font-weight: 700; margin: 48px 0 16px; letter-spacing: -0.01em; }
+        .article-body p { margin-bottom: 20px; color: var(--text-muted); }
+        .article-body strong { color: var(--text); }
+        .article-body a { color: var(--purple-light); }
+        .article-body a:hover { color: var(--pink); }
+        .article-body code {
+            font-family: 'SF Mono', 'Fira Code', monospace;
+            font-size: 14px; color: var(--pink);
+            background: rgba(236, 72, 153, 0.1);
+            padding: 2px 8px; border-radius: 4px;
+        }
+        .article-back {
+            display: inline-flex; align-items: center; gap: 6px;
+            font-size: 14px; font-weight: 600; color: var(--text-muted);
+            margin-bottom: 24px;
+        }
+        .article-back:hover { color: var(--purple-light); }
+    </style>
+</head>
+<body>
+
+<nav>
+    <div class="container">
+        <a href="/" class="nav-logo">
+            <img src="/assets/logo-64.png" alt="NEXO Brain" class="logo-image">
+            <span class="logo-text">NEXO Brain</span>
+        </a>
+        <button class="mobile-menu-toggle" aria-label="Toggle navigation" onclick="toggleMobileMenu()">
+            <span></span><span></span><span></span>
+        </button>
+        <div class="nav-links">
+            <a href="/">Home</a>
+            <a href="/features/">Features</a>
+            <a href="/evolution/">Evolution</a>
+            <a href="/compare/">Compare</a>
+            <a href="/blog/">Blog</a>
+            <a href="/changelog/">Changelog</a>
+            <a href="/docs/">Docs</a>
+            <a href="https://github.com/wazionapps/nexo" class="nav-cta">GitHub</a>
+        </div>
+    </div>
+</nav>
+
+<section class="article-header">
+    <div class="container">
+        <a href="/blog/" class="article-back">&larr; Back to blog</a>
+        <div class="article-meta">April 14, 2026 &middot; Hotfix &middot; CI / tests</div>
+        <h1 class="section-title" style="font-size:clamp(28px,4.5vw,48px);max-width:920px;margin:0 auto 16px;">NEXO 5.4.3: Test Isolation Fix for tree_hygiene Module</h1>
+        <p class="section-subtitle" style="max-width:760px;margin:0 auto;">The v5.4.2 publish workflow failed because two tests set up isolated runtime directories without copying the newly required <code>tree_hygiene.py</code> module. This hotfix adds the missing copy.</p>
+    </div>
+</section>
+
+<section>
+    <div class="article-body">
+
+        <h2>What happened</h2>
+        <p>When v5.4.2 introduced <code>from tree_hygiene import is_duplicate_artifact_name</code> in both <code>auto_update.py</code> and <code>plugins/update.py</code>, two existing tests in <code>TestRuntimeUpdate</code> broke. These tests create isolated temporary directories that simulate a packaged NEXO runtime, copying specific source files but not <code>tree_hygiene.py</code>. The result was a <code>ModuleNotFoundError</code> that caused the CI publish job to fail with 2 failed / 857 passed.</p>
+
+        <h2>The fix</h2>
+        <p>Both <code>test_installed_runtime_update_repairs_missing_public_contribution_module</code> and <code>test_packaged_update_reads_runtime_version_from_version_json</code> now copy <code>tree_hygiene.py</code> from the real source directory into their isolated runtime directories, matching the pattern already used for <code>runtime_home.py</code> and <code>auto_update.py</code>.</p>
+
+        <h2>Impact</h2>
+        <p>This is a test-only change. No runtime behavior is modified. The publish workflow should now complete successfully, allowing npm and GitHub Release artifacts for the 5.4.x line to be created.</p>
+
+    </div>
+</section>
+
+<footer>
+    <div class="container" style="text-align:center; padding: 48px 24px 32px; color: var(--text-muted); font-size: 14px;">
+        <p>&copy; 2024&ndash;2026 WAzion &middot; <a href="https://github.com/wazionapps/nexo" style="color:var(--purple-light);">GitHub</a> &middot; AGPL-3.0</p>
+    </div>
+</footer>
+
+<script>
+function toggleMobileMenu() {
+    document.querySelector('.nav-links').classList.toggle('active');
+    document.querySelector('.mobile-menu-toggle').classList.toggle('active');
+}
+</script>
+
+</body>
+</html>

--- a/changelog/index.html
+++ b/changelog/index.html
@@ -181,6 +181,17 @@
     </div>
 </section>
 
+<!-- v5.4.3 test isolation fix -->
+<section id="v543" class="section-compact" style="background:linear-gradient(135deg,#09111f 0%,#14253a 50%,#1e3a5f 100%);">
+    <div class="container">
+        <div class="section-label">New in v5.4.3 <span style="opacity:.5;font-weight:400;">&mdash; April 14, 2026</span></div>
+        <h2 class="section-title">Test isolation fix for tree_hygiene module</h2>
+        <p class="section-subtitle">
+            Hotfix: 2 tests in <code>TestRuntimeUpdate</code> that broke the v5.4.2 publish workflow now correctly copy <code>tree_hygiene.py</code> into their isolated runtime directories, resolving the <code>ModuleNotFoundError</code> that prevented the CI publish job from completing.
+        </p>
+    </div>
+</section>
+
 <!-- v5.4.2 traceability truth + buffer close-loop -->
 <section id="v542" class="section-compact" style="background:linear-gradient(135deg,#09111f 0%,#12324a 34%,#0f766e 68%,#22d3ee 100%);">
     <div class="container">

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 5.4.2
+version: 5.4.3
 metadata:
   openclaw:
     requires:

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents</title>
-    <meta name="description" content="Libre/open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.4.2 makes release traceability honest again, closes the Sensory Register buffer loop, and aligns the public docs with the real stop-hook/runtime behavior.">
+    <meta name="description" content="Libre/open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.4.3 fixes test isolation for the tree_hygiene module so the publish workflow passes.">
     <meta name="keywords" content="AI memory, cognitive architecture, MCP, Claude Code, Codex, Claude Desktop, agent memory, vector search, AI agents, shared brain, open source">
     <meta name="author" content="WAzion">
     <meta name="robots" content="index, follow">
@@ -14,7 +14,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://nexo-brain.com">
     <meta property="og:title" content="NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents">
-    <meta property="og:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.4.2 makes release traceability honest again, closes the Sensory Register buffer loop, and aligns the public docs with the real stop-hook/runtime behavior.">
+    <meta property="og:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.4.3 fixes test isolation for the tree_hygiene module so the publish workflow passes.">
     <meta property="og:image" content="https://nexo-brain.com/assets/og/og-home.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -22,7 +22,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents">
-    <meta name="twitter:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.4.2 makes release traceability honest again, closes the Sensory Register buffer loop, and aligns the public docs with the real stop-hook/runtime behavior.">
+    <meta name="twitter:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.4.3 fixes test isolation for the tree_hygiene module so the publish workflow passes.">
     <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-home.png">
 
     <!-- Google Analytics (GA4) -->
@@ -46,12 +46,12 @@
         "@context": "https://schema.org",
         "@type": "SoftwareApplication",
         "name": "NEXO Brain",
-        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.4.2 makes release traceability honest again, closes the Sensory Register buffer loop, and aligns the public docs with the real stop-hook/runtime behavior.",
+        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.4.3 fixes test isolation for the tree_hygiene module so the publish workflow passes.",
         "applicationCategory": "DeveloperApplication",
         "operatingSystem": "macOS, Linux, Windows",
         "url": "https://nexo-brain.com",
         "downloadUrl": "https://www.npmjs.com/package/nexo-brain",
-        "softwareVersion": "5.4.2",
+        "softwareVersion": "5.4.3",
         "license": "https://www.gnu.org/licenses/agpl-3.0",
         "author": {
             "@type": "Organization",
@@ -88,7 +88,7 @@
         "@type": "WebSite",
         "name": "NEXO Brain",
         "url": "https://nexo-brain.com",
-        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.4.2 makes release traceability honest again, closes the Sensory Register buffer loop, and aligns the public docs with the real stop-hook/runtime behavior.",
+        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.4.3 fixes test isolation for the tree_hygiene module so the publish workflow passes.",
         "publisher": {
             "@type": "Organization",
             "name": "WAzion",
@@ -697,7 +697,7 @@
     <div class="container">
         <div class="hero-badge fade-up">
             <span class="dot"></span>
-            <span id="version-badge">v5.4.2</span> &mdash; traceability truth + Sensory Register buffer close-loop
+            <span id="version-badge">v5.4.3</span> &mdash; test isolation fix for tree_hygiene module
         </div>
         <div class="fade-up" style="display:flex;gap:8px;justify-content:center;margin-bottom:12px;">
             <img src="https://img.shields.io/npm/v/nexo-brain?color=7C3AED&label=npm" alt="npm version">

--- a/llms.txt
+++ b/llms.txt
@@ -1,9 +1,10 @@
 # NEXO Brain
 
-> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.4.2).
+> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.4.3).
 
 NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. It adds a local shared brain across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, smarter retrieval defaults, long-horizon overnight analysis, and 150+ MCP tools.
 
+v5.4.3: test isolation fix — copy tree_hygiene.py into isolated runtime dirs so the publish workflow passes
 v5.4.2: traceability truth + Sensory Register buffer close-loop — diary warnings now distinguish repo `commit_ref` debt from local/server-side operational changes, the nocturnal postmortem drains pending `session_buffer.jsonl` events instead of looking only at "today", rewrites the buffer atomically, and the docs now say honestly that `nexo-reflection.py` is a standalone analyzer rather than something auto-triggered by the stop hook
 v5.4.1: hook hygiene fix — the PostToolUse `capture-session.sh` hook had been reading a nonexistent env var since 2026-04-12, silently writing `"tool":"unknown"` to `~/.nexo/brain/session_buffer.jsonl` for 48 hours. v5.4.1 parses `tool_name` from stdin JSON, removes the filter that was hiding `Bash`, deletes the contaminating `capture-session 2.sh` duplicate, and purges pre-fix entries from the buffer on update with a `.pre-v5.4.1.bak` backup
 v5.4.0: runtime events + health + logs + calibration migration — append-only event bus at `~/.nexo/runtime/events.ndjson` with stable envelope, `nexo notify` for one-shot proactive events, `nexo health --json` for a rolled-up subsystem snapshot, `nexo logs --tail --json` for structured log access, and a safe flat→nested migration for `calibration.json` that runs silently inside `nexo update` with a pre-migrate backup

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "5.4.2",
+  "version": "5.4.3",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.4.2" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.4.3" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.4.2",
+  "version": "5.4.3",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -145,6 +145,12 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://nexo-brain.com/blog/nexo-5-4-3-test-isolation-fix/</loc>
+    <lastmod>2026-04-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.95</priority>
+  </url>
+  <url>
     <loc>https://nexo-brain.com/blog/nexo-5-4-2-traceability-and-buffer-close-loop/</loc>
     <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>

--- a/tests/test_cli_scripts.py
+++ b/tests/test_cli_scripts.py
@@ -264,6 +264,7 @@ class TestRuntimeUpdate:
         (runtime_home / "cli.py").write_text((current_src / "cli.py").read_text())
         (runtime_home / "auto_update.py").write_text((current_src / "auto_update.py").read_text())
         (runtime_home / "runtime_home.py").write_text((current_src / "runtime_home.py").read_text())
+        (runtime_home / "tree_hygiene.py").write_text((current_src / "tree_hygiene.py").read_text())
         (runtime_home / "runtime_power.py").write_text(
             "def ensure_power_policy_choice(**kwargs):\n"
             "    return {'policy': 'disabled', 'prompted': False}\n\n"
@@ -455,6 +456,9 @@ class TestRuntimeUpdate:
         update_copy.write_text(src_update.read_text())
         (runtime_home / "runtime_home.py").write_text(
             (Path(os.path.dirname(__file__)).parent / "src" / "runtime_home.py").read_text()
+        )
+        (runtime_home / "tree_hygiene.py").write_text(
+            (Path(os.path.dirname(__file__)).parent / "src" / "tree_hygiene.py").read_text()
         )
 
         probe = (


### PR DESCRIPTION
## Summary
- 2 tests in `TestRuntimeUpdate` set up isolated runtime directories but did not copy `tree_hygiene.py`, causing `ModuleNotFoundError` when `auto_update.py` and `plugins/update.py` imported it
- This broke the v5.4.2 publish workflow (run 24406516172, 2 failed / 857 passed)
- Both tests now copy `tree_hygiene.py` into their isolated dirs

## Test plan
- [x] `pytest tests/test_cli_scripts.py::TestRuntimeUpdate` — 4/4 pass
- [x] `verify_release_readiness.py` — repo + website surfaces pass
- [x] gh-pages already updated and pushed

Once merged, tag `v5.4.3` and push to trigger the publish workflow.