### PR TITLE
feat: v5.4.7 — tool-enforcement-map.json for Protocol Enforcer

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.4.6",
+  "version": "5.4.7",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [5.4.7] - 2026-04-15
+
+### Feat: tool-enforcement-map.json for Protocol Enforcer
+
+- Canonical map of all 247 NEXO Brain MCP tools with enforcement metadata.
+- 16 tools have enforcement rules (periodic, event-based, session lifecycle).
+- NEXO Desktop and headless session-guard read this map to mechanically
+  enforce protocol compliance without depending on model self-discipline.
+- New `scripts/verify_tool_map.py` catches drift between code and map.
+- Learning #335 guards future tool additions/removals.
+
 ## [5.4.6] - 2026-04-14
 
 ### Feat: runtime dependency management in nexo update + daily auto-update cron

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
 
 [Watch the overview video](https://nexo-brain.com/watch/) · [Watch on YouTube](https://www.youtube.com/watch?v=i2lkGhKyVqI) · [Open the infographic](https://nexo-brain.com/assets/nexo-brain-infographic-v5.png)
 
-Version `5.4.6` is the current packaged-runtime line: runtime dependency management in `nexo update` + daily auto-update cron. `nexo update` now manages external dependencies declared in `runtimeDependencies` (starting with Claude Code).
+Version `5.4.7` is the current packaged-runtime line: tool-enforcement-map.json for Protocol Enforcer — canonical map of all 247 tools with enforcement metadata, plus verify script.
 
-Previously in `5.4.5`: test isolation for tree_hygiene module + fake venv to prevent CI timeout.
+Previously in `5.4.6`: runtime dependency management in `nexo update` + daily auto-update cron.
 
 Start here:
 - [5-minute quickstart](docs/quickstart-5-minutes.md)

--- a/blog/index.html
+++ b/blog/index.html
@@ -173,6 +173,20 @@
         <div class="blog-grid">
 
             <div class="blog-card">
+                <div class="blog-card-date">April 15, 2026</div>
+                <h2><a href="/blog/nexo-5-4-7-protocol-enforcer-map/">NEXO 5.4.7: Protocol Enforcer Tool Map</a></h2>
+                <p>Canonical map of all 247 NEXO Brain tools with enforcement metadata. Desktop and headless session-guard read this map to mechanically enforce protocol compliance.</p>
+                <a href="/blog/nexo-5-4-7-protocol-enforcer-map/" class="read-more">Read more &rarr;</a>
+            </div>
+
+            <div class="blog-card">
+                <div class="blog-card-date">April 15, 2026</div>
+                <h2><a href="/blog/nexo-5-4-7-protocol-enforcer-map/">NEXO 5.4.7: Protocol Enforcer Tool Map</a></h2>
+                <p>Canonical map of all 247 MCP tools with enforcement metadata. Desktop and headless sessions read it to mechanically enforce protocol compliance.</p>
+                <a href="/blog/nexo-5-4-7-protocol-enforcer-map/" class="read-more">Read more &rarr;</a>
+            </div>
+
+            <div class="blog-card">
                 <div class="blog-card-date">April 14, 2026</div>
                 <h2><a href="/blog/nexo-5-4-6-runtime-dependency-management/">NEXO 5.4.6: Runtime Dependency Management</a></h2>
                 <p><code>nexo update</code> now manages external runtime dependencies declared in <code>runtimeDependencies</code>. First dependency: Claude Code. Plus a daily auto-update cron.</p>

--- a/blog/nexo-5-4-7-protocol-enforcer-map/index.html
+++ b/blog/nexo-5-4-7-protocol-enforcer-map/index.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <title>NEXO 5.4.7: Protocol Enforcer Tool Map</title>
+    <meta name="description" content="NEXO 5.4.7 adds tool-enforcement-map.json — a canonical map of all 247 MCP tools with enforcement metadata for the Protocol Enforcer.">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://nexo-brain.com/blog/nexo-5-4-7-protocol-enforcer-map/">
+
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://nexo-brain.com/blog/nexo-5-4-7-protocol-enforcer-map/">
+    <meta property="og:title" content="NEXO 5.4.7: Protocol Enforcer Tool Map">
+    <meta property="og:description" content="Canonical map of all 247 NEXO Brain tools with enforcement rules. Desktop and headless sessions read it to enforce protocol compliance.">
+    <meta property="og:image" content="https://nexo-brain.com/assets/og/og-blog.png">
+    <meta property="article:published_time" content="2026-04-15">
+    <meta property="article:author" content="Francisco Cerda Puigserver">
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="NEXO 5.4.7: Protocol Enforcer Tool Map">
+    <meta name="twitter:description" content="Canonical map of all 247 NEXO Brain tools with enforcement rules.">
+    <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-blog.png">
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-1LNEMCJMS7"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-1LNEMCJMS7');
+    </script>
+
+    <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicon-32.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
+    <link rel="stylesheet" href="/assets/style.css">
+
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "NEXO 5.4.7: Protocol Enforcer Tool Map",
+        "description": "NEXO 5.4.7 adds tool-enforcement-map.json — a canonical map of all 247 MCP tools with enforcement metadata for the Protocol Enforcer.",
+        "datePublished": "2026-04-15",
+        "dateModified": "2026-04-15",
+        "author": {
+            "@type": "Person",
+            "name": "Francisco Cerda Puigserver"
+        },
+        "publisher": {
+            "@type": "Organization",
+            "name": "WAzion",
+            "url": "https://www.wazion.com"
+        },
+        "mainEntityOfPage": {
+            "@type": "WebPage",
+            "@id": "https://nexo-brain.com/blog/nexo-5-4-7-protocol-enforcer-map/"
+        },
+        "url": "https://nexo-brain.com/blog/nexo-5-4-7-protocol-enforcer-map/",
+        "image": "https://nexo-brain.com/assets/og/og-blog.png",
+        "keywords": ["NEXO 5.4.7", "protocol enforcer", "tool map", "enforcement", "MCP tools"]
+    }
+    </script>
+
+    <style>
+        .article-header { padding-top: 128px; padding-bottom: 40px; text-align: center; }
+        .article-meta { font-size: 14px; color: var(--text-muted); margin-bottom: 16px; }
+        .article-body {
+            max-width: 720px; margin: 0 auto; padding: 0 24px 80px;
+            font-size: 17px; line-height: 1.8; color: var(--text);
+        }
+        .article-body h2 { font-size: 28px; font-weight: 700; margin: 48px 0 16px; letter-spacing: -0.01em; }
+        .article-body p { margin-bottom: 20px; color: var(--text-muted); }
+        .article-body strong { color: var(--text); }
+        .article-body a { color: var(--purple-light); }
+        .article-body a:hover { color: var(--pink); }
+        .article-body code {
+            font-family: 'SF Mono', 'Fira Code', monospace;
+            font-size: 14px; color: var(--pink);
+            background: rgba(236, 72, 153, 0.1);
+            padding: 2px 8px; border-radius: 4px;
+        }
+        .article-back {
+            display: inline-flex; align-items: center; gap: 6px;
+            font-size: 14px; font-weight: 600; color: var(--text-muted);
+            margin-bottom: 24px;
+        }
+        .article-back:hover { color: var(--purple-light); }
+    </style>
+</head>
+<body>
+
+<nav>
+    <div class="container">
+        <a href="/" class="nav-logo">
+            <img src="/assets/logo-64.png" alt="NEXO Brain" class="logo-image">
+            <span class="logo-text">NEXO Brain</span>
+        </a>
+        <button class="mobile-menu-toggle" aria-label="Toggle navigation" onclick="toggleMobileMenu()">
+            <span></span><span></span><span></span>
+        </button>
+        <div class="nav-links">
+            <a href="/">Home</a>
+            <a href="/features/">Features</a>
+            <a href="/evolution/">Evolution</a>
+            <a href="/compare/">Compare</a>
+            <a href="/blog/">Blog</a>
+            <a href="/changelog/">Changelog</a>
+            <a href="/docs/">Docs</a>
+            <a href="https://github.com/wazionapps/nexo" class="nav-cta">GitHub</a>
+        </div>
+    </div>
+</nav>
+
+<section class="article-header">
+    <div class="container">
+        <a href="/blog/" class="article-back">&larr; Back to blog</a>
+        <div class="article-meta">April 15, 2026 &middot; Feature &middot; Protocol</div>
+        <h1 class="section-title" style="font-size:clamp(28px,4.5vw,48px);max-width:920px;margin:0 auto 16px;">NEXO 5.4.7: Protocol Enforcer Tool Map</h1>
+        <p class="section-subtitle" style="max-width:760px;margin:0 auto;">A canonical map of all 247 MCP tools with enforcement metadata. Desktop and headless sessions read it to mechanically enforce protocol compliance.</p>
+    </div>
+</section>
+
+<section>
+    <div class="article-body">
+
+        <h2>The problem</h2>
+        <p>NEXO Brain relies on the AI model remembering to call protocol tools like <strong>heartbeat</strong>, <strong>diary</strong>, and <strong>startup</strong>. In practice, the model often skips these &mdash; especially during long sessions or complex tasks. There was no mechanical enforcement layer.</p>
+
+        <h2>The solution</h2>
+        <p>A new <code>tool-enforcement-map.json</code> file in the repo root maps all 247 MCP tools with enforcement metadata. Each tool declares whether it needs enforcement, what type (periodic, event-based, session lifecycle), the trigger threshold, and the prompt to inject when the rule is violated.</p>
+        <p>16 tools have enforcement rules. The remaining 231 are utility, query, or management tools that don't need mechanical enforcement.</p>
+
+        <h2>Enforcement types</h2>
+        <p>The map supports 7 enforcement types: <code>on_session_start</code>, <code>on_session_end</code>, <code>periodic_by_messages</code>, <code>periodic_by_time</code>, <code>before_tool</code>, <code>after_tool</code>, and <code>on_event</code>. Each type defines when the enforcer should inject a prompt to force the model to comply.</p>
+
+        <h2>Drift detection</h2>
+        <p>A new <code>scripts/verify_tool_map.py</code> script scans all tool definitions in <code>server.py</code> and <code>plugins/</code>, compares against the map, and fails if any tool is missing or orphaned. This runs in CI to prevent drift.</p>
+
+    </div>
+</section>
+
+<footer>
+    <div class="container" style="text-align:center; padding: 48px 24px 32px; color: var(--text-muted); font-size: 14px;">
+        <p>&copy; 2024&ndash;2026 WAzion &middot; <a href="https://github.com/wazionapps/nexo" style="color:var(--purple-light);">GitHub</a> &middot; AGPL-3.0</p>
+    </div>
+</footer>
+
+<script>
+function toggleMobileMenu() {
+    document.querySelector('.nav-links').classList.toggle('active');
+    document.querySelector('.mobile-menu-toggle').classList.toggle('active');
+}
+</script>
+
+</body>
+</html>

--- a/changelog/index.html
+++ b/changelog/index.html
@@ -181,6 +181,28 @@
     </div>
 </section>
 
+<!-- v5.4.7 Protocol Enforcer tool map -->
+<section id="v547" class="section-compact" style="background:linear-gradient(135deg,#09111f 0%,#14253a 50%,#1e3a5f 100%);">
+    <div class="container">
+        <div class="section-label">New in v5.4.7 <span style="opacity:.5;font-weight:400;">&mdash; April 15, 2026</span></div>
+        <h2 class="section-title">Protocol Enforcer tool map</h2>
+        <p class="section-subtitle">
+            Canonical map of all 247 NEXO Brain MCP tools with enforcement metadata (<code>tool-enforcement-map.json</code>). 16 tools have enforcement rules (periodic, event-based, session lifecycle). NEXO Desktop and headless session-guard read this map to mechanically enforce protocol compliance. Includes <code>verify_tool_map.py</code> for drift detection between code and map.
+        </p>
+    </div>
+</section>
+
+<!-- v5.4.7 Protocol Enforcer tool map -->
+<section id="v547" class="section-compact" style="background:linear-gradient(135deg,#09111f 0%,#14253a 50%,#1e3a5f 100%);">
+    <div class="container">
+        <div class="section-label">New in v5.4.7 <span style="opacity:.5;font-weight:400;">&mdash; April 15, 2026</span></div>
+        <h2 class="section-title">Protocol Enforcer tool map</h2>
+        <p class="section-subtitle">
+            New <code>tool-enforcement-map.json</code> &mdash; canonical map of all 247 MCP tools with enforcement metadata. 16 tools have enforcement rules (periodic, event-based, session lifecycle). NEXO Desktop and headless session-guard read this map to mechanically enforce protocol compliance. Includes <code>verify_tool_map.py</code> for drift detection in CI.
+        </p>
+    </div>
+</section>
+
 <!-- v5.4.6 runtime dependency management -->
 <section id="v546" class="section-compact" style="background:linear-gradient(135deg,#09111f 0%,#14253a 50%,#1e3a5f 100%);">
     <div class="container">

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 5.4.6
+version: 5.4.7
 metadata:
   openclaw:
     requires:

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
         "operatingSystem": "macOS, Linux, Windows",
         "url": "https://nexo-brain.com",
         "downloadUrl": "https://www.npmjs.com/package/nexo-brain",
-        "softwareVersion": "5.4.6",
+        "softwareVersion": "5.4.7",
         "license": "https://www.gnu.org/licenses/agpl-3.0",
         "author": {
             "@type": "Organization",
@@ -697,7 +697,7 @@
     <div class="container">
         <div class="hero-badge fade-up">
             <span class="dot"></span>
-            <span id="version-badge">v5.4.6</span> &mdash; runtime dependency management + daily auto-update
+            <span id="version-badge">v5.4.7</span> &mdash; Protocol Enforcer tool map + 247 tools mapped
         </div>
         <div class="fade-up" style="display:flex;gap:8px;justify-content:center;margin-bottom:12px;">
             <img src="https://img.shields.io/npm/v/nexo-brain?color=7C3AED&label=npm" alt="npm version">

--- a/llms.txt
+++ b/llms.txt
@@ -1,9 +1,10 @@
 # NEXO Brain
 
-> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.4.6).
+> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.4.7).
 
 NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. It adds a local shared brain across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, smarter retrieval defaults, long-horizon overnight analysis, and 150+ MCP tools.
 
+v5.4.7: tool-enforcement-map.json — canonical map of all 247 tools with enforcement metadata for Protocol Enforcer. Includes verify_tool_map.py for drift detection
 v5.4.6: runtime dependency management — `nexo update` now manages external dependencies declared in `runtimeDependencies` (starting with Claude Code) + daily auto-update cron at 02:00
 v5.4.5: CI timeout increase — subprocess timeout 10→30s for nexo update test on slow CI runners
 v5.4.4: test isolation + venv timeout fix — tree_hygiene.py copy + fake venv to prevent CI timeout, completing the publish workflow fix

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "5.4.6",
+  "version": "5.4.7",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.4.6" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.4.7" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.4.6",
+  "version": "5.4.7",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/scripts/verify_tool_map.py
+++ b/scripts/verify_tool_map.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Verify tool-enforcement-map.json is in sync with actual tool definitions.
+
+Scans server.py + all plugin files for nexo_ tool definitions and compares
+against the keys in tool-enforcement-map.json. Exits non-zero if:
+  - A tool exists in code but not in the map (missing)
+  - A tool exists in the map but not in code (orphaned)
+
+Run: python3 scripts/verify_tool_map.py
+"""
+
+import json
+import os
+import re
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+MAP_PATH = os.path.join(REPO_ROOT, "tool-enforcement-map.json")
+SRC_DIR = os.path.join(REPO_ROOT, "src")
+SERVER_PY = os.path.join(SRC_DIR, "server.py")
+PLUGINS_DIR = os.path.join(SRC_DIR, "plugins")
+
+IGNORE_TOOLS = {"nexo_example_tool"}
+
+
+def get_server_tools() -> set[str]:
+    with open(SERVER_PY) as f:
+        content = f.read()
+    return {m.group(1) for m in re.finditer(r"def (nexo_[a-z_]+)\(", content)}
+
+
+def get_plugin_tools() -> set[str]:
+    tools = set()
+    for fname in sorted(os.listdir(PLUGINS_DIR)):
+        if not fname.endswith(".py") or fname == "__init__.py":
+            continue
+        with open(os.path.join(PLUGINS_DIR, fname)) as f:
+            content = f.read()
+        tools.update(m.group(1) for m in re.finditer(r'"(nexo_[a-z_]+)"', content))
+    return tools
+
+
+def get_map_tools() -> set[str]:
+    with open(MAP_PATH) as f:
+        data = json.load(f)
+    return set(data["tools"].keys())
+
+
+def main():
+    if not os.path.exists(MAP_PATH):
+        print(f"ERROR: {MAP_PATH} not found")
+        sys.exit(1)
+
+    code_tools = (get_server_tools() | get_plugin_tools()) - IGNORE_TOOLS
+    map_tools = get_map_tools()
+
+    missing = code_tools - map_tools
+    orphaned = map_tools - code_tools
+
+    ok = True
+
+    if missing:
+        ok = False
+        print(f"\n  MISSING from map ({len(missing)} tools in code but not in tool-enforcement-map.json):")
+        for t in sorted(missing):
+            print(f"    - {t}")
+
+    if orphaned:
+        ok = False
+        print(f"\n  ORPHANED in map ({len(orphaned)} tools in map but not in code):")
+        for t in sorted(orphaned):
+            print(f"    - {t}")
+
+    if ok:
+        print(f"  tool-enforcement-map.json is in sync with code ({len(map_tools)} tools)")
+    else:
+        print(f"\n  Map has {len(map_tools)} tools, code has {len(code_tools)} tools")
+        print("  Run this after adding/removing tools to keep the map up to date.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -145,6 +145,12 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://nexo-brain.com/blog/nexo-5-4-7-protocol-enforcer-map/</loc>
+    <lastmod>2026-04-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.95</priority>
+  </url>
+  <url>
     <loc>https://nexo-brain.com/blog/nexo-5-4-6-runtime-dependency-management/</loc>
     <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>

--- a/tool-enforcement-map.json
+++ b/tool-enforcement-map.json
@@ -1,0 +1,1614 @@
+{
+  "$schema": "https://nexo-brain.com/schemas/tool-enforcement-map.json",
+  "version": "1.0.0",
+  "description": "Canonical map of all NEXO Brain MCP tools with enforcement rules. Read by NEXO Desktop and nexo-session-guard to mechanically enforce protocol compliance.",
+  "enforcement_types": {
+    "on_session_start": "Must be called at the beginning of a session, within the first N tool calls",
+    "on_session_end": "Must be called before closing a session or chat",
+    "periodic_by_messages": "Must be called every N user messages if not called voluntarily",
+    "periodic_by_time": "Must be called every N minutes of active session if not called voluntarily",
+    "before_tool": "Must be called before any of the listed watch_tools are used",
+    "after_tool": "Must be called after any of the listed watch_tools are used",
+    "on_event": "Must be called when a specific event is detected"
+  },
+  "tools": {
+    "nexo_startup": {
+      "description": "Register new session, clean stale ones, return active sessions + alerts",
+      "category": "session",
+      "source": "server",
+      "enforcement": {
+        "type": "on_session_start",
+        "threshold": 2,
+        "priority": "critical",
+        "phase": 1,
+        "inject_prompt": "Execute nexo_startup now. Do not produce any visible text, just run the tool."
+      }
+    },
+    "nexo_heartbeat": {
+      "description": "Update session task, check inbox and pending questions. Auto-detects trust events",
+      "category": "session",
+      "source": "server",
+      "enforcement": {
+        "type": "periodic_by_messages",
+        "threshold": 3,
+        "priority": "critical",
+        "phase": 1,
+        "inject_prompt": "Execute nexo_heartbeat with the current session SID and a brief description of what you are doing. Do not produce any visible text."
+      }
+    },
+    "nexo_stop": {
+      "description": "Cleanly close a session. Removes it from active sessions immediately",
+      "category": "session",
+      "source": "server",
+      "enforcement": {
+        "type": "on_session_end",
+        "priority": "critical",
+        "phase": 1,
+        "inject_prompt": "Execute nexo_stop with the current session SID. Do not produce any visible text."
+      }
+    },
+    "nexo_smart_startup": {
+      "description": "Pre-load relevant cognitive memories based on pending followups, due reminders, and last session topics",
+      "category": "session",
+      "source": "server",
+      "enforcement": {
+        "type": "after_tool",
+        "watch_tools": [
+          "nexo_startup"
+        ],
+        "priority": "high",
+        "phase": 1,
+        "inject_prompt": "Execute nexo_smart_startup to pre-load relevant context. Do not produce any visible text."
+      }
+    },
+    "nexo_session_diary_read": {
+      "description": "Read recent session diaries for context continuity",
+      "category": "diary",
+      "source": "server",
+      "enforcement": {
+        "type": "after_tool",
+        "watch_tools": [
+          "nexo_startup"
+        ],
+        "priority": "high",
+        "phase": 1,
+        "inject_prompt": "Execute nexo_session_diary_read with last_day=true and brief=true to load context from previous sessions. Do not produce any visible text."
+      }
+    },
+    "nexo_session_diary_write": {
+      "description": "Write end-of-session diary with decisions, discards, and context for next session",
+      "category": "diary",
+      "source": "plugin:episodic_memory",
+      "enforcement": [
+        {
+          "type": "periodic_by_time",
+          "threshold": 15,
+          "priority": "critical",
+          "phase": 1,
+          "inject_prompt": "It has been 15 minutes of active session without writing a diary. Execute nexo_session_diary_write with a summary of what you have done so far. Do not produce any visible text."
+        },
+        {
+          "type": "on_session_end",
+          "priority": "critical",
+          "phase": 1,
+          "inject_prompt": "This session is ending. Execute nexo_session_diary_write with a complete summary of decisions, pending items, and context for the next session. Do not produce any visible text."
+        }
+      ]
+    },
+    "nexo_reminders": {
+      "description": "Check reminders and followups",
+      "category": "reminders",
+      "source": "server",
+      "enforcement": {
+        "type": "after_tool",
+        "watch_tools": [
+          "nexo_startup"
+        ],
+        "priority": "high",
+        "phase": 1,
+        "inject_prompt": "Execute nexo_reminders with filter='due' and then with filter='followups'. Do not produce any visible text."
+      }
+    },
+    "nexo_task_open": {
+      "description": "Open a non-trivial task with heartbeat, guard, rules, and Cortex captured as one protocol contract",
+      "category": "task",
+      "source": "plugin:protocol",
+      "enforcement": {
+        "type": "periodic_by_messages",
+        "threshold": 10,
+        "priority": "high",
+        "phase": 2,
+        "inject_prompt": "You have made 10+ tool calls without opening a protocol task. Execute nexo_task_open for the current work. Do not produce any visible text."
+      }
+    },
+    "nexo_task_close": {
+      "description": "Close a protocol task with evidence",
+      "category": "task",
+      "source": "plugin:protocol",
+      "enforcement": {
+        "type": "on_event",
+        "detection": "done_claimed",
+        "priority": "high",
+        "phase": 2,
+        "inject_prompt": "You claimed work is done but have not closed the protocol task. Execute nexo_task_close with evidence of completion. Do not produce any visible text."
+      }
+    },
+    "nexo_task_acknowledge_guard": {
+      "description": "Acknowledge blocking guard rules on an open protocol task before proceeding",
+      "category": "task",
+      "source": "plugin:protocol",
+      "enforcement": null
+    },
+    "nexo_guard_check": {
+      "description": "Check learnings relevant to files/area BEFORE editing code",
+      "category": "guard",
+      "source": "plugin:guard",
+      "enforcement": {
+        "type": "before_tool",
+        "watch_tools": [
+          "Edit",
+          "Write"
+        ],
+        "priority": "high",
+        "phase": 2,
+        "inject_prompt": "You are about to edit files without running guard_check first. Execute nexo_guard_check for the files you are about to modify. Do not produce any visible text."
+      }
+    },
+    "nexo_guard_file_check": {
+      "description": "Pre-edit check: surfaces learnings and recent changes for files about to be modified",
+      "category": "guard",
+      "source": "plugin:guard",
+      "enforcement": null
+    },
+    "nexo_guard_cross_check": {
+      "description": "Cross-check audit findings against known learnings to filter false positives",
+      "category": "guard",
+      "source": "plugin:guard",
+      "enforcement": null
+    },
+    "nexo_guard_log_repetition": {
+      "description": "Log a learning repetition (new learning matches existing one)",
+      "category": "guard",
+      "source": "plugin:guard",
+      "enforcement": null
+    },
+    "nexo_guard_stats": {
+      "description": "Get guard system statistics: repetition rate, trends, top problem areas",
+      "category": "guard",
+      "source": "plugin:guard",
+      "enforcement": null
+    },
+    "nexo_track": {
+      "description": "Track files being edited. Detects conflicts with other sessions",
+      "category": "files",
+      "source": "server",
+      "enforcement": {
+        "type": "before_tool",
+        "watch_tools": [
+          "Edit",
+          "Write"
+        ],
+        "priority": "medium",
+        "phase": 2,
+        "inject_prompt": "You are editing shared files without tracking them. Execute nexo_track for the files you are modifying. Do not produce any visible text."
+      }
+    },
+    "nexo_untrack": {
+      "description": "Stop tracking files. If no paths given, releases all",
+      "category": "files",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_files": {
+      "description": "Show all tracked files across all active sessions with conflict detection",
+      "category": "files",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_learning_add": {
+      "description": "Add a new learning (resolved error, pattern, gotcha)",
+      "category": "learning",
+      "source": "server",
+      "enforcement": {
+        "type": "on_event",
+        "detection": "user_correction_detected",
+        "grace_messages": 3,
+        "priority": "medium",
+        "phase": 2,
+        "inject_prompt": "The user just corrected you but no learning was captured. Execute nexo_learning_add to record this correction as a reusable learning. Do not produce any visible text."
+      }
+    },
+    "nexo_learning_search": {
+      "description": "Search learnings by keyword",
+      "category": "learning",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_learning_list": {
+      "description": "List all learnings, grouped by category",
+      "category": "learning",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_learning_update": {
+      "description": "Update a learning entry",
+      "category": "learning",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_learning_delete": {
+      "description": "Delete a learning entry",
+      "category": "learning",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_learning_quality": {
+      "description": "Score learning quality so fragile rules can be strengthened",
+      "category": "learning",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_learning_apply_retroactively": {
+      "description": "Scan recent decisions and surface those that conflict with a learning's prevention rule",
+      "category": "learning",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_checkpoint_save": {
+      "description": "Save a session checkpoint for auto-compaction continuity",
+      "category": "session",
+      "source": "server",
+      "enforcement": {
+        "type": "on_event",
+        "detection": "pre_compaction",
+        "priority": "high",
+        "phase": 2,
+        "inject_prompt": "Context compaction is imminent. Execute nexo_checkpoint_save to preserve session state. Do not produce any visible text."
+      }
+    },
+    "nexo_checkpoint_read": {
+      "description": "Read the latest session checkpoint",
+      "category": "session",
+      "source": "server",
+      "enforcement": {
+        "type": "on_event",
+        "detection": "post_compaction",
+        "priority": "high",
+        "phase": 2,
+        "inject_prompt": "Context was just compacted. Execute nexo_checkpoint_read to restore session state. Do not produce any visible text."
+      }
+    },
+    "nexo_skill_match": {
+      "description": "Find skills matching a task description",
+      "category": "skill",
+      "source": "plugin:skills",
+      "enforcement": {
+        "type": "on_event",
+        "detection": "multi_step_task_detected",
+        "priority": "low",
+        "phase": 2,
+        "inject_prompt": "A multi-step task was detected. Execute nexo_skill_match to check for reusable procedures. Do not produce any visible text."
+      }
+    },
+    "nexo_confidence_check": {
+      "description": "Decide whether a non-trivial answer should be answered, verified, asked, or deferred",
+      "category": "cortex",
+      "source": "plugin:protocol",
+      "enforcement": {
+        "type": "on_event",
+        "detection": "factual_answer_important",
+        "priority": "low",
+        "phase": 2,
+        "inject_prompt": "You are about to give an important factual answer. Execute nexo_confidence_check first. Do not produce any visible text."
+      }
+    },
+    "nexo_status": {
+      "description": "List active sessions",
+      "category": "session",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_menu": {
+      "description": "Generate the NEXO operations center menu",
+      "category": "session",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_tool_explain": {
+      "description": "Explain a live NEXO tool/capability from the generated system catalog",
+      "category": "system",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_system_catalog": {
+      "description": "Read NEXO's live system catalog",
+      "category": "system",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_doctor": {
+      "description": "Unified diagnostic report for boot/runtime/deep health",
+      "category": "system",
+      "source": "plugin:doctor",
+      "enforcement": null
+    },
+    "nexo_update": {
+      "description": "Pull latest NEXO code, backup DBs, run migrations, verify",
+      "category": "system",
+      "source": "plugin:update",
+      "enforcement": null
+    },
+    "nexo_reindex": {
+      "description": "Force full rebuild of the FTS5 search index",
+      "category": "index",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_index_add_dir": {
+      "description": "Register a new directory for FTS5 search indexing",
+      "category": "index",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_index_remove_dir": {
+      "description": "Remove a directory from FTS5 indexing",
+      "category": "index",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_index_dirs": {
+      "description": "List all directories being indexed by FTS5",
+      "category": "index",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_context_packet": {
+      "description": "Build a context packet for subagent injection",
+      "category": "context",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_recent_context_capture": {
+      "description": "Capture/update a recent 24h context item",
+      "category": "context",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_recent_context": {
+      "description": "Read recent hot context and continuity events",
+      "category": "context",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_pre_action_context": {
+      "description": "Build the 24h recent-context bundle that should be reviewed before acting",
+      "category": "context",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_recent_context_resolve": {
+      "description": "Resolve a recent hot-context item",
+      "category": "context",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_hot_context_list": {
+      "description": "List hot-context items currently alive",
+      "category": "context",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_session_portable_context": {
+      "description": "Build a portable handoff packet for another client/runtime",
+      "category": "session",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_session_export_bundle": {
+      "description": "Export a machine-readable session bundle for cross-client handoff",
+      "category": "session",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_transcript_recent": {
+      "description": "List recent Claude Code / Codex transcripts visible to NEXO",
+      "category": "transcript",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_transcript_search": {
+      "description": "Search recent transcripts",
+      "category": "transcript",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_transcript_read": {
+      "description": "Read a full transcript by session id or path",
+      "category": "transcript",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_send": {
+      "description": "Send a fire-and-forget message to another session or broadcast",
+      "category": "inter_session",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_ask": {
+      "description": "Ask a question to another session",
+      "category": "inter_session",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_answer": {
+      "description": "Answer a pending question from another session",
+      "category": "inter_session",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_check_answer": {
+      "description": "Check if a question has been answered",
+      "category": "inter_session",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_reminder_create": {
+      "description": "Create a new reminder for the user",
+      "category": "reminders",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_reminder_get": {
+      "description": "Read a reminder with its history",
+      "category": "reminders",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_reminder_update": {
+      "description": "Update fields of an existing reminder",
+      "category": "reminders",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_reminder_complete": {
+      "description": "Mark a reminder as completed",
+      "category": "reminders",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_reminder_note": {
+      "description": "Append a note to reminder history",
+      "category": "reminders",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_reminder_restore": {
+      "description": "Restore a soft-deleted reminder",
+      "category": "reminders",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_reminder_delete": {
+      "description": "Soft-delete a reminder",
+      "category": "reminders",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_followup_create": {
+      "description": "Create a new NEXO followup (autonomous task)",
+      "category": "followups",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_followup_get": {
+      "description": "Read a followup with its history",
+      "category": "followups",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_followup_update": {
+      "description": "Update fields of an existing followup",
+      "category": "followups",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_followup_complete": {
+      "description": "Mark a followup as completed",
+      "category": "followups",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_followup_note": {
+      "description": "Append a note to followup history",
+      "category": "followups",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_followup_restore": {
+      "description": "Restore a soft-deleted followup",
+      "category": "followups",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_followup_delete": {
+      "description": "Soft-delete a followup",
+      "category": "followups",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_hook_runs": {
+      "description": "List recent hook lifecycle runs and per-hook health summary",
+      "category": "system",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_credential_get": {
+      "description": "Get credential value(s) for a service",
+      "category": "credentials",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_credential_create": {
+      "description": "Store a new credential",
+      "category": "credentials",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_credential_update": {
+      "description": "Update a credential's value and/or notes",
+      "category": "credentials",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_credential_delete": {
+      "description": "Delete credential(s)",
+      "category": "credentials",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_credential_list": {
+      "description": "List credentials (names and notes only, no values)",
+      "category": "credentials",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_task_log": {
+      "description": "Record that an operational task was executed",
+      "category": "task",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_task_list": {
+      "description": "Show execution history for operational tasks",
+      "category": "task",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_task_frequency": {
+      "description": "Check which operational tasks are overdue based on their frequency",
+      "category": "task",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_plugin_load": {
+      "description": "Load or reload a plugin",
+      "category": "plugin",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_plugin_list": {
+      "description": "List all loaded plugins and their tools",
+      "category": "plugin",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_plugin_remove": {
+      "description": "Unregister a plugin's tools from MCP",
+      "category": "plugin",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_drive_signals": {
+      "description": "List autonomous drive/curiosity signals",
+      "category": "drive",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_drive_reinforce": {
+      "description": "Reinforce a drive signal with a new observation",
+      "category": "drive",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_drive_act": {
+      "description": "Mark a drive signal as investigated with an outcome",
+      "category": "drive",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_drive_dismiss": {
+      "description": "Dismiss a drive signal",
+      "category": "drive",
+      "source": "server",
+      "enforcement": null
+    },
+    "nexo_cognitive_retrieve": {
+      "description": "RAG query over cognitive memory (STM+LTM)",
+      "category": "cognitive",
+      "source": "plugin:cognitive_memory",
+      "enforcement": null
+    },
+    "nexo_cognitive_stats": {
+      "description": "Cognitive memory system metrics",
+      "category": "cognitive",
+      "source": "plugin:cognitive_memory",
+      "enforcement": null
+    },
+    "nexo_cognitive_inspect": {
+      "description": "Inspect a specific memory by ID (debug)",
+      "category": "cognitive",
+      "source": "plugin:cognitive_memory",
+      "enforcement": null
+    },
+    "nexo_cognitive_metrics": {
+      "description": "Performance metrics: retrieval relevance, repeat error rate",
+      "category": "cognitive",
+      "source": "plugin:cognitive_memory",
+      "enforcement": null
+    },
+    "nexo_cognitive_dissonance": {
+      "description": "Detect conflicts between a new instruction and established LTM memories",
+      "category": "cognitive",
+      "source": "plugin:cognitive_memory",
+      "enforcement": null
+    },
+    "nexo_cognitive_resolve": {
+      "description": "Resolve a cognitive dissonance",
+      "category": "cognitive",
+      "source": "plugin:cognitive_memory",
+      "enforcement": null
+    },
+    "nexo_cognitive_sentiment": {
+      "description": "Detect user's sentiment and get tone guidance",
+      "category": "cognitive",
+      "source": "plugin:cognitive_memory",
+      "enforcement": null
+    },
+    "nexo_cognitive_trust": {
+      "description": "View or adjust trust score (0-100)",
+      "category": "cognitive",
+      "source": "plugin:cognitive_memory",
+      "enforcement": null
+    },
+    "nexo_cognitive_pin": {
+      "description": "Pin a memory — never decays, boosted in search results",
+      "category": "cognitive",
+      "source": "plugin:cognitive_memory",
+      "enforcement": null
+    },
+    "nexo_cognitive_snooze": {
+      "description": "Snooze a memory — hidden from searches until a date",
+      "category": "cognitive",
+      "source": "plugin:cognitive_memory",
+      "enforcement": null
+    },
+    "nexo_cognitive_archive": {
+      "description": "Archive a memory — excluded from searches, can be restored",
+      "category": "cognitive",
+      "source": "plugin:cognitive_memory",
+      "enforcement": null
+    },
+    "nexo_cognitive_restore": {
+      "description": "Restore a memory to active state",
+      "category": "cognitive",
+      "source": "plugin:cognitive_memory",
+      "enforcement": null
+    },
+    "nexo_cognitive_quarantine_list": {
+      "description": "List quarantine queue items awaiting promotion to STM",
+      "category": "cognitive",
+      "source": "plugin:cognitive_memory",
+      "enforcement": null
+    },
+    "nexo_cognitive_quarantine_promote": {
+      "description": "Manually promote a quarantine item to STM",
+      "category": "cognitive",
+      "source": "plugin:cognitive_memory",
+      "enforcement": null
+    },
+    "nexo_cognitive_quarantine_reject": {
+      "description": "Manually reject a quarantine item",
+      "category": "cognitive",
+      "source": "plugin:cognitive_memory",
+      "enforcement": null
+    },
+    "nexo_cognitive_quarantine_process": {
+      "description": "Run quarantine promotion cycle",
+      "category": "cognitive",
+      "source": "plugin:cognitive_memory",
+      "enforcement": null
+    },
+    "nexo_cognitive_trigger_create": {
+      "description": "Create a prospective memory trigger",
+      "category": "cognitive",
+      "source": "plugin:cognitive_memory",
+      "enforcement": null
+    },
+    "nexo_cognitive_trigger_list": {
+      "description": "List prospective triggers by status",
+      "category": "cognitive",
+      "source": "plugin:cognitive_memory",
+      "enforcement": null
+    },
+    "nexo_cognitive_trigger_preview": {
+      "description": "Preview anticipatory trigger matches without firing",
+      "category": "cognitive",
+      "source": "plugin:cognitive_memory",
+      "enforcement": null
+    },
+    "nexo_cognitive_trigger_check": {
+      "description": "Check text against armed triggers",
+      "category": "cognitive",
+      "source": "plugin:cognitive_memory",
+      "enforcement": null
+    },
+    "nexo_cognitive_trigger_delete": {
+      "description": "Delete a prospective trigger by ID",
+      "category": "cognitive",
+      "source": "plugin:cognitive_memory",
+      "enforcement": null
+    },
+    "nexo_cognitive_trigger_rearm": {
+      "description": "Re-arm a fired trigger so it can fire again",
+      "category": "cognitive",
+      "source": "plugin:cognitive_memory",
+      "enforcement": null
+    },
+    "nexo_cortex_check": {
+      "description": "Cognitive pre-action check",
+      "category": "cortex",
+      "source": "plugin:cortex",
+      "enforcement": null
+    },
+    "nexo_cortex_decide": {
+      "description": "Evaluate 2+ alternatives for a high-impact task",
+      "category": "cortex",
+      "source": "plugin:cortex",
+      "enforcement": null
+    },
+    "nexo_cortex_override": {
+      "description": "Override a stored Cortex recommendation",
+      "category": "cortex",
+      "source": "plugin:cortex",
+      "enforcement": null
+    },
+    "nexo_cortex_quality": {
+      "description": "Summarise recommendation accept rate, override rate",
+      "category": "cortex",
+      "source": "plugin:cortex",
+      "enforcement": null
+    },
+    "nexo_cortex_review": {
+      "description": "Review persisted Cortex alternative evaluations",
+      "category": "cortex",
+      "source": "plugin:cortex",
+      "enforcement": null
+    },
+    "nexo_cortex_stats": {
+      "description": "View Cortex activation statistics",
+      "category": "cortex",
+      "source": "plugin:cortex",
+      "enforcement": null
+    },
+    "nexo_decision_log": {
+      "description": "Log a non-trivial decision with reasoning, alternatives, and evidence",
+      "category": "decision",
+      "source": "plugin:cortex",
+      "enforcement": null
+    },
+    "nexo_decision_outcome": {
+      "description": "Record what actually happened after a past decision",
+      "category": "decision",
+      "source": "plugin:cortex",
+      "enforcement": null
+    },
+    "nexo_decision_search": {
+      "description": "Search past decisions",
+      "category": "decision",
+      "source": "plugin:cortex",
+      "enforcement": null
+    },
+    "nexo_recall": {
+      "description": "Search across ALL NEXO memory",
+      "category": "memory",
+      "source": "plugin:simple_api",
+      "enforcement": null
+    },
+    "nexo_remember": {
+      "description": "High-level memory write: store one durable memory item",
+      "category": "memory",
+      "source": "plugin:simple_api",
+      "enforcement": null
+    },
+    "nexo_memory_recall": {
+      "description": "High-level memory lookup wrapper around nexo_recall",
+      "category": "memory",
+      "source": "plugin:memory_export",
+      "enforcement": null
+    },
+    "nexo_memory_export": {
+      "description": "Export a readable markdown snapshot of key NEXO memory layers",
+      "category": "memory",
+      "source": "plugin:memory_export",
+      "enforcement": null
+    },
+    "nexo_memory_backend_status": {
+      "description": "Show the active memory backend contract and registered backend list",
+      "category": "memory",
+      "source": "plugin:memory_export",
+      "enforcement": null
+    },
+    "nexo_memory_review_queue": {
+      "description": "Show decisions and learnings that are due for review",
+      "category": "memory",
+      "source": "plugin:memory_export",
+      "enforcement": null
+    },
+    "nexo_consolidate": {
+      "description": "Run NEXO memory consolidation explicitly",
+      "category": "memory",
+      "source": "plugin:episodic_memory",
+      "enforcement": null
+    },
+    "nexo_diary_archive_read": {
+      "description": "Read a single archived diary entry in full detail",
+      "category": "diary",
+      "source": "plugin:episodic_memory",
+      "enforcement": null
+    },
+    "nexo_diary_archive_search": {
+      "description": "Search the permanent diary archive (subconscious memory)",
+      "category": "diary",
+      "source": "plugin:episodic_memory",
+      "enforcement": null
+    },
+    "nexo_entity_create": {
+      "description": "Create a new entity (person, service, URL)",
+      "category": "entity",
+      "source": "plugin:entities",
+      "enforcement": null
+    },
+    "nexo_entity_delete": {
+      "description": "Delete an entity",
+      "category": "entity",
+      "source": "plugin:entities",
+      "enforcement": null
+    },
+    "nexo_entity_list": {
+      "description": "List all entities grouped by type",
+      "category": "entity",
+      "source": "plugin:entities",
+      "enforcement": null
+    },
+    "nexo_entity_search": {
+      "description": "Search entities by name, value, or type",
+      "category": "entity",
+      "source": "plugin:entities",
+      "enforcement": null
+    },
+    "nexo_entity_update": {
+      "description": "Update an entity's fields",
+      "category": "entity",
+      "source": "plugin:entities",
+      "enforcement": null
+    },
+    "nexo_claim_add": {
+      "description": "Add a structured claim with provenance, evidence, and freshness",
+      "category": "claims",
+      "source": "plugin:claims_tools",
+      "enforcement": null
+    },
+    "nexo_claim_get": {
+      "description": "Get a single claim with its links and freshness metadata",
+      "category": "claims",
+      "source": "plugin:claims_tools",
+      "enforcement": null
+    },
+    "nexo_claim_link": {
+      "description": "Link two claims",
+      "category": "claims",
+      "source": "plugin:claims_tools",
+      "enforcement": null
+    },
+    "nexo_claim_lint": {
+      "description": "Audit stale, weak, contradictory, or evidence-poor claims",
+      "category": "claims",
+      "source": "plugin:claims_tools",
+      "enforcement": null
+    },
+    "nexo_claim_search": {
+      "description": "Search claims by meaning or filters",
+      "category": "claims",
+      "source": "plugin:claims_tools",
+      "enforcement": null
+    },
+    "nexo_claim_stats": {
+      "description": "Claim graph statistics and attention counts",
+      "category": "claims",
+      "source": "plugin:claims_tools",
+      "enforcement": null
+    },
+    "nexo_claim_verify": {
+      "description": "Verify or reclassify a claim state",
+      "category": "claims",
+      "source": "plugin:claims_tools",
+      "enforcement": null
+    },
+    "nexo_kg_query": {
+      "description": "Query knowledge graph — traverse from a node",
+      "category": "knowledge_graph",
+      "source": "plugin:knowledge_graph_tools",
+      "enforcement": null
+    },
+    "nexo_kg_neighbors": {
+      "description": "Get direct neighbors of a node",
+      "category": "knowledge_graph",
+      "source": "plugin:knowledge_graph_tools",
+      "enforcement": null
+    },
+    "nexo_kg_path": {
+      "description": "Find shortest path between two nodes",
+      "category": "knowledge_graph",
+      "source": "plugin:knowledge_graph_tools",
+      "enforcement": null
+    },
+    "nexo_kg_stats": {
+      "description": "Knowledge graph statistics",
+      "category": "knowledge_graph",
+      "source": "plugin:knowledge_graph_tools",
+      "enforcement": null
+    },
+    "nexo_kg_export": {
+      "description": "Export the bitemporal KG to JSON-LD or GraphML",
+      "category": "knowledge_graph",
+      "source": "plugin:knowledge_graph_tools",
+      "enforcement": null
+    },
+    "nexo_media_memory_add": {
+      "description": "Store a non-text artifact as first-class media memory metadata",
+      "category": "media",
+      "source": "plugin:media_memory_tools",
+      "enforcement": null
+    },
+    "nexo_media_memory_get": {
+      "description": "Inspect one stored media memory",
+      "category": "media",
+      "source": "plugin:media_memory_tools",
+      "enforcement": null
+    },
+    "nexo_media_memory_search": {
+      "description": "Search media memories by text, type, tag, or domain",
+      "category": "media",
+      "source": "plugin:media_memory_tools",
+      "enforcement": null
+    },
+    "nexo_media_memory_stats": {
+      "description": "Stats for the multimodal/media memory layer",
+      "category": "media",
+      "source": "plugin:media_memory_tools",
+      "enforcement": null
+    },
+    "nexo_skill_apply": {
+      "description": "Apply a skill in guide, execute, or hybrid mode",
+      "category": "skill",
+      "source": "plugin:skills",
+      "enforcement": null
+    },
+    "nexo_skill_approve": {
+      "description": "Approve a local/remote executable skill so it can run",
+      "category": "skill",
+      "source": "plugin:skills",
+      "enforcement": null
+    },
+    "nexo_skill_compose": {
+      "description": "Compose multiple existing skills into one higher-level reusable skill",
+      "category": "skill",
+      "source": "plugin:skills",
+      "enforcement": null
+    },
+    "nexo_skill_compose_candidates": {
+      "description": "Voyager-style detection: list skill pairs that fired together frequently",
+      "category": "skill",
+      "source": "plugin:skills",
+      "enforcement": null
+    },
+    "nexo_skill_create": {
+      "description": "Create a new skill with guide/execute/hybrid metadata",
+      "category": "skill",
+      "source": "plugin:skills",
+      "enforcement": null
+    },
+    "nexo_skill_evolution_candidates": {
+      "description": "Return candidates for skill improvement or text-to-script evolution",
+      "category": "skill",
+      "source": "plugin:skills",
+      "enforcement": null
+    },
+    "nexo_skill_featured": {
+      "description": "Return featured published/stable skills for startup discovery",
+      "category": "skill",
+      "source": "plugin:skills",
+      "enforcement": null
+    },
+    "nexo_skill_get": {
+      "description": "Get a skill's full details",
+      "category": "skill",
+      "source": "plugin:skills",
+      "enforcement": null
+    },
+    "nexo_skill_list": {
+      "description": "List skills, optionally filtered by level, tag, or source",
+      "category": "skill",
+      "source": "plugin:skills",
+      "enforcement": null
+    },
+    "nexo_skill_merge": {
+      "description": "Merge two similar skills into one",
+      "category": "skill",
+      "source": "plugin:skills",
+      "enforcement": null
+    },
+    "nexo_skill_outcome_review": {
+      "description": "Review whether a skill should be promoted, deprioritized, or retired",
+      "category": "skill",
+      "source": "plugin:skills",
+      "enforcement": null
+    },
+    "nexo_skill_promote": {
+      "description": "Promote a skill to a stronger published/stable lifecycle stage",
+      "category": "skill",
+      "source": "plugin:skills",
+      "enforcement": null
+    },
+    "nexo_skill_result": {
+      "description": "Record the result of using a skill",
+      "category": "skill",
+      "source": "plugin:skills",
+      "enforcement": null
+    },
+    "nexo_skill_retire": {
+      "description": "Retire a skill cleanly so it leaves the active lifecycle",
+      "category": "skill",
+      "source": "plugin:skills",
+      "enforcement": null
+    },
+    "nexo_skill_seed_from_outcome_pattern": {
+      "description": "Materialize a draft skill candidate from a repeated successful outcome pattern",
+      "category": "skill",
+      "source": "plugin:skills",
+      "enforcement": null
+    },
+    "nexo_skill_stats": {
+      "description": "Show aggregate skill statistics",
+      "category": "skill",
+      "source": "plugin:skills",
+      "enforcement": null
+    },
+    "nexo_skill_sync": {
+      "description": "Sync filesystem skill definitions into SQLite",
+      "category": "skill",
+      "source": "plugin:skills",
+      "enforcement": null
+    },
+    "nexo_skill_test": {
+      "description": "Test a skill through the canonical runtime in dry-run mode",
+      "category": "skill",
+      "source": "plugin:skills",
+      "enforcement": null
+    },
+    "nexo_adaptive_mode": {
+      "description": "Get or compute adaptive personality mode (FLOW/NORMAL/TENSION)",
+      "category": "adaptive",
+      "source": "plugin:adaptive_mode",
+      "enforcement": null
+    },
+    "nexo_adaptive_decay": {
+      "description": "Trigger inter-session tension decay",
+      "category": "adaptive",
+      "source": "plugin:adaptive_mode",
+      "enforcement": null
+    },
+    "nexo_adaptive_history": {
+      "description": "View recent adaptive mode transitions and signal history",
+      "category": "adaptive",
+      "source": "plugin:adaptive_mode",
+      "enforcement": null
+    },
+    "nexo_adaptive_override": {
+      "description": "Manual override: force FLOW/NORMAL/TENSION",
+      "category": "adaptive",
+      "source": "plugin:adaptive_mode",
+      "enforcement": null
+    },
+    "nexo_adaptive_reset": {
+      "description": "Reset adaptive state for new session",
+      "category": "adaptive",
+      "source": "plugin:adaptive_mode",
+      "enforcement": null
+    },
+    "nexo_adaptive_weights": {
+      "description": "View adaptive weights — static vs learned, training stats",
+      "category": "adaptive",
+      "source": "plugin:adaptive_mode",
+      "enforcement": null
+    },
+    "nexo_agent_create": {
+      "description": "Register a new agent",
+      "category": "agent",
+      "source": "plugin:agents",
+      "enforcement": null
+    },
+    "nexo_agent_delete": {
+      "description": "Remove an agent from registry",
+      "category": "agent",
+      "source": "plugin:agents",
+      "enforcement": null
+    },
+    "nexo_agent_get": {
+      "description": "Get an agent's full profile",
+      "category": "agent",
+      "source": "plugin:agents",
+      "enforcement": null
+    },
+    "nexo_agent_list": {
+      "description": "List all registered agents",
+      "category": "agent",
+      "source": "plugin:agents",
+      "enforcement": null
+    },
+    "nexo_agent_update": {
+      "description": "Update agent fields",
+      "category": "agent",
+      "source": "plugin:agents",
+      "enforcement": null
+    },
+    "nexo_artifact_create": {
+      "description": "Register a new artifact (service, dashboard, script, API, etc)",
+      "category": "artifact",
+      "source": "plugin:artifact_registry",
+      "enforcement": null
+    },
+    "nexo_artifact_delete": {
+      "description": "Delete an artifact from the registry",
+      "category": "artifact",
+      "source": "plugin:artifact_registry",
+      "enforcement": null
+    },
+    "nexo_artifact_find": {
+      "description": "Find artifacts using the retrieval ladder",
+      "category": "artifact",
+      "source": "plugin:artifact_registry",
+      "enforcement": null
+    },
+    "nexo_artifact_learn_alias": {
+      "description": "Learn a new alias from user language",
+      "category": "artifact",
+      "source": "plugin:artifact_registry",
+      "enforcement": null
+    },
+    "nexo_artifact_list": {
+      "description": "List all registered artifacts",
+      "category": "artifact",
+      "source": "plugin:artifact_registry",
+      "enforcement": null
+    },
+    "nexo_artifact_update": {
+      "description": "Update an existing artifact",
+      "category": "artifact",
+      "source": "plugin:artifact_registry",
+      "enforcement": null
+    },
+    "nexo_auto_flush_recent": {
+      "description": "Show recent structured auto-flush records written before compaction",
+      "category": "system",
+      "source": "plugin:backup",
+      "enforcement": null
+    },
+    "nexo_auto_flush_stats": {
+      "description": "Stats for pre-compaction auto-flush activity",
+      "category": "system",
+      "source": "plugin:backup",
+      "enforcement": null
+    },
+    "nexo_backup_list": {
+      "description": "List available backups with dates and sizes",
+      "category": "backup",
+      "source": "plugin:backup",
+      "enforcement": null
+    },
+    "nexo_backup_now": {
+      "description": "Create an immediate backup of the NEXO database",
+      "category": "backup",
+      "source": "plugin:backup",
+      "enforcement": null
+    },
+    "nexo_backup_restore": {
+      "description": "Restore database from a backup (DESTRUCTIVE)",
+      "category": "backup",
+      "source": "plugin:backup",
+      "enforcement": null
+    },
+    "nexo_change_commit": {
+      "description": "Link a change log entry to its git commit hash",
+      "category": "change_log",
+      "source": "plugin:core_rules",
+      "enforcement": null
+    },
+    "nexo_change_log": {
+      "description": "Log a code/config change with full context",
+      "category": "change_log",
+      "source": "plugin:core_rules",
+      "enforcement": null
+    },
+    "nexo_change_search": {
+      "description": "Search past code changes",
+      "category": "change_log",
+      "source": "plugin:core_rules",
+      "enforcement": null
+    },
+    "nexo_rules_check": {
+      "description": "Get applicable core rules for an area before acting",
+      "category": "rules",
+      "source": "plugin:core_rules",
+      "enforcement": null
+    },
+    "nexo_rules_list": {
+      "description": "List all core rules with status, grouped by category",
+      "category": "rules",
+      "source": "plugin:core_rules",
+      "enforcement": null
+    },
+    "nexo_rules_migrate": {
+      "description": "Sync rules from JSON definition to database",
+      "category": "rules",
+      "source": "plugin:core_rules",
+      "enforcement": null
+    },
+    "nexo_evolution_approve": {
+      "description": "Approve a pending Evolution proposal (user only)",
+      "category": "evolution",
+      "source": "plugin:evolution",
+      "enforcement": null
+    },
+    "nexo_evolution_history": {
+      "description": "Show past evolution cycles, proposals, and their outcomes",
+      "category": "evolution",
+      "source": "plugin:evolution",
+      "enforcement": null
+    },
+    "nexo_evolution_propose": {
+      "description": "Manually trigger an evolution analysis outside weekly schedule",
+      "category": "evolution",
+      "source": "plugin:evolution",
+      "enforcement": null
+    },
+    "nexo_evolution_reject": {
+      "description": "Reject a pending Evolution proposal with reason",
+      "category": "evolution",
+      "source": "plugin:evolution",
+      "enforcement": null
+    },
+    "nexo_evolution_status": {
+      "description": "Show current NEXO dimension scores",
+      "category": "evolution",
+      "source": "plugin:evolution",
+      "enforcement": null
+    },
+    "nexo_goal_open": {
+      "description": "Open a durable goal so multi-session objectives stay explicit",
+      "category": "goal",
+      "source": "plugin:goal_engine",
+      "enforcement": null
+    },
+    "nexo_goal_get": {
+      "description": "Read a durable goal and optionally include linked workflow runs",
+      "category": "goal",
+      "source": "plugin:goal_engine",
+      "enforcement": null
+    },
+    "nexo_goal_list": {
+      "description": "List durable goals",
+      "category": "goal",
+      "source": "plugin:goal_engine",
+      "enforcement": null
+    },
+    "nexo_goal_update": {
+      "description": "Update a durable goal with state and next action",
+      "category": "goal",
+      "source": "plugin:goal_engine",
+      "enforcement": null
+    },
+    "nexo_goal_engine_status": {
+      "description": "Report Goal Engine telemetry readiness",
+      "category": "goal",
+      "source": "plugin:goal_engine",
+      "enforcement": null
+    },
+    "nexo_goal_profile_get": {
+      "description": "Get or resolve the active Goal Engine profile for a context",
+      "category": "goal",
+      "source": "plugin:goal_engine",
+      "enforcement": null
+    },
+    "nexo_goal_profile_list": {
+      "description": "List Goal Engine profiles currently available",
+      "category": "goal",
+      "source": "plugin:goal_engine",
+      "enforcement": null
+    },
+    "nexo_goal_profile_set": {
+      "description": "Create or update a Goal Engine profile",
+      "category": "goal",
+      "source": "plugin:goal_engine",
+      "enforcement": null
+    },
+    "nexo_impact_score": {
+      "description": "Compute and persist Impact Scoring for a followup",
+      "category": "impact",
+      "source": "plugin:impact",
+      "enforcement": null
+    },
+    "nexo_outcome_register": {
+      "description": "Register an expected action outcome with metric source and deadline",
+      "category": "outcome",
+      "source": "plugin:outcomes",
+      "enforcement": null
+    },
+    "nexo_outcome_check": {
+      "description": "Check a tracked outcome now using linked state or supplied evidence",
+      "category": "outcome",
+      "source": "plugin:outcomes",
+      "enforcement": null
+    },
+    "nexo_outcome_list": {
+      "description": "List tracked outcomes filtered by status and/or action type",
+      "category": "outcome",
+      "source": "plugin:outcomes",
+      "enforcement": null
+    },
+    "nexo_outcome_cancel": {
+      "description": "Cancel an outcome so it stops blocking reviews",
+      "category": "outcome",
+      "source": "plugin:outcomes",
+      "enforcement": null
+    },
+    "nexo_outcome_pattern_candidates": {
+      "description": "List repeated resolved outcome patterns consistent enough to become reusable knowledge",
+      "category": "outcome",
+      "source": "plugin:outcomes",
+      "enforcement": null
+    },
+    "nexo_outcome_pattern_capture": {
+      "description": "Capture one repeated outcome pattern as a reusable artifact",
+      "category": "outcome",
+      "source": "plugin:outcomes",
+      "enforcement": null
+    },
+    "nexo_personal_plugin_create": {
+      "description": "Create a persistent personal MCP plugin scaffold",
+      "category": "personal",
+      "source": "plugin:personal_plugins",
+      "enforcement": null
+    },
+    "nexo_personal_script_create": {
+      "description": "Create a new personal script, register it, and optionally schedule it",
+      "category": "personal",
+      "source": "plugin:personal_scripts",
+      "enforcement": null
+    },
+    "nexo_personal_script_remove": {
+      "description": "Remove a personal script from the registry",
+      "category": "personal",
+      "source": "plugin:personal_scripts",
+      "enforcement": null
+    },
+    "nexo_personal_script_schedules": {
+      "description": "List registered personal script schedules",
+      "category": "personal",
+      "source": "plugin:personal_scripts",
+      "enforcement": null
+    },
+    "nexo_personal_script_unschedule": {
+      "description": "Remove all personal schedules attached to a script",
+      "category": "personal",
+      "source": "plugin:personal_scripts",
+      "enforcement": null
+    },
+    "nexo_personal_scripts_classify": {
+      "description": "Classify files in NEXO_HOME/scripts into personal, core, ignored",
+      "category": "personal",
+      "source": "plugin:personal_scripts",
+      "enforcement": null
+    },
+    "nexo_personal_scripts_ensure_schedules": {
+      "description": "Create or repair personal script schedules declared in inline metadata",
+      "category": "personal",
+      "source": "plugin:personal_scripts",
+      "enforcement": null
+    },
+    "nexo_personal_scripts_list": {
+      "description": "List personal scripts known to NEXO",
+      "category": "personal",
+      "source": "plugin:personal_scripts",
+      "enforcement": null
+    },
+    "nexo_personal_scripts_reconcile": {
+      "description": "Classify, sync, and ensure declared personal schedules",
+      "category": "personal",
+      "source": "plugin:personal_scripts",
+      "enforcement": null
+    },
+    "nexo_personal_scripts_sync": {
+      "description": "Sync personal scripts and personal cron schedules from filesystem",
+      "category": "personal",
+      "source": "plugin:personal_scripts",
+      "enforcement": null
+    },
+    "nexo_preference_get": {
+      "description": "Get a specific preference value",
+      "category": "preferences",
+      "source": "plugin:preferences",
+      "enforcement": null
+    },
+    "nexo_preference_set": {
+      "description": "Set a preference (creates or updates)",
+      "category": "preferences",
+      "source": "plugin:preferences",
+      "enforcement": null
+    },
+    "nexo_preference_list": {
+      "description": "List all preferences grouped by category",
+      "category": "preferences",
+      "source": "plugin:preferences",
+      "enforcement": null
+    },
+    "nexo_preference_delete": {
+      "description": "Delete a preference",
+      "category": "preferences",
+      "source": "plugin:preferences",
+      "enforcement": null
+    },
+    "nexo_protocol_debt_list": {
+      "description": "List protocol debt records",
+      "category": "protocol",
+      "source": "plugin:protocol",
+      "enforcement": null
+    },
+    "nexo_protocol_debt_resolve": {
+      "description": "Resolve protocol debt records",
+      "category": "protocol",
+      "source": "plugin:protocol",
+      "enforcement": null
+    },
+    "nexo_schedule_add": {
+      "description": "Add a new personal cron job",
+      "category": "schedule",
+      "source": "plugin:schedule",
+      "enforcement": null
+    },
+    "nexo_schedule_status": {
+      "description": "Show cron execution status: what ran overnight, what failed",
+      "category": "schedule",
+      "source": "plugin:schedule",
+      "enforcement": null
+    },
+    "nexo_somatic_check": {
+      "description": "View somatic risk scores for files/areas — pain memory",
+      "category": "somatic",
+      "source": "plugin:guard",
+      "enforcement": null
+    },
+    "nexo_somatic_stats": {
+      "description": "Top 10 riskiest targets + risk distribution",
+      "category": "somatic",
+      "source": "plugin:guard",
+      "enforcement": null
+    },
+    "nexo_state_watcher_create": {
+      "description": "Create a persistent state watcher for drift detection",
+      "category": "watcher",
+      "source": "plugin:state_watchers",
+      "enforcement": null
+    },
+    "nexo_state_watcher_list": {
+      "description": "List persistent state watchers",
+      "category": "watcher",
+      "source": "plugin:state_watchers",
+      "enforcement": null
+    },
+    "nexo_state_watcher_run": {
+      "description": "Run persistent state watchers and return health summary",
+      "category": "watcher",
+      "source": "plugin:state_watchers",
+      "enforcement": null
+    },
+    "nexo_state_watcher_update": {
+      "description": "Update an existing persistent state watcher",
+      "category": "watcher",
+      "source": "plugin:state_watchers",
+      "enforcement": null
+    },
+    "nexo_user_state": {
+      "description": "Compute user-state snapshot from trust, corrections, sentiment",
+      "category": "user_state",
+      "source": "plugin:user_state_tools",
+      "enforcement": null
+    },
+    "nexo_user_state_history": {
+      "description": "List recent user-state snapshots",
+      "category": "user_state",
+      "source": "plugin:user_state_tools",
+      "enforcement": null
+    },
+    "nexo_user_state_stats": {
+      "description": "Aggregate user-state snapshots by label",
+      "category": "user_state",
+      "source": "plugin:user_state_tools",
+      "enforcement": null
+    },
+    "nexo_workflow_open": {
+      "description": "Open a durable workflow run for long multi-step or cross-session work",
+      "category": "workflow",
+      "source": "plugin:workflow",
+      "enforcement": null
+    },
+    "nexo_workflow_update": {
+      "description": "Update a workflow run with replayable checkpoints",
+      "category": "workflow",
+      "source": "plugin:workflow",
+      "enforcement": null
+    },
+    "nexo_workflow_get": {
+      "description": "Read the full durable workflow state",
+      "category": "workflow",
+      "source": "plugin:workflow",
+      "enforcement": null
+    },
+    "nexo_workflow_list": {
+      "description": "List durable workflow runs",
+      "category": "workflow",
+      "source": "plugin:workflow",
+      "enforcement": null
+    },
+    "nexo_workflow_resume": {
+      "description": "Summarize the next actionable step for a workflow run",
+      "category": "workflow",
+      "source": "plugin:workflow",
+      "enforcement": null
+    },
+    "nexo_workflow_replay": {
+      "description": "Replay the latest checkpoints of a workflow run",
+      "category": "workflow",
+      "source": "plugin:workflow",
+      "enforcement": null
+    },
+    "nexo_workflow_handoff": {
+      "description": "Record a durable handoff so another agent or client can resume",
+      "category": "workflow",
+      "source": "plugin:workflow",
+      "enforcement": null
+    },
+    "nexo_workflow_compensation": {
+      "description": "Show the rollback / compensation plan for a partially completed workflow",
+      "category": "workflow",
+      "source": "plugin:workflow",
+      "enforcement": null
+    },
+    "nexo_run_workflow": {
+      "description": "High-level durable workflow entry point for the public API surface",
+      "category": "workflow",
+      "source": "plugin:workflow",
+      "enforcement": null
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Canonical map of all 247 NEXO Brain MCP tools with enforcement metadata (`tool-enforcement-map.json`)
- 16 tools have enforcement rules (periodic, event-based, session lifecycle), 231 without
- Verification script `scripts/verify_tool_map.py` catches drift between code and map
- Version bump to 5.4.7

## Context
Protocol Enforcer (approved by Francisco 2026-04-15) uses this map as single source of truth.
NEXO Desktop and headless session-guard will read it to mechanically enforce protocol compliance.

## Test plan
- [x] `python3 scripts/verify_tool_map.py` passes (247 tools in sync)
- [x] Learning #335 created to guard future tool changes