### PR TITLE
fix: move auto-update cron to 02:00

### DIFF
--- a/src/crons/manifest.json
+++ b/src/crons/manifest.json
@@ -207,7 +207,7 @@
     {
       "id": "auto-update",
       "script": "scripts/nexo-auto-update.py",
-      "schedule": {"hour": 4, "minute": 45},
+      "schedule": {"hour": 2, "minute": 0},
       "description": "Daily auto-update — Brain + runtime dependencies",
       "core": true,
       "recovery_policy": "catchup",


### PR DESCRIPTION
Move from 04:45 to 02:00 — the 03:00-08:00 window is fully occupied by nightly DB-writing jobs. Deep sleep alone can run 1-2 hours. 02:00 gives a clean hour before anything starts.