### PR TITLE
fix: v5.5.2 verify launchagent repairs + model fallback cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@
 - Migrated all `launchctl load/unload` calls to modern `bootstrap/bootout` API.
 - Added return code verification for all repair operations.
 
+### Fix: headless automation scripts defer model resolution to the configured runtime
+
+- Core automation scripts no longer hardcode legacy `"opus"` / `"sonnet"`
+  fallback strings when `_USER_MODEL` is empty.
+- Passing an empty `model` now lets `run_automation_prompt()` resolve the
+  active backend profile, so Codex and Claude headless runs stay aligned with
+  the configured runtime defaults.
+- Added regression coverage for empty-model Codex resolution in
+  `tests/test_agent_runner.py`.
+
 ## [5.5.1] - 2026-04-15
 
 ### Fix: headless enforcement import + logging

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [Watch the overview video](https://nexo-brain.com/watch/) · [Watch on YouTube](https://www.youtube.com/watch?v=i2lkGhKyVqI) · [Open the infographic](https://nexo-brain.com/assets/nexo-brain-infographic-v5.png)
 
-Version `5.5.2` is the current packaged-runtime line: auto-repair unloaded LaunchAgents on startup and ensure_schedules.
+Version `5.5.2` is the current packaged-runtime line: auto-repair unloaded LaunchAgents on startup and ensure_schedules, plus headless model fallback cleanup so automation scripts defer to the configured runtime profile.
 
 Previously in `5.4.6`: runtime dependency management in `nexo update` + daily auto-update cron.
 

--- a/blog/index.html
+++ b/blog/index.html
@@ -174,8 +174,8 @@
 
             <div class="blog-card">
                 <div class="blog-card-date">April 15, 2026</div>
-                <h2><a href="/blog/nexo-5-5-2/">NEXO 5.5.2: Auto-Repair Unloaded LaunchAgents</a></h2>
-                <p>Startup and ensure_schedules now verify launchctl loaded state, auto-repair unloaded agents, and use the modern bootstrap/bootout API with return code verification.</p>
+                <h2><a href="/blog/nexo-5-5-2/">NEXO 5.5.2: Auto-Repair LaunchAgents + Model Fallback Cleanup</a></h2>
+                <p>Startup and ensure_schedules now verify launchctl loaded state, repair stale launchd entries with checked bootstrap/bootout calls, and core automation scripts defer empty model selection to the configured runtime profile.</p>
                 <a href="/blog/nexo-5-5-2/" class="read-more">Read more &rarr;</a>
             </div>
 

--- a/blog/nexo-5-5-2/index.html
+++ b/blog/nexo-5-5-2/index.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <title>NEXO 5.5.2: Auto-Repair LaunchAgents + Model Fallback Cleanup</title>
+    <meta name="description" content="NEXO 5.5.2 auto-repairs unloaded or stale macOS LaunchAgents with verified launchctl calls and removes legacy model fallbacks from core headless automation scripts.">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://nexo-brain.com/blog/nexo-5-5-2/">
+
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://nexo-brain.com/blog/nexo-5-5-2/">
+    <meta property="og:title" content="NEXO 5.5.2: Auto-Repair LaunchAgents + Model Fallback Cleanup">
+    <meta property="og:description" content="LaunchAgent repair now verifies launchctl state and core automation scripts stop hardcoding legacy opus/sonnet fallbacks.">
+    <meta property="og:image" content="https://nexo-brain.com/assets/og/og-blog.png">
+    <meta property="article:published_time" content="2026-04-15">
+    <meta property="article:author" content="Francisco Cerda Puigserver">
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="NEXO 5.5.2: Auto-Repair LaunchAgents + Model Fallback Cleanup">
+    <meta name="twitter:description" content="Verified launchctl repair for stale LaunchAgents plus runtime-aligned headless model selection.">
+    <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-blog.png">
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-1LNEMCJMS7"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-1LNEMCJMS7');
+    </script>
+
+    <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicon-32.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
+    <link rel="stylesheet" href="/assets/style.css">
+
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "NEXO 5.5.2: Auto-Repair LaunchAgents + Model Fallback Cleanup",
+        "description": "NEXO 5.5.2 auto-repairs unloaded or stale macOS LaunchAgents with verified launchctl calls and removes legacy model fallbacks from core headless automation scripts.",
+        "datePublished": "2026-04-15",
+        "dateModified": "2026-04-15",
+        "author": {
+            "@type": "Person",
+            "name": "Francisco Cerda Puigserver"
+        },
+        "publisher": {
+            "@type": "Organization",
+            "name": "WAzion",
+            "url": "https://www.wazion.com"
+        },
+        "mainEntityOfPage": {
+            "@type": "WebPage",
+            "@id": "https://nexo-brain.com/blog/nexo-5-5-2/"
+        },
+        "url": "https://nexo-brain.com/blog/nexo-5-5-2/",
+        "image": "https://nexo-brain.com/assets/og/og-blog.png",
+        "keywords": ["NEXO 5.5.2", "LaunchAgents", "launchctl", "Codex", "headless automation"]
+    }
+    </script>
+
+    <style>
+        .article-header { padding-top: 128px; padding-bottom: 40px; text-align: center; }
+        .article-meta { font-size: 14px; color: var(--text-muted); margin-bottom: 16px; }
+        .article-body {
+            max-width: 720px; margin: 0 auto; padding: 0 24px 80px;
+            font-size: 17px; line-height: 1.8; color: var(--text);
+        }
+        .article-body h2 { font-size: 28px; font-weight: 700; margin: 48px 0 16px; letter-spacing: -0.01em; }
+        .article-body p { margin-bottom: 20px; color: var(--text-muted); }
+        .article-body strong { color: var(--text); }
+        .article-body a { color: var(--purple-light); }
+        .article-body a:hover { color: var(--pink); }
+        .article-body code {
+            font-family: 'SF Mono', 'Fira Code', monospace;
+            font-size: 14px; color: var(--pink);
+            background: rgba(236, 72, 153, 0.1);
+            padding: 2px 8px; border-radius: 4px;
+        }
+        .article-back {
+            display: inline-flex; align-items: center; gap: 6px;
+            font-size: 14px; font-weight: 600; color: var(--text-muted);
+            margin-bottom: 24px;
+        }
+        .article-back:hover { color: var(--purple-light); }
+    </style>
+</head>
+<body>
+
+<nav>
+    <div class="container">
+        <a href="/" class="nav-logo">
+            <img src="/assets/logo-64.png" alt="NEXO Brain" class="logo-image">
+            <span class="logo-text">NEXO Brain</span>
+        </a>
+        <button class="mobile-menu-toggle" aria-label="Toggle navigation" onclick="toggleMobileMenu()">
+            <span></span><span></span><span></span>
+        </button>
+        <div class="nav-links">
+            <a href="/">Home</a>
+            <a href="/features/">Features</a>
+            <a href="/evolution/">Evolution</a>
+            <a href="/compare/">Compare</a>
+            <a href="/blog/">Blog</a>
+            <a href="/changelog/">Changelog</a>
+            <a href="/docs/">Docs</a>
+            <a href="https://github.com/wazionapps/nexo" class="nav-cta">GitHub</a>
+        </div>
+    </div>
+</nav>
+
+<section class="article-header">
+    <div class="container">
+        <a href="/blog/" class="article-back">&larr; Back to blog</a>
+        <div class="article-meta">April 15, 2026 &middot; Fix &middot; Runtime</div>
+        <h1 class="section-title" style="font-size:clamp(28px,4.5vw,48px);max-width:920px;margin:0 auto 16px;">NEXO 5.5.2: Auto-Repair LaunchAgents + Model Fallback Cleanup</h1>
+        <p class="section-subtitle" style="max-width:760px;margin:0 auto;">LaunchAgent recovery now verifies what launchd actually loaded before claiming success, and headless automation stops hardcoding legacy model names when the runtime already knows which backend profile to use.</p>
+    </div>
+</section>
+
+<section>
+    <div class="article-body">
+
+        <h2>LaunchAgents now repair from observed state</h2>
+        <p><code>ensure_personal_schedules</code> already knew when a declared schedule existed on disk. In 5.5.2 it also checks whether launchd actually has the matching service loaded. If the plist is present but the service is missing, NEXO runs <code>launchctl bootstrap</code> and records whether that reload really succeeded.</p>
+
+        <h2>No more false green on stale launchd entries</h2>
+        <p>Startup also inspects managed <code>com.nexo.*</code> plists and compares the on-disk <code>ProgramArguments</code> to what <code>launchctl</code> reports as loaded. When launchd is still pointing at a stale or temporary path, NEXO now uses the modern <code>bootout</code> plus <code>bootstrap</code> flow and only reports <strong>AUTO-REPAIRED</strong> after both commands succeed.</p>
+        <p>If either step fails, startup keeps the warning explicit instead of pretending the machine is healthy. That makes the self-heal path honest enough to trust during real bootstraps, updates, and packaged-runtime repairs.</p>
+
+        <h2>Headless model selection now defers to the runtime profile</h2>
+        <p>The other half of 5.5.2 removes legacy <code>&quot;opus&quot;</code> and <code>&quot;sonnet&quot;</code> fallback strings from core automation scripts. Passing an empty <code>model</code> now lets <code>run_automation_prompt()</code> resolve the active backend profile, so Codex and Claude headless runs stay aligned with the configured runtime instead of inheriting a stale default from an old script.</p>
+
+        <h2>Why these two fixes ship together</h2>
+        <p>Both fixes remove a class of hidden drift. One was launchd drift between the plist on disk and the service actually loaded by macOS. The other was runtime drift between the configured automation backend and the hardcoded model name a script might pass. 5.5.2 closes both gaps so packaged jobs behave like the runtime says they should.</p>
+
+    </div>
+</section>
+
+<footer>
+    <div class="container" style="text-align:center; padding: 48px 24px 32px; color: var(--text-muted); font-size: 14px;">
+        <p>&copy; 2024&ndash;2026 WAzion &middot; <a href="https://github.com/wazionapps/nexo" style="color:var(--purple-light);">GitHub</a> &middot; AGPL-3.0</p>
+    </div>
+</footer>
+
+<script>
+function toggleMobileMenu() {
+    document.querySelector('.nav-links').classList.toggle('active');
+    document.querySelector('.mobile-menu-toggle').classList.toggle('active');
+}
+</script>
+
+</body>
+</html>

--- a/changelog/index.html
+++ b/changelog/index.html
@@ -181,13 +181,13 @@
     </div>
 </section>
 
-<!-- v5.5.2 Auto-repair unloaded LaunchAgents -->
+<!-- v5.5.2 Auto-repair unloaded LaunchAgents + model fallback cleanup -->
 <section id="v552" class="section-compact" style="background:linear-gradient(135deg,#0a120f 0%,#152a1f 50%,#1e3f2f 100%);">
     <div class="container">
         <div class="section-label">New in v5.5.2 <span style="opacity:.5;font-weight:400;">&mdash; April 15, 2026</span></div>
-        <h2 class="section-title">Auto-Repair Unloaded LaunchAgents</h2>
+        <h2 class="section-title">Auto-Repair LaunchAgents + Model Fallback Cleanup</h2>
         <p class="section-subtitle">
-            ensure_personal_schedules now verifies launchctl loaded state and auto-repairs unloaded agents on startup. Migrated to modern bootstrap/bootout API with return code verification.
+            ensure_personal_schedules now verifies launchctl loaded state and auto-repairs unloaded agents on startup. Core automation scripts also stop hardcoding legacy opus/sonnet fallbacks and now defer empty model selection to the configured runtime profile.
         </p>
     </div>
 </section>

--- a/index.html
+++ b/index.html
@@ -697,7 +697,7 @@
     <div class="container">
         <div class="hero-badge fade-up">
             <span class="dot"></span>
-            <span id="version-badge">v5.5.2</span> &mdash; auto-repair unloaded LaunchAgents
+            <span id="version-badge">v5.5.2</span> &mdash; LaunchAgent auto-repair + model fallback cleanup
         </div>
         <div class="fade-up" style="display:flex;gap:8px;justify-content:center;margin-bottom:12px;">
             <img src="https://img.shields.io/npm/v/nexo-brain?color=7C3AED&label=npm" alt="npm version">

--- a/llms.txt
+++ b/llms.txt
@@ -4,7 +4,7 @@
 
 NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. It adds a local shared brain across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, smarter retrieval defaults, long-horizon overnight analysis, and 150+ MCP tools.
 
-v5.5.2: auto-repair unloaded LaunchAgents on startup and ensure_schedules — verifies launchctl loaded state, migrated to modern bootstrap/bootout API, added return code verification
+v5.5.2: auto-repair unloaded LaunchAgents + headless model fallback cleanup — verifies launchctl loaded state, migrated to modern bootstrap/bootout API, and removes legacy opus/sonnet fallbacks from core automation scripts
 v5.5.1: real-time headless Protocol Enforcer — enforcement_engine.py monitors tool calls and injects prompts in all headless sessions via stream-json Popen
 v5.4.9: headless Protocol Enforcer — all crons/scripts get enforcement rules via append_system_prompt automatically
 v5.4.8: tool-enforcement-map v2.0 — multi-dimensional enforcement with must/should/may levels, dependency chains, internal calls tracking. 11 must + 10 should + 225 none

--- a/src/scripts/check-context.py
+++ b/src/scripts/check-context.py
@@ -198,7 +198,7 @@ Rules:
     try:
         result = run_automation_prompt(
             prompt,
-            model=_USER_MODEL or "opus",
+            model=_USER_MODEL,
             timeout=300,
             output_format="text",
             append_system_prompt="Return exactly one valid JSON object.",

--- a/src/scripts/deep-sleep/extract.py
+++ b/src/scripts/deep-sleep/extract.py
@@ -134,7 +134,7 @@ def analyze_session(
 
         result = run_automation_prompt(
             prompt,
-            model=_USER_MODEL or "opus",
+            model=_USER_MODEL,
             timeout=CLAUDE_TIMEOUT,
             output_format="text",
             append_system_prompt=JSON_SYSTEM_PROMPT,
@@ -164,7 +164,7 @@ def analyze_session(
             )
             convert_result = run_automation_prompt(
                 convert_prompt,
-                model=_USER_MODEL or "sonnet",
+                model=_USER_MODEL,
                 timeout=120,
                 output_format="text",
                 append_system_prompt=JSON_SYSTEM_PROMPT,

--- a/src/scripts/deep-sleep/synthesize.py
+++ b/src/scripts/deep-sleep/synthesize.py
@@ -240,7 +240,7 @@ def main():
     try:
         result = run_automation_prompt(
             prompt,
-            model=_USER_MODEL or "opus",
+            model=_USER_MODEL,
             timeout=CLAUDE_TIMEOUT,
             output_format="text",
             allowed_tools="Read,Grep,Bash",

--- a/src/scripts/nexo-catchup.py
+++ b/src/scripts/nexo-catchup.py
@@ -279,7 +279,7 @@ Format:
     try:
         result = run_automation_prompt(
             prompt,
-            model=_USER_MODEL or "opus",
+            model=_USER_MODEL,
             timeout=21600,
             output_format="text",
             allowed_tools="Read,Write,Edit,Glob,Grep,Bash,mcp__nexo__*",

--- a/src/scripts/nexo-daily-self-audit.py
+++ b/src/scripts/nexo-daily-self-audit.py
@@ -2049,7 +2049,7 @@ Also write the machine-readable summary to {LOG_DIR}/self-audit-summary.json.
     try:
         result = run_automation_prompt(
             prompt,
-            model=_USER_MODEL or "opus",
+            model=_USER_MODEL,
             timeout=21600,
             output_format="text",
             allowed_tools="Read,Write,Edit,Glob,Grep,Bash,mcp__nexo__*",

--- a/src/scripts/nexo-evolution-run.py
+++ b/src/scripts/nexo-evolution-run.py
@@ -226,7 +226,7 @@ def call_claude_cli(prompt: str) -> str:
     """Call the configured automation backend for the managed evolution prompt."""
     result = run_automation_prompt(
         prompt,
-        model=_USER_MODEL or "opus",
+        model=_USER_MODEL,
         timeout=CLI_TIMEOUT,
         output_format="text",
         allowed_tools="Read,Write,Edit,Glob,Grep,Bash,mcp__nexo__*",
@@ -242,7 +242,7 @@ def call_public_claude_cli(prompt: str, *, cwd: Path) -> str:
         prompt,
         cwd=cwd,
         env={"NEXO_PUBLIC_CONTRIBUTION": "1"},
-        model=_USER_MODEL or "opus",
+        model=_USER_MODEL,
         timeout=CLI_TIMEOUT,
         output_format="text",
         allowed_tools="Read,Write,Edit,Glob,Grep,Bash",

--- a/src/scripts/nexo-immune.py
+++ b/src/scripts/nexo-immune.py
@@ -915,7 +915,7 @@ Write the report. Be concise — max 40 lines."""
     try:
         result = run_automation_prompt(
             prompt,
-            model=_USER_MODEL or "opus",
+            model=_USER_MODEL,
             timeout=21600,
             output_format="text",
             allowed_tools="Read,Write,Edit,Glob,Grep,Bash,mcp__nexo__*",

--- a/src/scripts/nexo-learning-validator.py
+++ b/src/scripts/nexo-learning-validator.py
@@ -158,7 +158,7 @@ Rules:
     try:
         result = run_automation_prompt(
             prompt,
-            model=_USER_MODEL or "sonnet",
+            model=_USER_MODEL,
             timeout=60,
             output_format="text",
             append_system_prompt=JSON_ONLY_SYSTEM_PROMPT,

--- a/src/scripts/nexo-postmortem-consolidator.py
+++ b/src/scripts/nexo-postmortem-consolidator.py
@@ -254,7 +254,7 @@ Execute without asking."""
     try:
         result = run_automation_prompt(
             prompt,
-            model=_USER_MODEL or "opus",
+            model=_USER_MODEL,
             timeout=21600,
             output_format="text",
             allowed_tools="Read,Write,Edit,Glob,Grep,Bash,mcp__nexo__*",

--- a/src/scripts/nexo-sleep.py
+++ b/src/scripts/nexo-sleep.py
@@ -445,7 +445,7 @@ Execute without asking."""
     try:
         result = run_automation_prompt(
             prompt,
-            model=_USER_MODEL or "opus",
+            model=_USER_MODEL,
             timeout=21600,
             output_format="text",
             allowed_tools="Read,Write,Edit,Glob,Grep,Bash,mcp__nexo__*",

--- a/src/scripts/nexo-synthesis.py
+++ b/src/scripts/nexo-synthesis.py
@@ -347,7 +347,7 @@ Execute without asking."""
     try:
         result = run_automation_prompt(
             prompt,
-            model=_USER_MODEL or "opus",
+            model=_USER_MODEL,
             timeout=21600,
             output_format="text",
             allowed_tools="Read,Write,Edit,Glob,Grep,Bash,mcp__nexo__*",

--- a/src/tools_sessions.py
+++ b/src/tools_sessions.py
@@ -350,6 +350,12 @@ def _check_launchagents() -> list[str]:
     plist_dir = os.path.expanduser("~/Library/LaunchAgents")
     warnings = []
 
+    def _stderr_text(result, fallback: str) -> str:
+        stderr = getattr(result, "stderr", "")
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode(errors="replace")
+        return stderr.strip() or fallback
+
     for plist_path in glob.glob(os.path.join(plist_dir, "com.nexo.*.plist")):
         label = os.path.basename(plist_path).replace(".plist", "")
         try:
@@ -364,12 +370,15 @@ def _check_launchagents() -> list[str]:
             if result.returncode != 0:
                 repair = subprocess.run(
                     ["launchctl", "bootstrap", f"gui/{os.getuid()}", plist_path],
-                    capture_output=True, timeout=5,
+                    capture_output=True, text=True, timeout=5,
                 )
                 if repair.returncode == 0:
                     warnings.append(f"{label}: AUTO-REPAIRED (was not loaded, reloaded from disk)")
                 else:
-                    warnings.append(f"{label}: REPAIR FAILED — not loaded (plist exists on disk)")
+                    warnings.append(
+                        f"{label}: REPAIR FAILED — "
+                        f"{_stderr_text(repair, 'not loaded (plist exists on disk)')}"
+                    )
                 continue
 
             # Parse loaded ProgramArguments from launchctl output
@@ -390,9 +399,31 @@ def _check_launchagents() -> list[str]:
                 # Check if loaded path points to /tmp or nonexistent path
                 stale = any("/tmp/" in a or not os.path.exists(a) for a in loaded_args if "/" in a)
                 if stale:
-                    subprocess.run(["launchctl", "bootout", f"gui/{os.getuid()}/{label}"], capture_output=True, timeout=5)
-                    subprocess.run(["launchctl", "bootstrap", f"gui/{os.getuid()}", plist_path], capture_output=True, timeout=5)
-                    warnings.append(f"{label}: AUTO-REPAIRED (was pointing to stale/tmp path, reloaded from disk)")
+                    bootout = subprocess.run(
+                        ["launchctl", "bootout", f"gui/{os.getuid()}/{label}"],
+                        capture_output=True,
+                        text=True,
+                        timeout=5,
+                    )
+                    if bootout.returncode != 0:
+                        warnings.append(
+                            f"{label}: REPAIR FAILED — "
+                            f"{_stderr_text(bootout, 'could not unload stale launchd entry')}"
+                        )
+                        continue
+                    repair = subprocess.run(
+                        ["launchctl", "bootstrap", f"gui/{os.getuid()}", plist_path],
+                        capture_output=True,
+                        text=True,
+                        timeout=5,
+                    )
+                    if repair.returncode == 0:
+                        warnings.append(f"{label}: AUTO-REPAIRED (was pointing to stale/tmp path, reloaded from disk)")
+                    else:
+                        warnings.append(
+                            f"{label}: REPAIR FAILED — "
+                            f"{_stderr_text(repair, 'could not reload stale plist from disk')}"
+                        )
                 else:
                     warnings.append(f"{label}: loaded args differ from disk plist")
         except Exception:

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -444,6 +444,48 @@ def test_codex_backend_maps_legacy_opus_hint_to_configured_profile(monkeypatch, 
     assert 'model_reasoning_effort="high"' in config_values
 
 
+def test_codex_backend_uses_configured_profile_when_model_is_empty(monkeypatch, tmp_path):
+    import agent_runner
+
+    monkeypatch.setattr(agent_runner, "_resolve_codex_cli", lambda: "/tmp/fake-codex")
+    monkeypatch.setattr(agent_runner, "_load_client_bootstrap_prompt", lambda client: "You are NEXO.")
+    monkeypatch.setattr(agent_runner, "_codex_managed_initial_messages_enabled", lambda: False)
+    monkeypatch.setattr(agent_runner, "_record_automation_run", lambda **kwargs: (True, ""))
+    monkeypatch.setattr(agent_runner, "load_client_preferences", lambda: {
+        "interactive_clients": {"claude_code": True, "codex": True, "claude_desktop": False},
+        "default_terminal_client": "codex",
+        "automation_enabled": True,
+        "automation_backend": "codex",
+        "client_runtime_profiles": {
+            "claude_code": {"model": "claude-opus-4-6[1m]", "reasoning_effort": ""},
+            "codex": {"model": "gpt-5.4-mini", "reasoning_effort": "high"},
+        },
+    })
+
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        out_idx = cmd.index("-o") + 1
+        with open(cmd[out_idx], "w", encoding="utf-8") as fh:
+            fh.write("OK")
+        return subprocess.CompletedProcess(cmd, 0, _codex_json_usage(), "")
+
+    monkeypatch.setattr(agent_runner.subprocess, "run", fake_run)
+
+    agent_runner.run_automation_prompt(
+        "Do it",
+        cwd=tmp_path,
+        model="",
+        output_format="text",
+    )
+
+    assert captured["cmd"][captured["cmd"].index("-m") + 1] == "gpt-5.4-mini"
+    config_values = [captured["cmd"][idx + 1] for idx, part in enumerate(captured["cmd"]) if part == "-c"]
+    assert 'initial_messages=[{role="system",content="You are NEXO."}]' in config_values
+    assert 'model_reasoning_effort="high"' in config_values
+
+
 def test_codex_runner_skips_inline_bootstrap_when_global_bootstrap_is_managed(monkeypatch, tmp_path):
     import agent_runner
 

--- a/tests/test_script_registry.py
+++ b/tests/test_script_registry.py
@@ -3,6 +3,7 @@ import json
 import os
 import stat
 import sys
+from types import SimpleNamespace
 
 import pytest
 
@@ -619,6 +620,112 @@ class TestRegistrySync:
         result = ensure_personal_schedules(dry_run=False)
         assert result["repaired"][0]["cron_id"] == "wake-recovery"
         assert "keep_alive=True" in result["repaired"][0]["result"]
+
+    def test_ensure_personal_schedules_reloads_unloaded_launchagent(self, scripts_dir, monkeypatch):
+        import script_registry
+
+        init_db()
+        script = scripts_dir / "email-monitor.py"
+        script.write_text(
+            "# nexo: name=email-monitor\n"
+            "# nexo: runtime=python\n"
+            "# nexo: cron_id=email-monitor\n"
+            "# nexo: interval_seconds=300\n"
+            "# nexo: schedule_required=true\n"
+            "print('ok')\n"
+        )
+
+        plist_path = scripts_dir / "com.nexo.email-monitor.plist"
+        plist_path.write_text("plist")
+
+        monkeypatch.setattr(
+            script_registry,
+            "audit_personal_schedules",
+            lambda: {
+                "schedules": [{
+                    "cron_id": "email-monitor",
+                    "script_path": str(script),
+                    "schedule_type": "interval",
+                    "schedule_value": "300",
+                    "schedule_label": "every 300s",
+                    "launchd_label": "com.nexo.email-monitor",
+                    "plist_path": str(plist_path),
+                    "enabled": True,
+                    "schedule_managed": True,
+                    "run_at_load": False,
+                }],
+                "summary": {},
+            },
+        )
+        monkeypatch.setattr(script_registry.platform, "system", lambda: "Darwin")
+        monkeypatch.setattr(script_registry, "_launchctl_service_state", lambda label: {"loaded": False})
+        monkeypatch.setattr(script_registry.os, "getuid", lambda: 501)
+
+        calls = []
+
+        def fake_run(args, **kwargs):
+            calls.append(args)
+            return SimpleNamespace(returncode=0, stderr=b"", stdout=b"")
+
+        monkeypatch.setattr(script_registry.subprocess, "run", fake_run)
+
+        result = ensure_personal_schedules(dry_run=False)
+        entry = result["already_present"][0]
+        assert entry["cron_id"] == "email-monitor"
+        assert entry["reloaded"] is True
+        assert entry["reason"] == "plist on disk but not loaded in launchd"
+        assert any(args[1] == "bootstrap" for args in calls)
+
+    def test_ensure_personal_schedules_reports_reload_failure(self, scripts_dir, monkeypatch):
+        import script_registry
+
+        init_db()
+        script = scripts_dir / "email-monitor.py"
+        script.write_text(
+            "# nexo: name=email-monitor\n"
+            "# nexo: runtime=python\n"
+            "# nexo: cron_id=email-monitor\n"
+            "# nexo: interval_seconds=300\n"
+            "# nexo: schedule_required=true\n"
+            "print('ok')\n"
+        )
+
+        plist_path = scripts_dir / "com.nexo.email-monitor.plist"
+        plist_path.write_text("plist")
+
+        monkeypatch.setattr(
+            script_registry,
+            "audit_personal_schedules",
+            lambda: {
+                "schedules": [{
+                    "cron_id": "email-monitor",
+                    "script_path": str(script),
+                    "schedule_type": "interval",
+                    "schedule_value": "300",
+                    "schedule_label": "every 300s",
+                    "launchd_label": "com.nexo.email-monitor",
+                    "plist_path": str(plist_path),
+                    "enabled": True,
+                    "schedule_managed": True,
+                    "run_at_load": False,
+                }],
+                "summary": {},
+            },
+        )
+        monkeypatch.setattr(script_registry.platform, "system", lambda: "Darwin")
+        monkeypatch.setattr(script_registry, "_launchctl_service_state", lambda label: {"loaded": False})
+        monkeypatch.setattr(script_registry.os, "getuid", lambda: 501)
+        monkeypatch.setattr(
+            script_registry.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(returncode=1, stderr=b"bootstrap failed", stdout=b""),
+        )
+
+        result = ensure_personal_schedules(dry_run=False)
+        entry = result["already_present"][0]
+        assert entry["cron_id"] == "email-monitor"
+        assert entry["reload_failed"] is True
+        assert entry["reason"] == "bootstrap failed"
 
     def test_unschedule_personal_script_prunes_schedule(self, scripts_dir, monkeypatch):
         import script_registry

--- a/tests/test_tools_sessions_launchagents.py
+++ b/tests/test_tools_sessions_launchagents.py
@@ -1,0 +1,85 @@
+"""Regression tests for launchagent auto-repair warnings in tools_sessions."""
+
+from __future__ import annotations
+
+import os
+import plistlib
+import sys
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+
+def _write_launchagent_plist(plist_path):
+    with plist_path.open("wb") as fh:
+        plistlib.dump(
+            {"ProgramArguments": ["/Users/tester/.nexo/scripts/watchdog.py"]},
+            fh,
+        )
+
+
+def test_check_launchagents_reports_verified_stale_path_repair(tmp_path, monkeypatch):
+    import glob
+    import platform
+    import subprocess
+    import tools_sessions
+
+    plist_path = tmp_path / "com.nexo.watchdog.plist"
+    _write_launchagent_plist(plist_path)
+
+    calls = []
+
+    def fake_run(args, **kwargs):
+        calls.append(args)
+        if args[1] == "list":
+            return SimpleNamespace(
+                returncode=0,
+                stdout='"ProgramArguments" = (\n"/tmp/stale/watchdog.py"\n);\n',
+                stderr="",
+            )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(glob, "glob", lambda pattern: [str(plist_path)])
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(os, "getuid", lambda: 501)
+
+    warnings = tools_sessions._check_launchagents()
+    assert warnings == [
+        "com.nexo.watchdog: AUTO-REPAIRED (was pointing to stale/tmp path, reloaded from disk)"
+    ]
+    assert [args[1] for args in calls] == ["list", "bootout", "bootstrap"]
+
+
+def test_check_launchagents_refuses_false_auto_repair_on_bootstrap_failure(tmp_path, monkeypatch):
+    import glob
+    import platform
+    import subprocess
+    import tools_sessions
+
+    plist_path = tmp_path / "com.nexo.watchdog.plist"
+    _write_launchagent_plist(plist_path)
+
+    calls = []
+
+    def fake_run(args, **kwargs):
+        calls.append(args)
+        if args[1] == "list":
+            return SimpleNamespace(
+                returncode=0,
+                stdout='"ProgramArguments" = (\n"/tmp/stale/watchdog.py"\n);\n',
+                stderr="",
+            )
+        if args[1] == "bootstrap":
+            return SimpleNamespace(returncode=1, stdout="", stderr="bootstrap failed")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(glob, "glob", lambda pattern: [str(plist_path)])
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(os, "getuid", lambda: 501)
+
+    warnings = tools_sessions._check_launchagents()
+    assert warnings == ["com.nexo.watchdog: REPAIR FAILED — bootstrap failed"]
+    assert not any("AUTO-REPAIRED" in warning for warning in warnings)
+    assert [args[1] for args in calls] == ["list", "bootout", "bootstrap"]


### PR DESCRIPTION
## Summary\n- verify bootout/bootstrap success before reporting stale LaunchAgents as auto-repaired\n- add regression tests for stale LaunchAgent repair and ensure_personal_schedules reload/failure paths\n- publish the missing v5.5.2 release page and align blog/home copy with the combined release notes\n- stack the existing headless model fallback cleanup commit on top of origin/main\n\n## Validation\n- pytest -q tests/test_script_registry.py\n- pytest -q tests/test_tools_sessions_launchagents.py\n- pytest -q tests/test_agent_runner.py\n- python3 scripts/verify_release_readiness.py --ci\n