### PR TITLE
fix: v5.4.4 — test isolation + CI venv timeout fix

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.4.3",
+  "version": "5.4.4",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [5.4.4] - 2026-04-14
+
+### Fix: test isolation for tree_hygiene module + venv timeout in CI
+
+- Fixed 2 test failures from v5.4.2: `tree_hygiene.py` now copied into
+  isolated runtime directories used by `TestRuntimeUpdate`.
+- Fixed CI timeout in `test_update_uses_recorded_source_repo`: tests now
+  pre-create a fake `.venv/bin/python3` so `_ensure_runtime_venv` skips
+  the slow venv creation that exceeds the 10-second timeout on GitHub
+  Actions runners.
+
 ## [5.4.3] - 2026-04-14
 
 ### Fix: test isolation for tree_hygiene module

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [Watch the overview video](https://nexo-brain.com/watch/) · [Watch on YouTube](https://www.youtube.com/watch?v=i2lkGhKyVqI) · [Open the infographic](https://nexo-brain.com/assets/nexo-brain-infographic-v5.png)
 
-Version `5.4.3` is the current packaged-runtime line: test isolation fix for tree_hygiene module — 2 tests that broke the v5.4.2 publish workflow now correctly copy `tree_hygiene.py` into their isolated runtime directories.
+Version `5.4.4` is the current packaged-runtime line: test isolation for tree_hygiene module + fake venv to prevent CI timeout — completes the publish workflow fix from v5.4.3.
 
 Previously in `5.4.0`: runtime event bus at `~/.nexo/runtime/events.ndjson`, `nexo notify`, `nexo health --json`, `nexo logs --tail --json`, and a safe flat→nested migration for `calibration.json`.
 

--- a/blog/index.html
+++ b/blog/index.html
@@ -134,7 +134,7 @@
                     <span class="page-chip">Competitive analysis</span>
                 </div>
                 <div class="hero-actions" style="justify-content:flex-start;">
-                    <a href="/blog/nexo-5-4-3-test-isolation-fix/" class="btn btn-primary">Read latest release</a>
+                    <a href="/blog/nexo-5-4-4-test-and-venv-fix/" class="btn btn-primary">Read latest release</a>
                     <a href="/changelog/" class="btn btn-secondary">Latest release notes</a>
                     <a href="/evolution/" class="btn btn-secondary">See Evolution</a>
                 </div>
@@ -146,16 +146,16 @@
                     <span class="compare-chip">Hotfix</span>
                     <span class="compare-chip">CI / tests</span>
                 </div>
-                <h2>NEXO 5.4.3: Test Isolation Fix for tree_hygiene Module</h2>
-                <p>Hotfix: 2 tests that broke the v5.4.2 publish workflow now correctly copy <code>tree_hygiene.py</code> into their isolated runtime directories, resolving the <code>ModuleNotFoundError</code> that prevented the CI publish job from completing.</p>
+                <h2>NEXO 5.4.4: Test Isolation + CI Venv Timeout Fix</h2>
+                <p>Completes the publish workflow fix: adds missing <code>tree_hygiene.py</code> copies + fake <code>.venv</code> to prevent CI timeout during <code>_ensure_runtime_venv</code>.</p>
                 <div class="hero-actions" style="justify-content:flex-start;margin-bottom:18px;">
-                    <a href="/blog/nexo-5-4-3-test-isolation-fix/" class="btn btn-primary">Open article</a>
-                    <a href="/changelog/#v543" class="btn btn-secondary">Open changelog</a>
+                    <a href="/blog/nexo-5-4-4-test-and-venv-fix/" class="btn btn-primary">Open article</a>
+                    <a href="/changelog/#v544" class="btn btn-secondary">Open changelog</a>
                 </div>
                 <div class="blog-mini-stack">
                     <div class="blog-mini-card">
                         <strong>Companion view</strong>
-                        <span><a href="/changelog/#v543">The 5.4.3 changelog section</a></span>
+                        <span><a href="/changelog/#v544">The 5.4.4 changelog section</a></span>
                     </div>
                     <div class="blog-mini-card">
                         <strong>Previous release</strong>
@@ -174,9 +174,9 @@
 
             <div class="blog-card">
                 <div class="blog-card-date">April 14, 2026</div>
-                <h2><a href="/blog/nexo-5-4-3-test-isolation-fix/">NEXO 5.4.3: Test Isolation Fix for tree_hygiene Module</a></h2>
+                <h2><a href="/blog/nexo-5-4-4-test-and-venv-fix/">NEXO 5.4.4: Test Isolation + CI Venv Timeout Fix</a></h2>
                 <p>Hotfix: 2 tests that broke the v5.4.2 publish workflow now correctly copy <code>tree_hygiene.py</code> into their isolated runtime directories.</p>
-                <a href="/blog/nexo-5-4-3-test-isolation-fix/" class="read-more">Read more &rarr;</a>
+                <a href="/blog/nexo-5-4-4-test-and-venv-fix/" class="read-more">Read more &rarr;</a>
             </div>
 
             <div class="blog-card">

--- a/blog/nexo-5-4-4-test-and-venv-fix/index.html
+++ b/blog/nexo-5-4-4-test-and-venv-fix/index.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <title>NEXO 5.4.4: Test Isolation + CI Venv Timeout Fix</title>
+    <meta name="description" content="NEXO 5.4.4 fixes 2 test failures that broke the v5.4.2 publish workflow by copying tree_hygiene.py into isolated runtime directories used by TestRuntimeUpdate.">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://nexo-brain.com/blog/nexo-5-4-4-test-and-venv-fix/">
+
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://nexo-brain.com/blog/nexo-5-4-4-test-and-venv-fix/">
+    <meta property="og:title" content="NEXO 5.4.4: Test Isolation + CI Venv Timeout Fix">
+    <meta property="og:description" content="Hotfix: 2 tests that broke the v5.4.2 publish workflow now correctly copy tree_hygiene.py into their isolated runtime directories.">
+    <meta property="og:image" content="https://nexo-brain.com/assets/og/og-blog.png">
+    <meta property="article:published_time" content="2026-04-14">
+    <meta property="article:author" content="Francisco Cerda Puigserver">
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="NEXO 5.4.4: Test Isolation + CI Venv Timeout Fix">
+    <meta name="twitter:description" content="Hotfix: 2 tests that broke the v5.4.2 publish workflow now correctly copy tree_hygiene.py into their isolated runtime directories.">
+    <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-blog.png">
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-1LNEMCJMS7"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-1LNEMCJMS7');
+    </script>
+
+    <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicon-32.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
+    <link rel="stylesheet" href="/assets/style.css">
+
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "NEXO 5.4.4: Test Isolation + CI Venv Timeout Fix",
+        "description": "NEXO 5.4.4 fixes 2 test failures that broke the v5.4.2 publish workflow by copying tree_hygiene.py into isolated runtime directories used by TestRuntimeUpdate.",
+        "datePublished": "2026-04-14",
+        "dateModified": "2026-04-14",
+        "author": {
+            "@type": "Person",
+            "name": "Francisco Cerda Puigserver"
+        },
+        "publisher": {
+            "@type": "Organization",
+            "name": "WAzion",
+            "url": "https://www.wazion.com"
+        },
+        "mainEntityOfPage": {
+            "@type": "WebPage",
+            "@id": "https://nexo-brain.com/blog/nexo-5-4-4-test-and-venv-fix/"
+        },
+        "url": "https://nexo-brain.com/blog/nexo-5-4-4-test-and-venv-fix/",
+        "image": "https://nexo-brain.com/assets/og/og-blog.png",
+        "keywords": ["NEXO 5.4.4", "test isolation", "tree_hygiene", "CI fix", "publish workflow"]
+    }
+    </script>
+
+    <style>
+        .article-header { padding-top: 128px; padding-bottom: 40px; text-align: center; }
+        .article-meta { font-size: 14px; color: var(--text-muted); margin-bottom: 16px; }
+        .article-body {
+            max-width: 720px; margin: 0 auto; padding: 0 24px 80px;
+            font-size: 17px; line-height: 1.8; color: var(--text);
+        }
+        .article-body h2 { font-size: 28px; font-weight: 700; margin: 48px 0 16px; letter-spacing: -0.01em; }
+        .article-body p { margin-bottom: 20px; color: var(--text-muted); }
+        .article-body strong { color: var(--text); }
+        .article-body a { color: var(--purple-light); }
+        .article-body a:hover { color: var(--pink); }
+        .article-body code {
+            font-family: 'SF Mono', 'Fira Code', monospace;
+            font-size: 14px; color: var(--pink);
+            background: rgba(236, 72, 153, 0.1);
+            padding: 2px 8px; border-radius: 4px;
+        }
+        .article-back {
+            display: inline-flex; align-items: center; gap: 6px;
+            font-size: 14px; font-weight: 600; color: var(--text-muted);
+            margin-bottom: 24px;
+        }
+        .article-back:hover { color: var(--purple-light); }
+    </style>
+</head>
+<body>
+
+<nav>
+    <div class="container">
+        <a href="/" class="nav-logo">
+            <img src="/assets/logo-64.png" alt="NEXO Brain" class="logo-image">
+            <span class="logo-text">NEXO Brain</span>
+        </a>
+        <button class="mobile-menu-toggle" aria-label="Toggle navigation" onclick="toggleMobileMenu()">
+            <span></span><span></span><span></span>
+        </button>
+        <div class="nav-links">
+            <a href="/">Home</a>
+            <a href="/features/">Features</a>
+            <a href="/evolution/">Evolution</a>
+            <a href="/compare/">Compare</a>
+            <a href="/blog/">Blog</a>
+            <a href="/changelog/">Changelog</a>
+            <a href="/docs/">Docs</a>
+            <a href="https://github.com/wazionapps/nexo" class="nav-cta">GitHub</a>
+        </div>
+    </div>
+</nav>
+
+<section class="article-header">
+    <div class="container">
+        <a href="/blog/" class="article-back">&larr; Back to blog</a>
+        <div class="article-meta">April 14, 2026 &middot; Hotfix &middot; CI / tests</div>
+        <h1 class="section-title" style="font-size:clamp(28px,4.5vw,48px);max-width:920px;margin:0 auto 16px;">NEXO 5.4.4: Test Isolation + CI Venv Timeout Fix</h1>
+        <p class="section-subtitle" style="max-width:760px;margin:0 auto;">The v5.4.2 publish workflow failed because two tests set up isolated runtime directories without copying the newly required <code>tree_hygiene.py</code> module. This hotfix adds the missing copy.</p>
+    </div>
+</section>
+
+<section>
+    <div class="article-body">
+
+        <h2>What happened</h2>
+        <p>When v5.4.2 introduced <code>from tree_hygiene import is_duplicate_artifact_name</code> in both <code>auto_update.py</code> and <code>plugins/update.py</code>, two existing tests in <code>TestRuntimeUpdate</code> broke. These tests create isolated temporary directories that simulate a packaged NEXO runtime, copying specific source files but not <code>tree_hygiene.py</code>. The result was a <code>ModuleNotFoundError</code> that caused the CI publish job to fail with 2 failed / 857 passed.</p>
+
+        <h2>The fix (v5.4.3 + v5.4.4)</h2>
+        <p><strong>v5.4.3</strong> added the missing <code>tree_hygiene.py</code> copy to both tests. <strong>v5.4.4</strong> adds fake <code>.venv/bin/python3</code> and <code>.venv/bin/pip</code> stubs to tests that run <code>nexo update</code>, so <code>_ensure_runtime_venv</code> finds a pre-existing venv and skips the slow creation that exceeded the 10-second subprocess timeout on GitHub Actions runners.</p>
+
+        <h2>Impact</h2>
+        <p>Test-only changes. No runtime behavior is modified. The publish workflow should now complete successfully, allowing npm and GitHub Release artifacts for the 5.4.x line to be created.</p>
+
+    </div>
+</section>
+
+<footer>
+    <div class="container" style="text-align:center; padding: 48px 24px 32px; color: var(--text-muted); font-size: 14px;">
+        <p>&copy; 2024&ndash;2026 WAzion &middot; <a href="https://github.com/wazionapps/nexo" style="color:var(--purple-light);">GitHub</a> &middot; AGPL-3.0</p>
+    </div>
+</footer>
+
+<script>
+function toggleMobileMenu() {
+    document.querySelector('.nav-links').classList.toggle('active');
+    document.querySelector('.mobile-menu-toggle').classList.toggle('active');
+}
+</script>
+
+</body>
+</html>

--- a/changelog/index.html
+++ b/changelog/index.html
@@ -181,6 +181,17 @@
     </div>
 </section>
 
+<!-- v5.4.4 test isolation + venv timeout fix -->
+<section id="v544" class="section-compact" style="background:linear-gradient(135deg,#09111f 0%,#14253a 50%,#1e3a5f 100%);">
+    <div class="container">
+        <div class="section-label">New in v5.4.4 <span style="opacity:.5;font-weight:400;">&mdash; April 14, 2026</span></div>
+        <h2 class="section-title">Test isolation + CI venv timeout fix</h2>
+        <p class="section-subtitle">
+            Completes the publish workflow fix: v5.4.3 added missing <code>tree_hygiene.py</code> copies, v5.4.4 adds fake <code>.venv</code> directories so <code>_ensure_runtime_venv</code> does not try to create a real venv during tests (which timed out on GitHub Actions runners).
+        </p>
+    </div>
+</section>
+
 <!-- v5.4.3 test isolation fix -->
 <section id="v543" class="section-compact" style="background:linear-gradient(135deg,#09111f 0%,#14253a 50%,#1e3a5f 100%);">
     <div class="container">

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 5.4.3
+version: 5.4.4
 metadata:
   openclaw:
     requires:

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents</title>
-    <meta name="description" content="Libre/open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.4.3 fixes test isolation for the tree_hygiene module so the publish workflow passes.">
+    <meta name="description" content="Libre/open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.4.4 fixes test isolation and CI venv timeout so the publish workflow passes.">
     <meta name="keywords" content="AI memory, cognitive architecture, MCP, Claude Code, Codex, Claude Desktop, agent memory, vector search, AI agents, shared brain, open source">
     <meta name="author" content="WAzion">
     <meta name="robots" content="index, follow">
@@ -14,7 +14,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://nexo-brain.com">
     <meta property="og:title" content="NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents">
-    <meta property="og:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.4.3 fixes test isolation for the tree_hygiene module so the publish workflow passes.">
+    <meta property="og:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.4.4 fixes test isolation and CI venv timeout so the publish workflow passes.">
     <meta property="og:image" content="https://nexo-brain.com/assets/og/og-home.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -22,7 +22,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents">
-    <meta name="twitter:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.4.3 fixes test isolation for the tree_hygiene module so the publish workflow passes.">
+    <meta name="twitter:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.4.4 fixes test isolation and CI venv timeout so the publish workflow passes.">
     <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-home.png">
 
     <!-- Google Analytics (GA4) -->
@@ -46,12 +46,12 @@
         "@context": "https://schema.org",
         "@type": "SoftwareApplication",
         "name": "NEXO Brain",
-        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.4.3 fixes test isolation for the tree_hygiene module so the publish workflow passes.",
+        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.4.4 fixes test isolation and CI venv timeout so the publish workflow passes.",
         "applicationCategory": "DeveloperApplication",
         "operatingSystem": "macOS, Linux, Windows",
         "url": "https://nexo-brain.com",
         "downloadUrl": "https://www.npmjs.com/package/nexo-brain",
-        "softwareVersion": "5.4.3",
+        "softwareVersion": "5.4.4",
         "license": "https://www.gnu.org/licenses/agpl-3.0",
         "author": {
             "@type": "Organization",
@@ -88,7 +88,7 @@
         "@type": "WebSite",
         "name": "NEXO Brain",
         "url": "https://nexo-brain.com",
-        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.4.3 fixes test isolation for the tree_hygiene module so the publish workflow passes.",
+        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.4.4 fixes test isolation and CI venv timeout so the publish workflow passes.",
         "publisher": {
             "@type": "Organization",
             "name": "WAzion",
@@ -697,7 +697,7 @@
     <div class="container">
         <div class="hero-badge fade-up">
             <span class="dot"></span>
-            <span id="version-badge">v5.4.3</span> &mdash; test isolation fix for tree_hygiene module
+            <span id="version-badge">v5.4.4</span> &mdash; test isolation + CI venv timeout fix
         </div>
         <div class="fade-up" style="display:flex;gap:8px;justify-content:center;margin-bottom:12px;">
             <img src="https://img.shields.io/npm/v/nexo-brain?color=7C3AED&label=npm" alt="npm version">

--- a/llms.txt
+++ b/llms.txt
@@ -1,9 +1,10 @@
 # NEXO Brain
 
-> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.4.3).
+> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.4.4).
 
 NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. It adds a local shared brain across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, smarter retrieval defaults, long-horizon overnight analysis, and 150+ MCP tools.
 
+v5.4.4: test isolation + venv timeout fix — tree_hygiene.py copy + fake venv to prevent CI timeout, completing the publish workflow fix
 v5.4.3: test isolation fix — copy tree_hygiene.py into isolated runtime dirs so the publish workflow passes
 v5.4.2: traceability truth + Sensory Register buffer close-loop — diary warnings now distinguish repo `commit_ref` debt from local/server-side operational changes, the nocturnal postmortem drains pending `session_buffer.jsonl` events instead of looking only at "today", rewrites the buffer atomically, and the docs now say honestly that `nexo-reflection.py` is a standalone analyzer rather than something auto-triggered by the stop hook
 v5.4.1: hook hygiene fix — the PostToolUse `capture-session.sh` hook had been reading a nonexistent env var since 2026-04-12, silently writing `"tool":"unknown"` to `~/.nexo/brain/session_buffer.jsonl` for 48 hours. v5.4.1 parses `tool_name` from stdin JSON, removes the filter that was hiding `Bash`, deletes the contaminating `capture-session 2.sh` duplicate, and purges pre-fix entries from the buffer on update with a `.pre-v5.4.1.bak` backup

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "5.4.3",
+  "version": "5.4.4",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.4.3" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.4.4" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.4.3",
+  "version": "5.4.4",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -145,7 +145,7 @@
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://nexo-brain.com/blog/nexo-5-4-3-test-isolation-fix/</loc>
+    <loc>https://nexo-brain.com/blog/nexo-5-4-4-test-and-venv-fix/</loc>
     <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.95</priority>

--- a/tests/test_cli_scripts.py
+++ b/tests/test_cli_scripts.py
@@ -190,6 +190,13 @@ class TestRuntimeUpdate:
         runtime_home.mkdir()
         (runtime_home / "bin").mkdir()
         (runtime_home / "db").mkdir()
+        (runtime_home / ".venv" / "bin").mkdir(parents=True)
+        fake_python = runtime_home / ".venv" / "bin" / "python3"
+        fake_python.write_text("#!/bin/sh\nexit 0\n")
+        fake_python.chmod(0o755)
+        fake_pip = runtime_home / ".venv" / "bin" / "pip"
+        fake_pip.write_text("#!/bin/sh\nexit 0\n")
+        fake_pip.chmod(0o755)
 
         repo = tmp_path / "repo"
         src = repo / "src"
@@ -362,6 +369,13 @@ class TestRuntimeUpdate:
         runtime_home.mkdir()
         (runtime_home / "bin").mkdir()
         (runtime_home / "db").mkdir()
+        (runtime_home / ".venv" / "bin").mkdir(parents=True)
+        fake_python = runtime_home / ".venv" / "bin" / "python3"
+        fake_python.write_text("#!/bin/sh\nexit 0\n")
+        fake_python.chmod(0o755)
+        fake_pip = runtime_home / ".venv" / "bin" / "pip"
+        fake_pip.write_text("#!/bin/sh\nexit 0\n")
+        fake_pip.chmod(0o755)
 
         repo = tmp_path / "repo"
         src = repo / "src"


### PR DESCRIPTION
## Summary
- Adds fake `.venv/bin/python3` and `pip` stubs to `test_update_uses_recorded_source_repo` and `test_update_reports_personal_schedule_self_heal` so `_ensure_runtime_venv` skips slow venv creation (timed out at 10s on CI)
- Builds on v5.4.3 tree_hygiene.py fix — together these resolve the v5.4.2 publish workflow failure

## Test plan
- [x] `pytest tests/test_cli_scripts.py::TestRuntimeUpdate` — 4/4 pass locally (2.85s, down from 5.67s)
- [x] `verify_release_readiness.py` — repo + website surfaces pass
- [x] gh-pages already updated and pushed

Once merged, tag `v5.4.4` and push to trigger the publish workflow.