### PR TITLE
fix: v5.5.4 — Deep Sleep unblocks on unparseable sessions + unified 3h timeout

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.5.3",
+  "version": "5.5.4",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## [5.5.4] - 2026-04-16
+
+### Fix: Deep Sleep no longer blocks on unparseable sessions
+
+- Root cause: Phase 2 (`extract.py`) retried the same session 3 times with
+  identical prompt and context when Claude returned non-JSON output, so a
+  single semantic parse failure could stall the entire night's run behind a
+  6-hour per-attempt safety net. In the worst observed case, one session
+  could block the pipeline for up to ~18h before the skip logic kicked in.
+- Reduced `MAX_RETRIES` in `src/scripts/deep-sleep/extract.py` from 3 to 2:
+  two attempts is enough to cover transient failures; a second failure is
+  almost always deterministic (parse, schema, prompt mismatch) and further
+  retries just burn time. Failed sessions are still checkpointed with
+  `error: "cannot_comply"` and the run continues.
+- Added a JSON escape hatch to the `JSON_SYSTEM_PROMPT`: if the model cannot
+  comply with the extraction schema for any reason, it is now instructed to
+  return a structured `{session_id, findings:[], error:"cannot_comply",
+  reason:"..."}` object instead of plain text. Guarantees parseable output
+  even on degenerate inputs and removes the most common cause of retry
+  loops.
+
+### Fix: Unified automation subprocess timeout to 3h across core
+
+- Discovered historical inconsistency: 10 scripts (`extract.py`,
+  `synthesize.py`, `nexo-evolution-run.py`, `nexo-agent-run.py`,
+  `nexo-synthesis.py`, `nexo-sleep.py`, `nexo-catchup.py`, `nexo-immune.py`,
+  `nexo-daily-self-audit.py`, `nexo-postmortem-consolidator.py`) all carried
+  the comment `# 3h safety net` while the actual value was `21600` seconds
+  (6h). The CHANGELOG entry that introduced the unification claimed 6h,
+  but the per-file comments had drifted toward 3h, leaving the repo in a
+  "comment says 3h, code says 6h" state that masked the real ceiling.
+- Added `src/constants.py` with `AUTOMATION_SUBPROCESS_TIMEOUT = 10800`
+  (3 hours) as single source of truth.
+- Rewired all 10 scripts to import and use the shared constant, so future
+  tuning is one-file-one-edit instead of ten.
+
+### Verification
+
+- Compiles: `py_compile` green across all edited files.
+- Runtime parity: `~/.nexo/scripts/*.py` re-synced from `src/` and validated
+  importing `constants.AUTOMATION_SUBPROCESS_TIMEOUT`.
+
 ## [5.5.3] - 2026-04-16
 
 ### Feat: NEXO Protocol Enforcer section in CLAUDE.md CORE

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
 
 [Watch the overview video](https://nexo-brain.com/watch/) · [Watch on YouTube](https://www.youtube.com/watch?v=i2lkGhKyVqI) · [Open the infographic](https://nexo-brain.com/assets/nexo-brain-infographic-v5.png)
 
-Version `5.5.3` is the current packaged-runtime line: CLAUDE.md CORE now teaches the model to trust the Protocol Enforcer, so aligned backends stop rejecting heartbeat, diary, and checkpoint injections as suspected prompt injection.
+Version `5.5.4` is the current packaged-runtime line: Deep Sleep no longer blocks on unparseable sessions — reduced retries, added a JSON escape hatch, and unified the automation subprocess timeout to 3h across all scripts via a single shared constant.
 
-Previously in `5.4.6`: runtime dependency management in `nexo update` + daily auto-update cron.
+Previously in `5.5.3`: CLAUDE.md CORE teaches the model to trust the Protocol Enforcer, so aligned backends stop rejecting heartbeat, diary, and checkpoint injections as suspected prompt injection.
 
 Start here:
 - [5-minute quickstart](docs/quickstart-5-minutes.md)

--- a/blog/index.html
+++ b/blog/index.html
@@ -174,6 +174,13 @@
 
             <div class="blog-card">
                 <div class="blog-card-date">April 16, 2026</div>
+                <h2><a href="/blog/nexo-5-5-4/">NEXO 5.5.4: Deep Sleep Stops Blocking on Unparseable Sessions</a></h2>
+                <p>Phase 2 extraction was retrying the same session three times with identical prompt and context, hiding a 6h per-attempt safety net that silently drifted out of alignment with its own <code>3h</code> comment. Retries dropped from 3 to 2, the JSON system prompt gained an escape hatch so the model always returns parseable output, and all 10 automation subprocess timeouts now live in a single <code>AUTOMATION_SUBPROCESS_TIMEOUT</code> constant.</p>
+                <a href="/blog/nexo-5-5-4/" class="read-more">Read more &rarr;</a>
+            </div>
+
+            <div class="blog-card">
+                <div class="blog-card-date">April 16, 2026</div>
                 <h2><a href="/blog/nexo-5-5-3/">NEXO 5.5.3: Protocol Enforcer Explained in CLAUDE.md CORE</a></h2>
                 <p>Aligned models were rejecting enforcer injections as suspected prompt injection, breaking heartbeat, diary, and checkpoints. A new CORE section teaches the model that <code>&lt;system-reminder&gt;</code> messages prefixed with <code>[NEXO Protocol Enforcer]</code> are legitimate protocol instructions. Paired with NEXO Desktop v0.9.25 that wraps every injection accordingly.</p>
                 <a href="/blog/nexo-5-5-3/" class="read-more">Read more &rarr;</a>

--- a/blog/nexo-5-5-4/index.html
+++ b/blog/nexo-5-5-4/index.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <title>NEXO 5.5.4: Deep Sleep Stops Blocking on Unparseable Sessions</title>
+    <meta name="description" content="NEXO 5.5.4 reduces Deep Sleep Phase 2 retries from 3 to 2, adds a JSON escape hatch so the model always returns parseable output, and unifies the automation subprocess timeout to 3h across 10 scripts via a single shared constant.">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://nexo-brain.com/blog/nexo-5-5-4/">
+
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://nexo-brain.com/blog/nexo-5-5-4/">
+    <meta property="og:title" content="NEXO 5.5.4: Deep Sleep Stops Blocking on Unparseable Sessions">
+    <meta property="og:description" content="Phase 2 extraction was retrying the same unparseable session three times behind a 6h per-attempt safety net. 5.5.4 caps retries, adds a JSON escape hatch, and unifies the timeout to 3h everywhere.">
+    <meta property="og:image" content="https://nexo-brain.com/assets/og/og-blog.png">
+    <meta property="article:published_time" content="2026-04-16">
+    <meta property="article:author" content="Francisco Cerda Puigserver">
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="NEXO 5.5.4: Deep Sleep Stops Blocking on Unparseable Sessions">
+    <meta name="twitter:description" content="Retries reduced from 3 to 2, JSON escape hatch in the system prompt, and a single AUTOMATION_SUBPROCESS_TIMEOUT constant across 10 scripts.">
+    <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-blog.png">
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-1LNEMCJMS7"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-1LNEMCJMS7');
+    </script>
+
+    <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicon-32.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
+    <link rel="stylesheet" href="/assets/style.css">
+
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "NEXO 5.5.4: Deep Sleep Stops Blocking on Unparseable Sessions",
+        "description": "NEXO 5.5.4 reduces Deep Sleep Phase 2 retries from 3 to 2, adds a JSON escape hatch so the model always returns parseable output, and unifies the automation subprocess timeout to 3h across 10 scripts via a single shared constant.",
+        "datePublished": "2026-04-16",
+        "dateModified": "2026-04-16",
+        "author": {
+            "@type": "Person",
+            "name": "Francisco Cerda Puigserver"
+        },
+        "publisher": {
+            "@type": "Organization",
+            "name": "WAzion",
+            "url": "https://www.wazion.com"
+        },
+        "mainEntityOfPage": {
+            "@type": "WebPage",
+            "@id": "https://nexo-brain.com/blog/nexo-5-5-4/"
+        },
+        "url": "https://nexo-brain.com/blog/nexo-5-5-4/",
+        "image": "https://nexo-brain.com/assets/og/og-blog.png",
+        "keywords": ["NEXO 5.5.4", "Deep Sleep", "retry logic", "JSON schema", "subprocess timeout"]
+    }
+    </script>
+
+    <style>
+        .article-header { padding-top: 128px; padding-bottom: 40px; text-align: center; }
+        .article-meta { font-size: 14px; color: var(--text-muted); margin-bottom: 16px; }
+        .article-body {
+            max-width: 720px; margin: 0 auto; padding: 0 24px 80px;
+            font-size: 17px; line-height: 1.8; color: var(--text);
+        }
+        .article-body h2 { font-size: 28px; font-weight: 700; margin: 48px 0 16px; letter-spacing: -0.01em; }
+        .article-body p { margin-bottom: 20px; color: var(--text-muted); }
+        .article-body strong { color: var(--text); }
+        .article-body a { color: var(--purple-light); }
+        .article-body a:hover { color: var(--pink); }
+        .article-body code {
+            font-family: 'SF Mono', 'Fira Code', monospace;
+            font-size: 14px; color: var(--pink);
+            background: rgba(236, 72, 153, 0.1);
+            padding: 2px 8px; border-radius: 4px;
+        }
+        .article-back {
+            display: inline-flex; align-items: center; gap: 6px;
+            font-size: 14px; font-weight: 600; color: var(--text-muted);
+            margin-bottom: 24px;
+        }
+        .article-back:hover { color: var(--purple-light); }
+    </style>
+</head>
+<body>
+
+<nav>
+    <div class="container">
+        <a href="/" class="nav-logo">
+            <img src="/assets/logo-64.png" alt="NEXO Brain" class="logo-image">
+            <span class="logo-text">NEXO Brain</span>
+        </a>
+        <button class="mobile-menu-toggle" aria-label="Toggle navigation" onclick="toggleMobileMenu()">
+            <span></span><span></span><span></span>
+        </button>
+        <div class="nav-links">
+            <a href="/">Home</a>
+            <a href="/features/">Features</a>
+            <a href="/evolution/">Evolution</a>
+            <a href="/compare/">Compare</a>
+            <a href="/blog/">Blog</a>
+            <a href="/changelog/">Changelog</a>
+            <a href="/docs/">Docs</a>
+            <a href="https://github.com/wazionapps/nexo" class="nav-cta">GitHub</a>
+        </div>
+    </div>
+</nav>
+
+<section class="article-header">
+    <div class="container">
+        <a href="/blog/" class="article-back">&larr; Back to blog</a>
+        <div class="article-meta">April 16, 2026 &middot; Fix &middot; Runtime</div>
+        <h1 class="section-title" style="font-size:clamp(28px,4.5vw,48px);max-width:920px;margin:0 auto 16px;">NEXO 5.5.4: Deep Sleep Stops Blocking on Unparseable Sessions</h1>
+        <p class="section-subtitle" style="max-width:760px;margin:0 auto;">Phase 2 extraction was retrying the same session three times with identical prompt and context, hiding a 6h per-attempt safety net that silently drifted out of alignment with its own &quot;3h&quot; comment. 5.5.4 caps retries, adds a JSON escape hatch, and unifies the timeout to 3h everywhere via a single shared constant.</p>
+    </div>
+</section>
+
+<section>
+    <div class="article-body">
+
+        <h2>The failure mode</h2>
+        <p>Deep Sleep Phase 2 (<code>extract.py</code>) walks every session from the last 48 hours and asks the configured automation backend to return a JSON summary for each one. When the backend returned non-JSON output &mdash; a common semantic failure for large or ambiguous transcripts &mdash; the script retried the same session three times with identical prompt and context. The retries almost never succeeded, because the cause was deterministic, not transient.</p>
+        <p>Worse, the per-attempt safety net was <code>21600</code> seconds (6 hours). The comment next to that value read &quot;3h safety net&quot;, but the value had drifted out of alignment with the comment across 10 scripts. In the worst observed case, a single unparseable session could stall the entire night's run for up to ~18h before the skip logic finally kicked in.</p>
+
+        <h2>What 5.5.4 changes</h2>
+        <p><strong>Retries reduced from 3 to 2.</strong> Two attempts is enough to cover transient backend hiccups. A second failure is almost always deterministic, so further retries just burn time. Failed sessions are still checkpointed with <code>error: &quot;cannot_comply&quot;</code> and the run continues normally.</p>
+        <p><strong>JSON escape hatch in the system prompt.</strong> The <code>JSON_SYSTEM_PROMPT</code> now instructs the model to return a structured <code>{session_id, findings:[], error:&quot;cannot_comply&quot;, reason:&quot;&hellip;&quot;}</code> object whenever it cannot comply with the extraction schema for any reason. This guarantees parseable output even on degenerate inputs and removes the most common cause of retry loops.</p>
+        <p><strong>Unified automation subprocess timeout.</strong> A new <code>src/constants.py</code> defines <code>AUTOMATION_SUBPROCESS_TIMEOUT = 10800</code> (3 hours). All 10 scripts that previously hard-coded <code>21600</code> &mdash; <code>extract.py</code>, <code>synthesize.py</code>, <code>nexo-evolution-run.py</code>, <code>nexo-agent-run.py</code>, <code>nexo-synthesis.py</code>, <code>nexo-sleep.py</code>, <code>nexo-catchup.py</code>, <code>nexo-immune.py</code>, <code>nexo-daily-self-audit.py</code>, <code>nexo-postmortem-consolidator.py</code> &mdash; now import the shared constant. Future tuning is one edit, not ten.</p>
+
+        <h2>Why this matters</h2>
+        <p>Deep Sleep is the cron that carries every learning, pattern, and context packet from one working day to the next. When Phase 2 blocks, the morning briefing, the applied-findings pipeline, and the weekly summaries all run late or not at all. 5.5.4 turns a 10-script coordination footgun into a single-source-of-truth constant and gives the model an honest way to report &quot;I cannot summarise this&quot; without stalling the whole night.</p>
+
+    </div>
+</section>
+
+<footer>
+    <div class="container" style="text-align:center; padding: 48px 24px 32px; color: var(--text-muted); font-size: 14px;">
+        <p>&copy; 2024&ndash;2026 WAzion &middot; <a href="https://github.com/wazionapps/nexo" style="color:var(--purple-light);">GitHub</a> &middot; AGPL-3.0</p>
+    </div>
+</footer>
+
+<script>
+function toggleMobileMenu() {
+    document.querySelector('.nav-links').classList.toggle('active');
+    document.querySelector('.mobile-menu-toggle').classList.toggle('active');
+}
+</script>
+
+</body>
+</html>

--- a/changelog/index.html
+++ b/changelog/index.html
@@ -181,6 +181,17 @@
     </div>
 </section>
 
+<!-- v5.5.4 Deep Sleep no longer blocks on unparseable sessions -->
+<section id="v554" class="section-compact" style="background:linear-gradient(135deg,#0a120f 0%,#152a1f 50%,#1e3f2f 100%);">
+    <div class="container">
+        <div class="section-label">New in v5.5.4 <span style="opacity:.5;font-weight:400;">&mdash; April 16, 2026</span></div>
+        <h2 class="section-title">Deep Sleep Stops Blocking on Unparseable Sessions</h2>
+        <p class="section-subtitle">
+            Phase 2 extraction was retrying the same session three times with identical prompt and context, hiding a 6h per-attempt safety net that had silently drifted out of alignment with its own &quot;3h&quot; comment. Retries dropped from 3 to 2, the JSON system prompt gained an escape hatch so the model always returns parseable output, and all 10 automation subprocess timeouts now live in a single <code>AUTOMATION_SUBPROCESS_TIMEOUT</code> constant in <code>src/constants.py</code>.
+        </p>
+    </div>
+</section>
+
 <!-- v5.5.3 Protocol Enforcer explained in CLAUDE.md CORE -->
 <section id="v553" class="section-compact" style="background:linear-gradient(135deg,#0a120f 0%,#152a1f 50%,#1e3f2f 100%);">
     <div class="container">

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 5.5.3
+version: 5.5.4
 metadata:
   openclaw:
     requires:

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
         "operatingSystem": "macOS, Linux, Windows",
         "url": "https://nexo-brain.com",
         "downloadUrl": "https://www.npmjs.com/package/nexo-brain",
-        "softwareVersion": "5.5.3",
+        "softwareVersion": "5.5.4",
         "license": "https://www.gnu.org/licenses/agpl-3.0",
         "author": {
             "@type": "Organization",
@@ -697,7 +697,7 @@
     <div class="container">
         <div class="hero-badge fade-up">
             <span class="dot"></span>
-            <span id="version-badge">v5.5.3</span> &mdash; Protocol Enforcer explained in CLAUDE.md CORE
+            <span id="version-badge">v5.5.4</span> &mdash; Deep Sleep no longer blocks on unparseable sessions
         </div>
         <div class="fade-up" style="display:flex;gap:8px;justify-content:center;margin-bottom:12px;">
             <img src="https://img.shields.io/npm/v/nexo-brain?color=7C3AED&label=npm" alt="npm version">

--- a/llms.txt
+++ b/llms.txt
@@ -1,9 +1,10 @@
 # NEXO Brain
 
-> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.5.3).
+> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.5.4).
 
 NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. It adds a local shared brain across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, smarter retrieval defaults, long-horizon overnight analysis, and 150+ MCP tools.
 
+v5.5.4: Deep Sleep no longer blocks on unparseable sessions — retries reduced from 3 to 2, added a JSON escape hatch so the model always returns parseable output, and unified the automation subprocess timeout to 3h (10800s) across 10 scripts via a new shared constant AUTOMATION_SUBPROCESS_TIMEOUT in src/constants.py.
 v5.5.3: CLAUDE.md CORE now explains the Protocol Enforcer — aligned models (Opus 4.6, safety-tuned variants) stop rejecting heartbeat, diary, and checkpoint injections as suspected prompt injection. Paired with NEXO Desktop v0.9.25 which wraps enforcer prompts in <system-reminder> tags.
 v5.5.2: auto-repair unloaded LaunchAgents + headless model fallback cleanup — verifies launchctl loaded state, migrated to modern bootstrap/bootout API, and removes legacy opus/sonnet fallbacks from core automation scripts
 v5.5.1: real-time headless Protocol Enforcer — enforcement_engine.py monitors tool calls and injects prompts in all headless sessions via stream-json Popen

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "5.5.3",
+  "version": "5.5.4",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.5.3" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.5.4" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.5.3",
+  "version": "5.5.4",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain \u2014 Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -145,6 +145,12 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://nexo-brain.com/blog/nexo-5-5-4/</loc>
+    <lastmod>2026-04-16</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.75</priority>
+  </url>
+  <url>
     <loc>https://nexo-brain.com/blog/nexo-5-5-3/</loc>
     <lastmod>2026-04-16</lastmod>
     <changefreq>monthly</changefreq>

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,0 +1,9 @@
+"""Shared constants for NEXO scripts and runtime."""
+from __future__ import annotations
+
+# Safety-net timeout (seconds) for Claude CLI / automation subprocess calls.
+# Applied across deep-sleep, synthesis, immune, evolution, catchup, and other
+# headless scripts that invoke the configured automation backend. Three hours
+# is long enough for legitimate long runs but short enough to prevent zombie
+# subprocesses from blocking the pipeline indefinitely.
+AUTOMATION_SUBPROCESS_TIMEOUT = 10800

--- a/src/scripts/deep-sleep/extract.py
+++ b/src/scripts/deep-sleep/extract.py
@@ -26,6 +26,7 @@ if str(NEXO_CODE) not in sys.path:
     sys.path.insert(0, str(NEXO_CODE))
 
 from agent_runner import AutomationBackendUnavailableError, run_automation_prompt
+from constants import AUTOMATION_SUBPROCESS_TIMEOUT
 try:
     from client_preferences import resolve_user_model as _resolve_user_model
     _USER_MODEL = _resolve_user_model()
@@ -33,8 +34,9 @@ except Exception:
     _USER_MODEL = ""
 
 
-# No timeout -- headless automation can take as long as needed
-CLAUDE_TIMEOUT = 21600  # 3h safety net (prevents zombie processes)
+# 3h safety net for the Claude CLI subprocess. Prevents zombie processes while
+# still leaving enough headroom for legitimate long per-session extractions.
+CLAUDE_TIMEOUT = AUTOMATION_SUBPROCESS_TIMEOUT
 
 
 def extract_json_from_response(text: str) -> dict | None:
@@ -129,7 +131,11 @@ def analyze_session(
         JSON_SYSTEM_PROMPT = (
             "You are a JSON-only analyst. Your ENTIRE response must be a single valid JSON object. "
             "No text before it. No text after it. No markdown fences. No explanations. "
-            "If you want to summarize, put it inside the JSON fields. Start with { and end with }."
+            "If you want to summarize, put it inside the JSON fields. Start with { and end with }. "
+            "If for ANY reason you cannot comply with the requested schema (context too large, "
+            "file unreadable, ambiguous, uncertain), you MUST still return a JSON object shaped as "
+            '{"session_id":"<the id>","findings":[],"error":"cannot_comply","reason":"<short reason>"}. '
+            "NEVER return plain text, apology, markdown, or empty output."
         )
 
         result = run_automation_prompt(
@@ -249,7 +255,10 @@ def main():
     all_extractions = []
     total_findings = 0
     skipped = 0
-    MAX_RETRIES = 3
+    # Two attempts is enough: if a session's extraction fails twice, the cause is
+    # almost always deterministic (JSON parse, schema violation) rather than transient,
+    # so further retries just burn time. Skip and continue instead.
+    MAX_RETRIES = 2
 
     for i, session_id in enumerate(session_files):
         sid_safe = _safe_session_slug(session_id)[:40]

--- a/src/scripts/deep-sleep/synthesize.py
+++ b/src/scripts/deep-sleep/synthesize.py
@@ -34,8 +34,9 @@ if str(NEXO_CODE) not in sys.path:
     sys.path.insert(0, str(NEXO_CODE))
 
 from agent_runner import AutomationBackendUnavailableError, run_automation_prompt
+from constants import AUTOMATION_SUBPROCESS_TIMEOUT
 
-CLAUDE_TIMEOUT = 21600  # 3h safety net (prevents zombie processes)
+CLAUDE_TIMEOUT = AUTOMATION_SUBPROCESS_TIMEOUT
 ACTION_VERBS = {"add", "implement", "create", "write", "build", "enforce", "automate", "validate", "guard", "fix", "review"}
 
 

--- a/src/scripts/nexo-agent-run.py
+++ b/src/scripts/nexo-agent-run.py
@@ -16,6 +16,7 @@ if str(NEXO_CODE) not in sys.path:
     sys.path.insert(0, str(NEXO_CODE))
 
 from agent_runner import AutomationBackendUnavailableError, run_automation_prompt
+from constants import AUTOMATION_SUBPROCESS_TIMEOUT
 
 
 def _read_text(path: str | None) -> str:
@@ -32,7 +33,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--task-profile", default="", help="Automation task profile: default|fast|balanced|deep")
     parser.add_argument("--model", default="", help="Backend model hint")
     parser.add_argument("--reasoning-effort", default="", help="Backend reasoning effort/profile")
-    parser.add_argument("--timeout", type=int, default=21600, help="Timeout in seconds")
+    parser.add_argument("--timeout", type=int, default=AUTOMATION_SUBPROCESS_TIMEOUT, help="Timeout in seconds")
     parser.add_argument("--output-format", default="text", help="Requested output format")
     parser.add_argument("--allowed-tools", default="", help="Claude-style allowed tools contract")
     parser.add_argument("--append-system-prompt", default="", help="Extra system prompt text")

--- a/src/scripts/nexo-catchup.py
+++ b/src/scripts/nexo-catchup.py
@@ -27,6 +27,7 @@ if str(_runtime_root) not in sys.path:
     sys.path.insert(0, str(_runtime_root))
 
 from agent_runner import AutomationBackendUnavailableError, probe_automation_backend, run_automation_prompt
+from constants import AUTOMATION_SUBPROCESS_TIMEOUT
 from cron_recovery import catchup_candidates
 
 HOME = Path.home()
@@ -175,7 +176,7 @@ def run_task(candidate: dict, state: dict) -> bool:
     try:
         result = subprocess.run(
             command,
-            capture_output=True, text=True, timeout=21600,
+            capture_output=True, text=True, timeout=AUTOMATION_SUBPROCESS_TIMEOUT,
             env={**os.environ, "HOME": str(HOME), "NEXO_CATCHUP": "1"}
         )
         if result.returncode == 0:
@@ -189,7 +190,7 @@ def run_task(candidate: dict, state: dict) -> bool:
                 log(f"    stderr: {result.stderr[:300]}")
             return False
     except subprocess.TimeoutExpired:
-        log(f"  TIMEOUT {name} (21600s)")
+        log(f"  TIMEOUT {name} ({AUTOMATION_SUBPROCESS_TIMEOUT}s)")
         return False
     except Exception as e:
         log(f"  ERROR {name}: {e}")
@@ -280,7 +281,7 @@ Format:
         result = run_automation_prompt(
             prompt,
             model=_USER_MODEL,
-            timeout=21600,
+            timeout=AUTOMATION_SUBPROCESS_TIMEOUT,
             output_format="text",
             allowed_tools="Read,Write,Edit,Glob,Grep,Bash,mcp__nexo__*",
         )

--- a/src/scripts/nexo-daily-self-audit.py
+++ b/src/scripts/nexo-daily-self-audit.py
@@ -37,6 +37,7 @@ if str(NEXO_CODE) not in sys.path:
     sys.path.insert(0, str(NEXO_CODE))
 
 from agent_runner import AutomationBackendUnavailableError, run_automation_prompt
+from constants import AUTOMATION_SUBPROCESS_TIMEOUT
 import db as nexo_db
 from public_evolution_queue import queue_public_port_candidate
 
@@ -2050,7 +2051,7 @@ Also write the machine-readable summary to {LOG_DIR}/self-audit-summary.json.
         result = run_automation_prompt(
             prompt,
             model=_USER_MODEL,
-            timeout=21600,
+            timeout=AUTOMATION_SUBPROCESS_TIMEOUT,
             output_format="text",
             allowed_tools="Read,Write,Edit,Glob,Grep,Bash,mcp__nexo__*",
         )

--- a/src/scripts/nexo-evolution-run.py
+++ b/src/scripts/nexo-evolution-run.py
@@ -179,6 +179,7 @@ def log(msg: str):
 # ── Import from evolution_cycle.py (lives in NEXO_CODE, i.e. src/) ──────
 sys.path.insert(0, str(NEXO_CODE))
 from agent_runner import probe_automation_backend, run_automation_prompt
+from constants import AUTOMATION_SUBPROCESS_TIMEOUT
 from evolution_cycle import (
     load_objective, save_objective, get_week_data, build_evolution_prompt,
     dry_run_restore_test, max_auto_changes, create_snapshot,
@@ -214,7 +215,7 @@ def set_consecutive_failures(count: int):
 
 
 # ── Automation backend call ──────────────────────────────────────────────
-CLI_TIMEOUT = 21600  # 3h safety net (prevents zombie processes)
+CLI_TIMEOUT = AUTOMATION_SUBPROCESS_TIMEOUT
 
 
 def verify_claude_cli() -> bool:

--- a/src/scripts/nexo-immune.py
+++ b/src/scripts/nexo-immune.py
@@ -38,6 +38,7 @@ if str(NEXO_CODE) not in sys.path:
     sys.path.insert(0, str(NEXO_CODE))
 
 from agent_runner import AutomationBackendUnavailableError, run_automation_prompt
+from constants import AUTOMATION_SUBPROCESS_TIMEOUT
 
 from urllib.request import Request, urlopen
 from urllib.error import URLError, HTTPError
@@ -916,7 +917,7 @@ Write the report. Be concise — max 40 lines."""
         result = run_automation_prompt(
             prompt,
             model=_USER_MODEL,
-            timeout=21600,
+            timeout=AUTOMATION_SUBPROCESS_TIMEOUT,
             output_format="text",
             allowed_tools="Read,Write,Edit,Glob,Grep,Bash,mcp__nexo__*",
         )

--- a/src/scripts/nexo-postmortem-consolidator.py
+++ b/src/scripts/nexo-postmortem-consolidator.py
@@ -37,6 +37,7 @@ NEXO_CODE = Path(os.environ.get("NEXO_CODE", str(_repo_src) if (_repo_src / "ser
 sys.path.insert(0, str(NEXO_CODE))
 
 from agent_runner import AutomationBackendUnavailableError, run_automation_prompt
+from constants import AUTOMATION_SUBPROCESS_TIMEOUT
 
 try:
     from client_preferences import resolve_user_model as _resolve_user_model
@@ -255,7 +256,7 @@ Execute without asking."""
         result = run_automation_prompt(
             prompt,
             model=_USER_MODEL,
-            timeout=21600,
+            timeout=AUTOMATION_SUBPROCESS_TIMEOUT,
             output_format="text",
             allowed_tools="Read,Write,Edit,Glob,Grep,Bash,mcp__nexo__*",
         )

--- a/src/scripts/nexo-sleep.py
+++ b/src/scripts/nexo-sleep.py
@@ -37,6 +37,7 @@ if str(NEXO_CODE) not in sys.path:
     sys.path.insert(0, str(NEXO_CODE))
 
 from agent_runner import AutomationBackendUnavailableError, run_automation_prompt
+from constants import AUTOMATION_SUBPROCESS_TIMEOUT
 try:
     from client_preferences import resolve_user_model as _resolve_user_model
     _USER_MODEL = _resolve_user_model()
@@ -446,7 +447,7 @@ Execute without asking."""
         result = run_automation_prompt(
             prompt,
             model=_USER_MODEL,
-            timeout=21600,
+            timeout=AUTOMATION_SUBPROCESS_TIMEOUT,
             output_format="text",
             allowed_tools="Read,Write,Edit,Glob,Grep,Bash,mcp__nexo__*",
         )

--- a/src/scripts/nexo-synthesis.py
+++ b/src/scripts/nexo-synthesis.py
@@ -34,6 +34,7 @@ if str(NEXO_CODE) not in sys.path:
     sys.path.insert(0, str(NEXO_CODE))
 
 from agent_runner import AutomationBackendUnavailableError, run_automation_prompt
+from constants import AUTOMATION_SUBPROCESS_TIMEOUT
 
 CLAUDE_DIR = NEXO_HOME
 COORD_DIR = CLAUDE_DIR / "coordination"
@@ -348,7 +349,7 @@ Execute without asking."""
         result = run_automation_prompt(
             prompt,
             model=_USER_MODEL,
-            timeout=21600,
+            timeout=AUTOMATION_SUBPROCESS_TIMEOUT,
             output_format="text",
             allowed_tools="Read,Write,Edit,Glob,Grep,Bash,mcp__nexo__*",
         )


### PR DESCRIPTION
## Summary

- Deep Sleep Phase 2 no longer blocks on unparseable sessions: `MAX_RETRIES` drops from 3 to 2, and the `JSON_SYSTEM_PROMPT` gains an escape hatch so the model always returns `{session_id, findings:[], error:"cannot_comply", reason:"..."}` instead of plain text.
- Unified the automation subprocess timeout to 3h (`AUTOMATION_SUBPROCESS_TIMEOUT = 10800`) in a new `src/constants.py`. Rewired 10 scripts (`extract.py`, `synthesize.py`, `nexo-evolution-run.py`, `nexo-agent-run.py`, `nexo-synthesis.py`, `nexo-sleep.py`, `nexo-catchup.py`, `nexo-immune.py`, `nexo-daily-self-audit.py`, `nexo-postmortem-consolidator.py`) to import the shared constant. The prior 10-file hard-coded `21600` with `# 3h safety net` comments was a drift landed by an earlier unification pass.
- Release artifacts updated: `package.json`, `.claude-plugin/plugin.json`, `clawhub-skill/SKILL.md`, `openclaw-plugin/package.json`, `openclaw-plugin/src/mcp-bridge.ts` (via `sync_release_artifacts.py`), plus `CHANGELOG.md`, `README.md`, `llms.txt`, `index.html`, `blog/index.html`, `blog/nexo-5-5-4/`, `changelog/index.html`, `sitemap.xml`.

## Why

In the worst observed case, a single session that returned non-JSON output stalled the whole night's Deep Sleep run for up to ~18h before the skip logic kicked in (3 retries × 6h safety net). Retries were also blind — same prompt, same context, same result. A deterministic parse failure doesn't benefit from being repeated; it benefits from a shorter-circuit cap and a structured escape hatch so the run continues cleanly.

## Test plan

- [x] `py_compile` green across all edited files
- [x] `PYTHONPATH=src pytest -q tests/` — 168 passed
- [x] `python3 scripts/verify_client_parity.py` — OK
- [x] `python3 scripts/verify_release_readiness.py` — OK (source + gh-pages)
- [x] Runtime parity re-synced at `~/.nexo/scripts/` and imports the shared constant
- [x] Manual relaunch of `nexo-deep-sleep.sh` after sync to confirm the new code path runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
