### PR TITLE
hotfix: v5.5.6 — rate-limit backup/restore/export tools

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.5.5",
+  "version": "5.5.6",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## [5.5.6] - 2026-04-16
+
+### Hotfix: rate-limit the backup/restore/export tools
+
+Same-day follow-up to v5.5.5. The v5.5.5 release neutralised the *consequences*
+of the 2026-04-16 incident (validated backups, pre-flight guard, post-migration
+gate, startup self-heal, `nexo recover`). v5.5.6 closes the *cause*: a runaway
+MCP client (Claude Code tool-use loop, a buggy Desktop handler, etc.) can no
+longer hammer `sqlite3.Connection.backup()` from the tool boundary.
+
+- **`plugins/backup.py`**: `handle_backup_now` rate-limited to one call every
+  `NEXO_BACKUP_MIN_INTERVAL_SECS` (default 30 s). `handle_backup_restore`
+  rate-limited to one call every `NEXO_BACKUP_RESTORE_MIN_INTERVAL_SECS`
+  (default 60 s). `handle_backup_list` is read-only and never rate-limited.
+- **`user_data_portability.export_user_bundle`**: rate-limited to one call
+  every `NEXO_EXPORT_MIN_INTERVAL_SECS` (default 120 s). Returns
+  `{"ok": False, "rate_limited": True, "error": "..."}` so callers can react.
+- Each rate-limit message is explicit about loop detection ("If you see this
+  repeatedly, a client may be stuck in a tool-use loop…") so transcript
+  evidence surfaces the next time a client misbehaves.
+- **Test coverage**: 10 new tests in `tests/test_backup_rate_limit.py`. Full
+  suite remains 880/880 green.
+
+### Why not in v5.5.5
+
+v5.5.5 was the minimal-surface data-loss hotfix. Rate-limits at the tool
+boundary change tool semantics (well-behaved callers occasionally hit the
+"try again in N s" response) and deserved a dedicated release so operators
+read the limit numbers, not just the recovery flow.
+
 ## [5.5.5] - 2026-04-16
 
 ### Hotfix: Data-loss guardrails and automatic self-heal

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@
 
 [Watch the overview video](https://nexo-brain.com/watch/) · [Watch on YouTube](https://www.youtube.com/watch?v=i2lkGhKyVqI) · [Open the infographic](https://nexo-brain.com/assets/nexo-brain-infographic-v5.png)
 
-Version `5.5.5` is the current packaged-runtime line: data-loss guardrails + automatic self-heal. The updater now refuses to capture an already-wiped `nexo.db` into a `pre-update-*` snapshot (validated `sqlite3.backup` + pre-flight wipe guard + post-migration row-count gate), and an auto-heal restores `data/nexo.db` from the newest hourly backup on the next server boot when a wipe is detected. New `nexo recover` CLI + `nexo_recover` MCP tool.
+Version `5.5.6` is the current packaged-runtime line: same-day follow-up to v5.5.5 that adds in-process rate-limits to `nexo_backup_now` (30 s), `nexo_backup_restore` (60 s), and `export_user_bundle` (120 s) so a runaway MCP client can no longer hammer `sqlite3.Connection.backup()` from a tool-use loop — closing the cause of the 2026-04-16 incident the same day v5.5.5 closed its consequences.
+
+Previously in `5.5.5`: data-loss guardrails + automatic self-heal. The updater now refuses to capture an already-wiped `nexo.db` into a `pre-update-*` snapshot (validated `sqlite3.backup` + pre-flight wipe guard + post-migration row-count gate), and an auto-heal restores `data/nexo.db` from the newest hourly backup on the next server boot when a wipe is detected. New `nexo recover` CLI + `nexo_recover` MCP tool.
 
 Previously in `5.5.4`: Deep Sleep no longer blocks on unparseable sessions — reduced retries, added a JSON escape hatch, and unified the automation subprocess timeout to 3h across all scripts via a single shared constant.
 

--- a/blog/index.html
+++ b/blog/index.html
@@ -174,6 +174,13 @@
 
             <div class="blog-card">
                 <div class="blog-card-date">April 16, 2026</div>
+                <h2><a href="/blog/nexo-5-5-6/">NEXO 5.5.6: Rate-Limiting the Backup/Restore/Export Tools</a></h2>
+                <p>Same-day follow-up to v5.5.5. The data-loss guardrails in v5.5.5 neutralised the <em>consequences</em> of the 2026-04-16 incident; v5.5.6 closes the <em>cause</em>. <code>nexo_backup_now</code>, <code>nexo_backup_restore</code>, and <code>export_user_bundle</code> now refuse reentrant calls inside 30 s / 60 s / 120 s windows, so a runaway MCP client stuck in a tool-use loop can no longer hammer <code>sqlite3.Connection.backup()</code> the way it did when this incident first struck.</p>
+                <a href="/blog/nexo-5-5-6/" class="read-more">Read more &rarr;</a>
+            </div>
+
+            <div class="blog-card">
+                <div class="blog-card-date">April 16, 2026</div>
                 <h2><a href="/blog/nexo-5-5-5/">NEXO 5.5.5: Data-Loss Guardrails and Automatic Self-Heal</a></h2>
                 <p>A hotfix for the 2026-04-16 incident where one user's <code>~/.nexo/data/nexo.db</code> was reset to a 4 KB empty-schema file while three consecutive <code>nexo update</code> attempts each captured the already-empty DB into a new <code>pre-update-*</code> snapshot, masking the wipe. v5.5.5 adds a pre-flight wipe guard, validated <code>sqlite3.backup</code> copies, a post-migration row-count gate, a startup self-heal that auto-restores from the newest hourly backup, and a new <code>nexo recover</code> CLI + <code>nexo_recover</code> MCP tool.</p>
                 <a href="/blog/nexo-5-5-5/" class="read-more">Read more &rarr;</a>

--- a/changelog/index.html
+++ b/changelog/index.html
@@ -181,6 +181,17 @@
     </div>
 </section>
 
+<!-- v5.5.6 Rate-limit backup/restore/export -->
+<section id="v556" class="section-compact" style="background:linear-gradient(135deg,#0a120f 0%,#152a1f 50%,#1e3f2f 100%);">
+    <div class="container">
+        <div class="section-label">New in v5.5.6 <span style="opacity:.5;font-weight:400;">&mdash; April 16, 2026</span></div>
+        <h2 class="section-title">Rate-Limiting the Backup/Restore/Export Tools</h2>
+        <p class="section-subtitle">
+            Same-day follow-up to v5.5.5. <code>nexo_backup_now</code>, <code>nexo_backup_restore</code>, and <code>export_user_bundle</code> now refuse reentrant calls inside 30 s / 60 s / 120 s windows. A runaway MCP client stuck in a tool-use loop can no longer hammer <code>sqlite3.Connection.backup()</code>. v5.5.5 neutralised the consequences of the 2026-04-16 incident; v5.5.6 closes the cause.
+        </p>
+    </div>
+</section>
+
 <!-- v5.5.5 Data-loss guardrails + self-heal -->
 <section id="v555" class="section-compact" style="background:linear-gradient(135deg,#0a120f 0%,#152a1f 50%,#1e3f2f 100%);">
     <div class="container">

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 5.5.5
+version: 5.5.6
 metadata:
   openclaw:
     requires:

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
         "operatingSystem": "macOS, Linux, Windows",
         "url": "https://nexo-brain.com",
         "downloadUrl": "https://www.npmjs.com/package/nexo-brain",
-        "softwareVersion": "5.5.5",
+        "softwareVersion": "5.5.6",
         "license": "https://www.gnu.org/licenses/agpl-3.0",
         "author": {
             "@type": "Organization",
@@ -697,7 +697,7 @@
     <div class="container">
         <div class="hero-badge fade-up">
             <span class="dot"></span>
-            <span id="version-badge">v5.5.5</span> &mdash; Data-loss guardrails + automatic self-heal
+            <span id="version-badge">v5.5.6</span> &mdash; Backup/restore/export tools rate-limited at the MCP boundary
         </div>
         <div class="fade-up" style="display:flex;gap:8px;justify-content:center;margin-bottom:12px;">
             <img src="https://img.shields.io/npm/v/nexo-brain?color=7C3AED&label=npm" alt="npm version">

--- a/llms.txt
+++ b/llms.txt
@@ -1,9 +1,10 @@
 # NEXO Brain
 
-> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.5.5).
+> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.5.6).
 
 NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. It adds a local shared brain across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, smarter retrieval defaults, long-horizon overnight analysis, and 150+ MCP tools.
 
+v5.5.6: rate-limit the backup/restore/export tools in the MCP boundary. `nexo_backup_now` capped at 1/30s, `nexo_backup_restore` at 1/60s, `export_user_bundle` at 1/120s. A runaway MCP client (tool-use loop) can no longer hammer sqlite3.Connection.backup() the way the 2026-04-16 incident did. Same-day follow-up to v5.5.5.
 v5.5.5: data-loss guardrails + automatic self-heal. The updater now refuses to capture an already-wiped nexo.db into a pre-update snapshot (validated sqlite3.backup + pre-flight wipe guard + post-migration row-count gate), and an auto-heal restores ~/.nexo/data/nexo.db from the newest hourly backup on the next server boot when a wipe is detected. New `nexo recover` CLI + `nexo_recover` MCP tool with mandatory kill-MCP, pre-recover snapshot, and post-restore row-count validation.
 v5.5.4: Deep Sleep no longer blocks on unparseable sessions — retries reduced from 3 to 2, added a JSON escape hatch so the model always returns parseable output, and unified the automation subprocess timeout to 3h (10800s) across 10 scripts via a new shared constant AUTOMATION_SUBPROCESS_TIMEOUT in src/constants.py.
 v5.5.3: CLAUDE.md CORE now explains the Protocol Enforcer — aligned models (Opus 4.6, safety-tuned variants) stop rejecting heartbeat, diary, and checkpoint injections as suspected prompt injection. Paired with NEXO Desktop v0.9.25 which wraps enforcer prompts in <system-reminder> tags.

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "5.5.5",
+  "version": "5.5.6",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.5.5" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.5.6" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.5.5",
+  "version": "5.5.6",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain \u2014 Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -145,6 +145,12 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://nexo-brain.com/blog/nexo-5-5-6/</loc>
+    <lastmod>2026-04-16</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.75</priority>
+  </url>
+  <url>
     <loc>https://nexo-brain.com/blog/nexo-5-5-5/</loc>
     <lastmod>2026-04-16</lastmod>
     <changefreq>monthly</changefreq>

--- a/src/plugins/backup.py
+++ b/src/plugins/backup.py
@@ -1,8 +1,20 @@
-"""Backup plugin — hourly SQLite backups with 7-day retention."""
+"""Backup plugin — hourly SQLite backups with 7-day retention.
+
+v5.5.6: all three tools are rate-limited in-process so that a runaway MCP
+client (tool-use loop in Claude Code, buggy Desktop handler, etc.) cannot
+hammer ``sqlite3.Connection.backup()`` hundreds of times in minutes. The
+v5.5.4 incident where an external loop caused ~8.5 GB of file-backed writes
+in 37 minutes and corrupted nexo.db when the OS finally killed the process
+is the exact scenario this limit prevents at the tool boundary — in addition
+to the v5.5.5 self-heal that recovers from that class of wipe.
+"""
+import glob
 import os
 import shutil
+import sqlite3
+import threading
 import time
-import glob
+
 from db import get_db
 
 NEXO_HOME = os.environ.get("NEXO_HOME", os.path.expanduser("~/.nexo"))
@@ -11,15 +23,63 @@ BACKUP_DIR = os.path.join(NEXO_HOME, "backups")
 
 RETENTION_DAYS = 7
 
+# ── Rate limits (v5.5.6) ────────────────────────────────────────────
+# Minimum seconds between successive calls to each destructive/expensive
+# backup tool. Overridable per-tool via env var for tests or deliberate
+# recovery scenarios (NEXO_BACKUP_MIN_INTERVAL_SECS, etc.).
+BACKUP_NOW_MIN_INTERVAL_SECS = int(
+    os.environ.get("NEXO_BACKUP_MIN_INTERVAL_SECS", "30")
+)
+BACKUP_RESTORE_MIN_INTERVAL_SECS = int(
+    os.environ.get("NEXO_BACKUP_RESTORE_MIN_INTERVAL_SECS", "60")
+)
+
+_rate_limit_lock = threading.Lock()
+_last_call_ts: dict[str, float] = {
+    "backup_now": 0.0,
+    "backup_restore": 0.0,
+}
+
+
+def _check_rate_limit(tool: str, min_interval: int) -> str | None:
+    """Return a rate-limit error string if the tool is called too soon, else None."""
+    now = time.time()
+    with _rate_limit_lock:
+        last = _last_call_ts.get(tool, 0.0)
+        elapsed = now - last
+        if last > 0 and elapsed < min_interval:
+            remaining = int(min_interval - elapsed)
+            return (
+                f"Rate-limited: {tool} called {int(elapsed)}s ago "
+                f"(min {min_interval}s between calls). Wait {remaining}s. "
+                "If you are seeing this message repeatedly, a client may be stuck in a "
+                "tool-use loop — check NEXO transcripts and kill the runaway session."
+            )
+        _last_call_ts[tool] = now
+    return None
+
+
+def _reset_rate_limit_state_for_tests() -> None:
+    """Test hook: clear all tracked call timestamps."""
+    with _rate_limit_lock:
+        for key in _last_call_ts:
+            _last_call_ts[key] = 0.0
+
 
 def handle_backup_now() -> str:
-    """Create an immediate backup of the NEXO database."""
+    """Create an immediate backup of the NEXO database.
+
+    Rate-limited to one call every BACKUP_NOW_MIN_INTERVAL_SECS (default 30 s).
+    """
+    err = _check_rate_limit("backup_now", BACKUP_NOW_MIN_INTERVAL_SECS)
+    if err is not None:
+        return err
+
     os.makedirs(BACKUP_DIR, exist_ok=True)
     timestamp = time.strftime("%Y-%m-%d-%H%M")
     dest = os.path.join(BACKUP_DIR, f"nexo-{timestamp}.db")
 
     # Use SQLite backup API for consistency
-    import sqlite3
     src_conn = sqlite3.connect(DB_PATH)
     try:
         dst_conn = sqlite3.connect(dest)
@@ -56,16 +116,23 @@ def handle_backup_list() -> str:
 def handle_backup_restore(filename: str) -> str:
     """Restore database from a backup file. DESTRUCTIVE — replaces current DB.
 
+    Rate-limited to one call every BACKUP_RESTORE_MIN_INTERVAL_SECS (default
+    60 s). A client hammering restore in a loop is the exact shape of the
+    v5.5.4 incident.
+
     Args:
         filename: Backup filename (e.g., 'nexo-2026-03-11-1200.db')
     """
+    err = _check_rate_limit("backup_restore", BACKUP_RESTORE_MIN_INTERVAL_SECS)
+    if err is not None:
+        return err
+
     src = os.path.join(BACKUP_DIR, filename)
     if not os.path.isfile(src):
         return f"Backup not found: {filename}"
 
     # Create safety backup first
     safety = os.path.join(BACKUP_DIR, f"nexo-pre-restore-{time.strftime('%Y%m%d%H%M%S')}.db")
-    import sqlite3
     src_conn = sqlite3.connect(DB_PATH)
     try:
         dst_conn = sqlite3.connect(safety)

--- a/src/user_data_portability.py
+++ b/src/user_data_portability.py
@@ -8,6 +8,8 @@ import shutil
 import sqlite3
 import tarfile
 import tempfile
+import threading
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -22,6 +24,36 @@ USER_CONFIG_FILES = ("schedule.json",)
 IGNORED_FILENAMES = {".DS_Store"}
 IGNORED_DIRS = {"__pycache__"}
 IGNORED_SUFFIXES = {".pyc", ".pyo"}
+
+# v5.5.6: rate-limit the whole-bundle export so a runaway MCP client cannot
+# loop this tool. Each export snapshots the entire NEXO state through
+# sqlite3.Connection.backup() plus a tree copy — in the v5.5.4 incident a
+# similar loop wrote 8.5 GB in 37 minutes. Overridable for tests / deliberate
+# batch exports via NEXO_EXPORT_MIN_INTERVAL_SECS.
+EXPORT_MIN_INTERVAL_SECS = int(os.environ.get("NEXO_EXPORT_MIN_INTERVAL_SECS", "120"))
+_export_rate_lock = threading.Lock()
+_export_last_call_ts = [0.0]
+
+
+def _check_export_rate_limit() -> str | None:
+    now = time.time()
+    with _export_rate_lock:
+        last = _export_last_call_ts[0]
+        elapsed = now - last
+        if last > 0 and elapsed < EXPORT_MIN_INTERVAL_SECS:
+            remaining = int(EXPORT_MIN_INTERVAL_SECS - elapsed)
+            return (
+                f"Rate-limited: export_user_bundle called {int(elapsed)}s ago "
+                f"(min {EXPORT_MIN_INTERVAL_SECS}s between calls). Wait {remaining}s. "
+                "If you see this repeatedly, a client may be stuck in a tool-use loop."
+            )
+        _export_last_call_ts[0] = now
+    return None
+
+
+def _reset_export_rate_limit_state_for_tests() -> None:
+    with _export_rate_lock:
+        _export_last_call_ts[0] = 0.0
 
 
 def _now_stamp() -> str:
@@ -137,6 +169,9 @@ def _load_personal_scripts() -> tuple[list[dict], list[dict]]:
 
 
 def export_user_bundle(output_path: str = "") -> dict:
+    err = _check_export_rate_limit()
+    if err is not None:
+        return {"ok": False, "error": err, "rate_limited": True}
     output = Path(output_path).expanduser() if output_path.strip() else (EXPORTS_DIR / f"nexo-user-data-{_now_stamp()}.tar.gz")
     output.parent.mkdir(parents=True, exist_ok=True)
     STAGING_DIR.mkdir(parents=True, exist_ok=True)

--- a/tests/test_backup_rate_limit.py
+++ b/tests/test_backup_rate_limit.py
@@ -1,0 +1,150 @@
+"""Tests for the v5.5.6 rate-limit on plugins.backup and user_data_portability.
+
+These guard the v5.5.4 incident surface from the tool side: a runaway MCP
+client calling nexo_backup_now / nexo_backup_restore / export_user_bundle in
+a loop can no longer hammer sqlite3.Connection.backup() hundreds of times per
+minute. The first call goes through; subsequent calls within the window
+return a clear, client-actionable error.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+
+def _seed_db(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.execute("CREATE TABLE IF NOT EXISTS sample (id INTEGER PRIMARY KEY, body TEXT)")
+        for i in range(20):
+            conn.execute("INSERT INTO sample (body) VALUES (?)", (f"row-{i}",))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def backup_env(tmp_path, monkeypatch):
+    nexo_home = tmp_path / "nexo_home"
+    (nexo_home / "data").mkdir(parents=True)
+    (nexo_home / "backups").mkdir(parents=True)
+    _seed_db(nexo_home / "data" / "nexo.db")
+
+    monkeypatch.setenv("NEXO_HOME", str(nexo_home))
+    # Keep the window short enough for deterministic tests but long enough to
+    # still exercise the "second call too soon" branch before time advances.
+    monkeypatch.setenv("NEXO_BACKUP_MIN_INTERVAL_SECS", "2")
+    monkeypatch.setenv("NEXO_BACKUP_RESTORE_MIN_INTERVAL_SECS", "2")
+
+    import plugins.backup as backup_mod
+    importlib.reload(backup_mod)
+    backup_mod._reset_rate_limit_state_for_tests()
+    return {
+        "home": nexo_home,
+        "backups": nexo_home / "backups",
+        "mod": backup_mod,
+    }
+
+
+def test_backup_now_first_call_succeeds(backup_env):
+    result = backup_env["mod"].handle_backup_now()
+    assert result.startswith("Backup created:"), result
+
+
+def test_backup_now_second_call_is_rate_limited(backup_env):
+    first = backup_env["mod"].handle_backup_now()
+    assert first.startswith("Backup created:"), first
+    second = backup_env["mod"].handle_backup_now()
+    assert "Rate-limited" in second, second
+    assert "backup_now" in second
+    assert "stuck in a" in second  # explicit loop guidance
+
+
+def test_backup_now_rate_limit_clears_after_interval(backup_env):
+    backup_env["mod"].handle_backup_now()
+    # interval is 2s in the fixture
+    time.sleep(2.1)
+    again = backup_env["mod"].handle_backup_now()
+    assert again.startswith("Backup created:"), again
+
+
+def test_backup_restore_first_call_succeeds(backup_env):
+    # Create a source backup file to restore from.
+    src_backup = backup_env["backups"] / "nexo-2026-01-01-0000.db"
+    _seed_db(src_backup)
+    result = backup_env["mod"].handle_backup_restore("nexo-2026-01-01-0000.db")
+    assert result.startswith("DB restaurada desde"), result
+
+
+def test_backup_restore_second_call_is_rate_limited(backup_env):
+    src_backup = backup_env["backups"] / "nexo-2026-01-01-0000.db"
+    _seed_db(src_backup)
+    first = backup_env["mod"].handle_backup_restore("nexo-2026-01-01-0000.db")
+    assert first.startswith("DB restaurada desde"), first
+    second = backup_env["mod"].handle_backup_restore("nexo-2026-01-01-0000.db")
+    assert "Rate-limited" in second
+    assert "backup_restore" in second
+
+
+def test_backup_list_is_never_rate_limited(backup_env):
+    """backup_list is pure read; should not be rate-limited under any circumstance."""
+    for _ in range(50):
+        result = backup_env["mod"].handle_backup_list()
+        assert "Rate-limited" not in result
+
+
+def test_rate_limit_state_is_tool_local(backup_env):
+    """Hitting backup_now must not consume the quota of backup_restore."""
+    src_backup = backup_env["backups"] / "nexo-2026-01-01-0000.db"
+    _seed_db(src_backup)
+    first = backup_env["mod"].handle_backup_now()
+    assert first.startswith("Backup created:")
+    # restore should still be allowed — separate counter
+    restore = backup_env["mod"].handle_backup_restore("nexo-2026-01-01-0000.db")
+    assert restore.startswith("DB restaurada desde")
+
+
+# ── Export bundle rate limit ────────────────────────────────────────
+
+@pytest.fixture
+def export_env(tmp_path, monkeypatch):
+    nexo_home = tmp_path / "nexo_home"
+    (nexo_home / "data").mkdir(parents=True)
+    (nexo_home / "exports").mkdir(parents=True)
+    _seed_db(nexo_home / "data" / "nexo.db")
+    monkeypatch.setenv("NEXO_HOME", str(nexo_home))
+    monkeypatch.setenv("NEXO_EXPORT_MIN_INTERVAL_SECS", "2")
+    import user_data_portability as portability
+    importlib.reload(portability)
+    portability._reset_export_rate_limit_state_for_tests()
+    return {"home": nexo_home, "mod": portability}
+
+
+def test_export_first_call_succeeds(export_env):
+    result = export_env["mod"].export_user_bundle()
+    # Export may succeed or partially succeed; what matters here is it is not
+    # flagged as rate-limited.
+    assert not result.get("rate_limited"), result
+
+
+def test_export_second_call_is_rate_limited(export_env):
+    first = export_env["mod"].export_user_bundle()
+    assert not first.get("rate_limited"), first
+    second = export_env["mod"].export_user_bundle()
+    assert second.get("rate_limited") is True
+    assert second["ok"] is False
+    assert "Rate-limited" in second["error"]
+
+
+def test_export_rate_limit_clears_after_interval(export_env):
+    export_env["mod"].export_user_bundle()
+    time.sleep(2.1)
+    again = export_env["mod"].export_user_bundle()
+    assert not again.get("rate_limited"), again


### PR DESCRIPTION
## Summary

Same-day follow-up to v5.5.5. v5.5.5 neutralised the *consequences* of the 2026-04-16 incident (validated backups, pre-flight guard, post-migration gate, startup self-heal, `nexo recover`). v5.5.6 closes the *cause*: a runaway MCP client (Claude Code tool-use loop, buggy Desktop handler, etc.) can no longer hammer `sqlite3.Connection.backup()` from the tool boundary.

### Changes

- **`plugins/backup.py`**: `handle_backup_now` rate-limited to one call every `NEXO_BACKUP_MIN_INTERVAL_SECS` (default 30 s). `handle_backup_restore` rate-limited to one call every `NEXO_BACKUP_RESTORE_MIN_INTERVAL_SECS` (default 60 s). `handle_backup_list` stays read-only, never rate-limited.
- **`user_data_portability.export_user_bundle`**: rate-limited to one call every `NEXO_EXPORT_MIN_INTERVAL_SECS` (default 120 s). Returns `{"ok": False, "rate_limited": True, "error": "..."}` so clients can react.
- Each rate-limit response explicitly mentions loop detection ("If you see this repeatedly, a client may be stuck in a tool-use loop…") so transcript evidence surfaces the next time a client misbehaves.

### Test plan

- [x] `pytest tests/test_backup_rate_limit.py` → 10/10 ✅
- [x] Full suite → **880/880 passing**, 0 regressions
- [x] `ruff` clean on touched files
- [x] `scripts/verify_release_readiness.py` → OK

### Why not in v5.5.5

v5.5.5 was the minimal-surface data-loss hotfix. Rate-limits change tool semantics (well-behaved callers may occasionally hit the "try again in N s" response) and deserved a dedicated release so operators read the limit numbers, not just the recovery flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
