### PR TITLE
fix: v5.4.5 — increase CI test timeout for nexo update

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.4.4",
+  "version": "5.4.5",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [5.4.5] - 2026-04-14
+
+### Fix: increase CI test timeout for nexo update
+
+- Increased `test_update_uses_recorded_source_repo` subprocess timeout
+  from 10s to 30s. GitHub Actions runners are too slow for the full
+  `nexo update --json` flow within 10 seconds even with a fake venv.
+
 ## [5.4.4] - 2026-04-14
 
 ### Fix: test isolation for tree_hygiene module + venv timeout in CI

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [Watch the overview video](https://nexo-brain.com/watch/) · [Watch on YouTube](https://www.youtube.com/watch?v=i2lkGhKyVqI) · [Open the infographic](https://nexo-brain.com/assets/nexo-brain-infographic-v5.png)
 
-Version `5.4.4` is the current packaged-runtime line: test isolation for tree_hygiene module + fake venv to prevent CI timeout — completes the publish workflow fix from v5.4.3.
+Version `5.4.5` is the current packaged-runtime line: test isolation for tree_hygiene module + fake venv to prevent CI timeout — completes the publish workflow fix from v5.4.3.
 
 Previously in `5.4.0`: runtime event bus at `~/.nexo/runtime/events.ndjson`, `nexo notify`, `nexo health --json`, `nexo logs --tail --json`, and a safe flat→nested migration for `calibration.json`.
 

--- a/blog/index.html
+++ b/blog/index.html
@@ -146,11 +146,11 @@
                     <span class="compare-chip">Hotfix</span>
                     <span class="compare-chip">CI / tests</span>
                 </div>
-                <h2>NEXO 5.4.4: Test Isolation + CI Venv Timeout Fix</h2>
-                <p>Completes the publish workflow fix: adds missing <code>tree_hygiene.py</code> copies + fake <code>.venv</code> to prevent CI timeout during <code>_ensure_runtime_venv</code>.</p>
+                <h2>NEXO 5.4.5: CI Test Timeout Fix</h2>
+                <p>Completes the publish workflow fix from v5.4.3–v5.4.4: increases <code>test_update_uses_recorded_source_repo</code> subprocess timeout from 10s to 30s for slow CI runners.</p>
                 <div class="hero-actions" style="justify-content:flex-start;margin-bottom:18px;">
                     <a href="/blog/nexo-5-4-4-test-and-venv-fix/" class="btn btn-primary">Open article</a>
-                    <a href="/changelog/#v544" class="btn btn-secondary">Open changelog</a>
+                    <a href="/changelog/#v545" class="btn btn-secondary">Open changelog</a>
                 </div>
                 <div class="blog-mini-stack">
                     <div class="blog-mini-card">
@@ -171,6 +171,13 @@
 <section class="section-flush-top">
     <div class="container">
         <div class="blog-grid">
+
+            <div class="blog-card">
+                <div class="blog-card-date">April 14, 2026</div>
+                <h2><a href="/blog/nexo-5-4-5-ci-timeout-fix/">NEXO 5.4.5: CI Test Timeout Fix</a></h2>
+                <p>Increases subprocess timeout from 10s to 30s for <code>test_update_uses_recorded_source_repo</code>. Completes the v5.4.2 publish workflow fix.</p>
+                <a href="/blog/nexo-5-4-5-ci-timeout-fix/" class="read-more">Read more &rarr;</a>
+            </div>
 
             <div class="blog-card">
                 <div class="blog-card-date">April 14, 2026</div>

--- a/blog/nexo-5-4-5-ci-timeout-fix/index.html
+++ b/blog/nexo-5-4-5-ci-timeout-fix/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>NEXO 5.4.5: CI Test Timeout Fix</title>
+    <meta name="description" content="NEXO 5.4.5 increases the subprocess timeout from 10s to 30s for test_update_uses_recorded_source_repo on slow CI runners.">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://nexo-brain.com/blog/nexo-5-4-5-ci-timeout-fix/">
+    <meta http-equiv="refresh" content="0; url=/blog/nexo-5-4-4-test-and-venv-fix/">
+</head>
+<body>
+    <p>Redirecting to the combined publish workflow fix article: <a href="/blog/nexo-5-4-4-test-and-venv-fix/">NEXO 5.4.3–5.4.5: Publish Workflow Fix</a>.</p>
+</body>
+</html>

--- a/changelog/index.html
+++ b/changelog/index.html
@@ -181,6 +181,17 @@
     </div>
 </section>
 
+<!-- v5.4.5 CI timeout increase -->
+<section id="v545" class="section-compact" style="background:linear-gradient(135deg,#09111f 0%,#14253a 50%,#1e3a5f 100%);">
+    <div class="container">
+        <div class="section-label">New in v5.4.5 <span style="opacity:.5;font-weight:400;">&mdash; April 14, 2026</span></div>
+        <h2 class="section-title">CI test timeout increase</h2>
+        <p class="section-subtitle">
+            Increased <code>test_update_uses_recorded_source_repo</code> subprocess timeout from 10s to 30s. The full <code>nexo update --json</code> flow exceeds 10 seconds on GitHub Actions runners even with a fake venv.
+        </p>
+    </div>
+</section>
+
 <!-- v5.4.4 test isolation + venv timeout fix -->
 <section id="v544" class="section-compact" style="background:linear-gradient(135deg,#09111f 0%,#14253a 50%,#1e3a5f 100%);">
     <div class="container">

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 5.4.4
+version: 5.4.5
 metadata:
   openclaw:
     requires:

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents</title>
-    <meta name="description" content="Libre/open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.4.4 fixes test isolation and CI venv timeout so the publish workflow passes.">
+    <meta name="description" content="Libre/open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.4.5 increases CI test timeout so the publish workflow passes on slow runners.">
     <meta name="keywords" content="AI memory, cognitive architecture, MCP, Claude Code, Codex, Claude Desktop, agent memory, vector search, AI agents, shared brain, open source">
     <meta name="author" content="WAzion">
     <meta name="robots" content="index, follow">
@@ -14,7 +14,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://nexo-brain.com">
     <meta property="og:title" content="NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents">
-    <meta property="og:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.4.4 fixes test isolation and CI venv timeout so the publish workflow passes.">
+    <meta property="og:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.4.5 increases CI test timeout so the publish workflow passes on slow runners.">
     <meta property="og:image" content="https://nexo-brain.com/assets/og/og-home.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -22,7 +22,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents">
-    <meta name="twitter:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.4.4 fixes test isolation and CI venv timeout so the publish workflow passes.">
+    <meta name="twitter:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.4.5 increases CI test timeout so the publish workflow passes on slow runners.">
     <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-home.png">
 
     <!-- Google Analytics (GA4) -->
@@ -46,12 +46,12 @@
         "@context": "https://schema.org",
         "@type": "SoftwareApplication",
         "name": "NEXO Brain",
-        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.4.4 fixes test isolation and CI venv timeout so the publish workflow passes.",
+        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.4.5 increases CI test timeout so the publish workflow passes on slow runners.",
         "applicationCategory": "DeveloperApplication",
         "operatingSystem": "macOS, Linux, Windows",
         "url": "https://nexo-brain.com",
         "downloadUrl": "https://www.npmjs.com/package/nexo-brain",
-        "softwareVersion": "5.4.4",
+        "softwareVersion": "5.4.5",
         "license": "https://www.gnu.org/licenses/agpl-3.0",
         "author": {
             "@type": "Organization",
@@ -88,7 +88,7 @@
         "@type": "WebSite",
         "name": "NEXO Brain",
         "url": "https://nexo-brain.com",
-        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.4.4 fixes test isolation and CI venv timeout so the publish workflow passes.",
+        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 5.4.5 increases CI test timeout so the publish workflow passes on slow runners.",
         "publisher": {
             "@type": "Organization",
             "name": "WAzion",
@@ -697,7 +697,7 @@
     <div class="container">
         <div class="hero-badge fade-up">
             <span class="dot"></span>
-            <span id="version-badge">v5.4.4</span> &mdash; test isolation + CI venv timeout fix
+            <span id="version-badge">v5.4.5</span> &mdash; CI test timeout fix
         </div>
         <div class="fade-up" style="display:flex;gap:8px;justify-content:center;margin-bottom:12px;">
             <img src="https://img.shields.io/npm/v/nexo-brain?color=7C3AED&label=npm" alt="npm version">

--- a/llms.txt
+++ b/llms.txt
@@ -1,9 +1,10 @@
 # NEXO Brain
 
-> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.4.4).
+> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.4.5).
 
 NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. It adds a local shared brain across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, smarter retrieval defaults, long-horizon overnight analysis, and 150+ MCP tools.
 
+v5.4.5: CI timeout increase — subprocess timeout 10→30s for nexo update test on slow CI runners
 v5.4.4: test isolation + venv timeout fix — tree_hygiene.py copy + fake venv to prevent CI timeout, completing the publish workflow fix
 v5.4.3: test isolation fix — copy tree_hygiene.py into isolated runtime dirs so the publish workflow passes
 v5.4.2: traceability truth + Sensory Register buffer close-loop — diary warnings now distinguish repo `commit_ref` debt from local/server-side operational changes, the nocturnal postmortem drains pending `session_buffer.jsonl` events instead of looking only at "today", rewrites the buffer atomically, and the docs now say honestly that `nexo-reflection.py` is a standalone analyzer rather than something auto-triggered by the stop hook

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "5.4.4",
+  "version": "5.4.5",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.4.4" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.4.5" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.4.4",
+  "version": "5.4.5",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -145,6 +145,12 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://nexo-brain.com/blog/nexo-5-4-5-ci-timeout-fix/</loc>
+    <lastmod>2026-04-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.95</priority>
+  </url>
+  <url>
     <loc>https://nexo-brain.com/blog/nexo-5-4-4-test-and-venv-fix/</loc>
     <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>

--- a/tests/test_cli_scripts.py
+++ b/tests/test_cli_scripts.py
@@ -242,7 +242,7 @@ class TestRuntimeUpdate:
         }
         result = subprocess.run(
             [sys.executable, CLI_PY, "update", "--json"],
-            capture_output=True, text=True, timeout=10, env=env,
+            capture_output=True, text=True, timeout=30, env=env,
         )
         assert result.returncode == 0
         data = json.loads(result.stdout)


### PR DESCRIPTION
## Summary
- `test_update_uses_recorded_source_repo` subprocess timeout: 10s → 30s
- GitHub Actions runners are too slow for the full `nexo update --json` flow within 10 seconds

## Context
- v5.4.3 fixed tree_hygiene.py missing in tests
- v5.4.4 added fake .venv to skip venv creation
- v5.4.5 increases the timeout because the update flow itself is slow on CI

## Test plan
- [x] All 4 TestRuntimeUpdate tests pass locally
- [x] verify_release_readiness.py passes (repo + website)
- [x] gh-pages already synced and pushed