### PR TITLE
feat: v5.6.0 — default model upgrade Opus 4.6 → 4.7 with auto-migration

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.5.6",
+  "version": "5.6.0",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/.well-known/llms.txt
+++ b/.well-known/llms.txt
@@ -1,6 +1,6 @@
 # NEXO Brain
 
-> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.4.1).
+> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.6.0).
 
 NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. It adds a local shared brain across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, smarter retrieval defaults, long-horizon overnight analysis, and 150+ MCP tools.
 
@@ -70,7 +70,7 @@ v5.2.0: bilingual response-discipline scoring + cortex quality cache reader
 ## Recommended Defaults
 
 - Claude Code: recommended primary client
-- Claude Code model profile: Opus 4.6 with 1M context
+- Claude Code model profile: Opus 4.7 with 1M context
 - Codex model profile: GPT-5.4 xhigh
 
 ## Installation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## [5.6.0] - 2026-04-16
+
+### Feature: Default model upgrade — Opus 4.6 → 4.7
+
+NEXO Brain now ships with **Claude Opus 4.7** as the recommended model for
+Claude Code users. The 1M context window remains active (same beta header).
+
+- **`src/model_defaults.json`**: `claude_code.model` updated to
+  `claude-opus-4-7[1m]` with `reasoning_effort: "max"`. The new `max` tier
+  is the highest reasoning level available on Opus 4.7 (verified empirically
+  against `/v1/messages`). `recommendation_version` bumped to 2.
+- **Auto-migration on `nexo update`**: `heal_runtime_profiles()` now
+  detects users whose model starts with `claude-opus-4-6` and silently
+  migrates to `claude-opus-4-7` preserving any suffix (e.g. `[1m]`).
+  Reasoning effort is bumped to `max` if the user had an empty value,
+  `xhigh`, or the legacy `enabled` format.
+- **Codex untouched**: GPT-5.4 / xhigh remains the Codex default. No
+  migration applies to Codex profiles.
+- **Interactive prompt preserved**: users on an older NEXO default who have
+  not yet run `nexo update` will also be offered the upgrade interactively
+  via `detect_outdated_recommendations`.
+
+### Breaking API change in Opus 4.7 (informational)
+
+Opus 4.7 changed the thinking/reasoning API from `thinking.enabled` +
+`thinking.budget_tokens` to `thinking.type: "adaptive"` + `output_config.effort`.
+NEXO Brain does not call the Anthropic API directly (Claude Code handles it),
+but this is documented here for operators building custom integrations.
+Valid effort values: `low`, `medium`, `high`, `xhigh`, `max`.
+
 ## [5.5.6] - 2026-04-16
 
 ### Hotfix: rate-limit the backup/restore/export tools

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [Watch the overview video](https://nexo-brain.com/watch/) · [Watch on YouTube](https://www.youtube.com/watch?v=i2lkGhKyVqI) · [Open the infographic](https://nexo-brain.com/assets/nexo-brain-infographic-v5.png)
 
-Version `5.5.6` is the current packaged-runtime line: same-day follow-up to v5.5.5 that adds in-process rate-limits to `nexo_backup_now` (30 s), `nexo_backup_restore` (60 s), and `export_user_bundle` (120 s) so a runaway MCP client can no longer hammer `sqlite3.Connection.backup()` from a tool-use loop — closing the cause of the 2026-04-16 incident the same day v5.5.5 closed its consequences.
+Version `5.6.0` is the current packaged-runtime line: default model upgrade from Opus 4.6 to **Opus 4.7** with `reasoning_effort: "max"` (the new highest tier). Auto-migration on `nexo update` silently upgrades existing users from `claude-opus-4-6*` to `claude-opus-4-7` preserving the 1M context suffix. Codex profiles are untouched.
 
 Previously in `5.5.5`: data-loss guardrails + automatic self-heal. The updater now refuses to capture an already-wiped `nexo.db` into a `pre-update-*` snapshot (validated `sqlite3.backup` + pre-flight wipe guard + post-migration row-count gate), and an auto-heal restores `data/nexo.db` from the newest hourly backup on the next server boot when a wipe is detected. New `nexo recover` CLI + `nexo_recover` MCP tool.
 
@@ -830,7 +830,7 @@ If you want the shell or Python wrappers instead of raw MCP tools:
 - [docs/reference-verticals.md](docs/reference-verticals.md)
 - [compare/README.md](compare/README.md)
 
-The model you pick during install is used everywhere — interactive sessions, automation scripts, and all task profiles.  Change it once in your preferences and every part of the system follows.  Default: `Opus 4.6 with 1M context`.
+The model you pick during install is used everywhere — interactive sessions, automation scripts, and all task profiles.  Change it once in your preferences and every part of the system follows.  Default: `Opus 4.7 with 1M context`.
 
 Or use the shell alias created during install (e.g. `atlas`), which now runs `nexo chat .` so it opens the terminal client you pick for that session, with the last-used option shown first.
 
@@ -911,7 +911,7 @@ The Doctor system reads existing health artifacts (immune, watchdog, self-audit)
 - **macOS or Linux** (Windows via [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
 - **Node.js 18+** (for the installer)
 - **Claude Code is the primary recommended client.** It remains the most mature NEXO path: native hooks, the most battle-tested automation contract, and the clearest parity with historical production behavior.
-- **Model:** You pick your model during install and every component uses it.  Default is `Opus 4.6 with 1M context`.  Scripts and automation profiles read from a single preference — no hardcoded model strings.
+- **Model:** You pick your model during install and every component uses it.  Default is `Opus 4.7 with 1M context`.  Scripts and automation profiles read from a single preference — no hardcoded model strings.
 - Python 3, Homebrew, and the selected required client/backend can be installed automatically when NEXO has a supported installer path for that dependency.
 
 ## Architecture
@@ -1020,7 +1020,7 @@ NEXO Brain is designed as an MCP server. Claude Code remains the primary recomme
 npx nexo-brain
 ```
 
-All 150+ tools are available immediately after installation. The installer configures Claude Code's `~/.claude/settings.json` automatically. The recommended Claude profile is `Opus 4.6 with 1M context`.
+All 150+ tools are available immediately after installation. The installer configures Claude Code's `~/.claude/settings.json` automatically. The recommended Claude profile is `Opus 4.7 with 1M context`.
 
 ### Claude Desktop
 

--- a/blog/index.html
+++ b/blog/index.html
@@ -188,6 +188,13 @@
 
             <div class="blog-card">
                 <div class="blog-card-date">April 16, 2026</div>
+                <h2><a href="/blog/nexo-5-6-0/">NEXO 5.6.0: Default Model Upgrade — Opus 4.6 → 4.7</a></h2>
+                <p>NEXO Brain now ships with <strong>Claude Opus 4.7</strong> and <code>reasoning_effort: "max"</code> — the highest reasoning tier available. Auto-migration on <code>nexo update</code> silently upgrades existing users from <code>claude-opus-4-6*</code> to <code>claude-opus-4-7</code>, preserving the 1M context suffix. Codex profiles are untouched.</p>
+                <a href="/blog/nexo-5-6-0/" class="read-more">Read more &rarr;</a>
+            </div>
+
+            <div class="blog-card">
+                <div class="blog-card-date">April 16, 2026</div>
                 <h2><a href="/blog/nexo-5-5-4/">NEXO 5.5.4: Deep Sleep Stops Blocking on Unparseable Sessions</a></h2>
                 <p>Phase 2 extraction was retrying the same session three times with identical prompt and context, hiding a 6h per-attempt safety net that silently drifted out of alignment with its own <code>3h</code> comment. Retries dropped from 3 to 2, the JSON system prompt gained an escape hatch so the model always returns parseable output, and all 10 automation subprocess timeouts now live in a single <code>AUTOMATION_SUBPROCESS_TIMEOUT</code> constant.</p>
                 <a href="/blog/nexo-5-5-4/" class="read-more">Read more &rarr;</a>

--- a/blog/nexo-5-6-0/index.html
+++ b/blog/nexo-5-6-0/index.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <title>NEXO 5.6.0: Default Model Upgrade — Opus 4.6 → 4.7</title>
+    <meta name="description" content="NEXO Brain 5.6.0 upgrades the default model to Claude Opus 4.7 with reasoning_effort max. Auto-migration on nexo update silently upgrades existing users from 4.6 to 4.7.">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://nexo-brain.com/blog/nexo-5-6-0/">
+
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://nexo-brain.com/blog/nexo-5-6-0/">
+    <meta property="og:title" content="NEXO 5.6.0: Default Model Upgrade — Opus 4.6 → 4.7">
+    <meta property="og:description" content="NEXO Brain now ships with Claude Opus 4.7 and reasoning_effort max. Existing users on 4.6 are silently migrated on nexo update.">
+    <meta property="og:image" content="https://nexo-brain.com/assets/og/og-blog.png">
+    <meta property="article:published_time" content="2026-04-16">
+    <meta property="article:author" content="Francisco Cerda Puigserver">
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="NEXO 5.6.0: Default Model Upgrade — Opus 4.6 → 4.7">
+    <meta name="twitter:description" content="Claude Opus 4.7 with reasoning_effort max is now the default. Auto-migration on nexo update handles existing installations.">
+    <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-blog.png">
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-1LNEMCJMS7"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-1LNEMCJMS7');
+    </script>
+
+    <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicon-32.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
+    <link rel="stylesheet" href="/assets/style.css">
+
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "NEXO 5.6.0: Default Model Upgrade — Opus 4.6 → 4.7",
+        "description": "NEXO Brain 5.6.0 upgrades the default model to Claude Opus 4.7 with reasoning_effort max. Auto-migration on nexo update silently upgrades existing users.",
+        "datePublished": "2026-04-16",
+        "dateModified": "2026-04-16",
+        "author": {
+            "@type": "Person",
+            "name": "Francisco Cerda Puigserver"
+        },
+        "publisher": {
+            "@type": "Organization",
+            "name": "WAzion",
+            "url": "https://www.wazion.com"
+        },
+        "mainEntityOfPage": {
+            "@type": "WebPage",
+            "@id": "https://nexo-brain.com/blog/nexo-5-6-0/"
+        },
+        "url": "https://nexo-brain.com/blog/nexo-5-6-0/",
+        "image": "https://nexo-brain.com/assets/og/og-blog.png",
+        "keywords": ["NEXO 5.6.0", "Opus 4.7", "model upgrade", "auto-migration", "reasoning effort"]
+    }
+    </script>
+
+    <style>
+        .article-header { padding-top: 128px; padding-bottom: 40px; text-align: center; }
+        .article-meta { font-size: 14px; color: var(--text-muted); margin-bottom: 16px; }
+        .article-body {
+            max-width: 720px; margin: 0 auto; padding: 0 24px 80px;
+            font-size: 17px; line-height: 1.8; color: var(--text);
+        }
+        .article-body h2 { font-size: 28px; font-weight: 700; margin: 48px 0 16px; letter-spacing: -0.01em; }
+        .article-body p { margin-bottom: 20px; color: var(--text-muted); }
+        .article-body strong { color: var(--text); }
+        .article-body a { color: var(--purple-light); }
+        .article-body a:hover { color: var(--pink); }
+        .article-body code {
+            font-family: 'SF Mono', 'Fira Code', monospace;
+            font-size: 14px; color: var(--pink);
+            background: rgba(236, 72, 153, 0.1);
+            padding: 2px 8px; border-radius: 4px;
+        }
+        .article-back {
+            display: inline-flex; align-items: center; gap: 6px;
+            font-size: 14px; font-weight: 600; color: var(--text-muted);
+            margin-bottom: 24px;
+        }
+        .article-back:hover { color: var(--purple-light); }
+    </style>
+</head>
+<body>
+
+<nav>
+    <div class="container">
+        <a href="/" class="nav-logo">
+            <img src="/assets/logo-64.png" alt="NEXO Brain" class="logo-image">
+            <span class="logo-text">NEXO Brain</span>
+        </a>
+        <button class="mobile-menu-toggle" aria-label="Toggle navigation" onclick="toggleMobileMenu()">
+            <span></span><span></span><span></span>
+        </button>
+        <div class="nav-links">
+            <a href="/">Home</a>
+            <a href="/features/">Features</a>
+            <a href="/evolution/">Evolution</a>
+            <a href="/compare/">Compare</a>
+            <a href="/blog/">Blog</a>
+            <a href="/changelog/">Changelog</a>
+            <a href="/docs/">Docs</a>
+            <a href="https://github.com/wazionapps/nexo" class="nav-cta">GitHub</a>
+        </div>
+    </div>
+</nav>
+
+<section class="article-header">
+    <div class="container">
+        <a href="/blog/" class="article-back">&larr; Back to blog</a>
+        <div class="article-meta">April 16, 2026 &middot; Feature &middot; Model Upgrade</div>
+        <h1 class="section-title" style="font-size:clamp(28px,4.5vw,48px);max-width:920px;margin:0 auto 16px;">NEXO 5.6.0: Default Model Upgrade &mdash; Opus 4.6 &rarr; 4.7</h1>
+        <p class="section-subtitle" style="max-width:760px;margin:0 auto;">NEXO Brain now ships with <strong>Claude Opus 4.7</strong> as the recommended model for Claude Code users. The 1M context window stays active. Existing installations on 4.6 are silently migrated when they run <code>nexo update</code>.</p>
+    </div>
+</section>
+
+<section>
+    <div class="article-body">
+
+        <h2>What changed</h2>
+        <p><strong>New default model: <code>claude-opus-4-7[1m]</code>.</strong> The <code>[1m]</code> suffix is NEXO&rsquo;s internal notation that translates to the <code>anthropic-beta: context-1m-2025-08-07</code> header at call time. The header is accepted by Opus 4.7, so the 1M context window continues to work exactly as before.</p>
+        <p><strong>Reasoning effort set to <code>max</code>.</strong> Opus 4.7 introduced a new effort tier above <code>xhigh</code>. The valid values are <code>low</code>, <code>medium</code>, <code>high</code>, <code>xhigh</code>, and <code>max</code> &mdash; all verified empirically against <code>/v1/messages</code>. NEXO now defaults to the highest tier.</p>
+        <p><strong>Auto-migration on <code>nexo update</code>.</strong> The <code>heal_runtime_profiles()</code> function detects users whose model starts with <code>claude-opus-4-6</code> and silently migrates to <code>claude-opus-4-7</code>, preserving any suffix (e.g. <code>[1m]</code>). If the user had an empty reasoning effort, <code>xhigh</code>, or the legacy <code>enabled</code> format, it bumps to <code>max</code>.</p>
+        <p><strong>Codex untouched.</strong> GPT-5.4 with <code>xhigh</code> reasoning remains the Codex default. No migration applies to Codex profiles.</p>
+
+        <h2>Breaking API change in Opus 4.7</h2>
+        <p>Opus 4.7 changed the thinking/reasoning API from <code>thinking.enabled</code> + <code>thinking.budget_tokens</code> to <code>thinking.type: &quot;adaptive&quot;</code> + <code>output_config.effort</code>. NEXO Brain does not call the Anthropic API directly (Claude Code handles it), but this is documented here for operators building custom integrations.</p>
+
+        <h2>How to upgrade</h2>
+        <p>Run <code>nexo update</code> in your terminal. If you were on Opus 4.6, the migration happens automatically. No manual configuration needed.</p>
+
+    </div>
+</section>
+
+<footer style="padding:48px 24px;text-align:center;font-size:13px;color:var(--text-muted);">
+    &copy; 2026 <a href="https://www.wazion.com" style="color:var(--purple-light);">WAzion</a>. NEXO Brain is open-source under <a href="https://github.com/wazionapps/nexo/blob/main/LICENSE" style="color:var(--purple-light);">AGPL-3.0</a>.
+</footer>
+
+<script src="/assets/main.js"></script>
+</body>
+</html>

--- a/changelog/index.html
+++ b/changelog/index.html
@@ -181,6 +181,17 @@
     </div>
 </section>
 
+<!-- v5.6.0 Default model upgrade Opus 4.6 → 4.7 -->
+<section id="v560" class="section-compact" style="background:linear-gradient(135deg,#09111f 0%,#14253a 50%,#1e3a5f 100%);">
+    <div class="container">
+        <div class="section-label">New in v5.6.0 <span style="opacity:.5;font-weight:400;">&mdash; April 16, 2026</span></div>
+        <h2 class="section-title">Default Model Upgrade: Opus 4.6 &rarr; 4.7</h2>
+        <p class="section-subtitle">
+            NEXO Brain now ships with <strong>Claude Opus 4.7</strong> and <code>reasoning_effort: "max"</code> &mdash; the highest reasoning tier available. Auto-migration on <code>nexo update</code> silently upgrades existing users from <code>claude-opus-4-6*</code> to <code>claude-opus-4-7</code>, preserving the 1M context suffix. Codex profiles (GPT-5.4 / xhigh) are untouched.
+        </p>
+    </div>
+</section>
+
 <!-- v5.5.6 Rate-limit backup/restore/export -->
 <section id="v556" class="section-compact" style="background:linear-gradient(135deg,#0a120f 0%,#152a1f 50%,#1e3f2f 100%);">
     <div class="container">

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 5.5.6
+version: 5.6.0
 metadata:
   openclaw:
     requires:

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
         "operatingSystem": "macOS, Linux, Windows",
         "url": "https://nexo-brain.com",
         "downloadUrl": "https://www.npmjs.com/package/nexo-brain",
-        "softwareVersion": "5.5.6",
+        "softwareVersion": "5.6.0",
         "license": "https://www.gnu.org/licenses/agpl-3.0",
         "author": {
             "@type": "Organization",
@@ -697,7 +697,7 @@
     <div class="container">
         <div class="hero-badge fade-up">
             <span class="dot"></span>
-            <span id="version-badge">v5.5.6</span> &mdash; Backup/restore/export tools rate-limited at the MCP boundary
+            <span id="version-badge">v5.6.0</span> &mdash; Default model upgrade: Opus 4.7 with reasoning_effort max
         </div>
         <div class="fade-up" style="display:flex;gap:8px;justify-content:center;margin-bottom:12px;">
             <img src="https://img.shields.io/npm/v/nexo-brain?color=7C3AED&label=npm" alt="npm version">

--- a/llms.txt
+++ b/llms.txt
@@ -1,9 +1,10 @@
 # NEXO Brain
 
-> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.5.6).
+> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.6.0).
 
 NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. It adds a local shared brain across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, smarter retrieval defaults, long-horizon overnight analysis, and 150+ MCP tools.
 
+v5.6.0: default model upgrade Opus 4.6 → 4.7 with reasoning_effort "max". Auto-migration on `nexo update` silently upgrades users from claude-opus-4-6* to claude-opus-4-7, preserving 1M suffix. Codex untouched.
 v5.5.6: rate-limit the backup/restore/export tools in the MCP boundary. `nexo_backup_now` capped at 1/30s, `nexo_backup_restore` at 1/60s, `export_user_bundle` at 1/120s. A runaway MCP client (tool-use loop) can no longer hammer sqlite3.Connection.backup() the way the 2026-04-16 incident did. Same-day follow-up to v5.5.5.
 v5.5.5: data-loss guardrails + automatic self-heal. The updater now refuses to capture an already-wiped nexo.db into a pre-update snapshot (validated sqlite3.backup + pre-flight wipe guard + post-migration row-count gate), and an auto-heal restores ~/.nexo/data/nexo.db from the newest hourly backup on the next server boot when a wipe is detected. New `nexo recover` CLI + `nexo_recover` MCP tool with mandatory kill-MCP, pre-recover snapshot, and post-restore row-count validation.
 v5.5.4: Deep Sleep no longer blocks on unparseable sessions — retries reduced from 3 to 2, added a JSON escape hatch so the model always returns parseable output, and unified the automation subprocess timeout to 3h (10800s) across 10 scripts via a new shared constant AUTOMATION_SUBPROCESS_TIMEOUT in src/constants.py.
@@ -84,7 +85,7 @@ v5.2.0: bilingual response-discipline scoring + cortex quality cache reader
 ## Recommended Defaults
 
 - Claude Code: recommended primary client
-- Claude Code model profile: Opus 4.6 with 1M context
+- Claude Code model profile: Opus 4.7 with 1M context
 - Codex model profile: GPT-5.4 xhigh
 
 ## Installation

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "5.5.6",
+  "version": "5.6.0",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.5.6" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.6.0" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.5.6",
+  "version": "5.6.0",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain \u2014 Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -157,6 +157,12 @@
     <priority>0.75</priority>
   </url>
   <url>
+    <loc>https://nexo-brain.com/blog/nexo-5-6-0/</loc>
+    <lastmod>2026-04-16</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.75</priority>
+  </url>
+  <url>
     <loc>https://nexo-brain.com/blog/nexo-5-5-4/</loc>
     <lastmod>2026-04-16</lastmod>
     <changefreq>monthly</changefreq>

--- a/src/client_sync.py
+++ b/src/client_sync.py
@@ -62,7 +62,7 @@ except Exception:
         }
 
     def resolve_client_runtime_profile(client: str, preferences: dict | None = None) -> dict:
-        _default_model = "claude-opus-4-6[1m]"
+        _default_model = "claude-opus-4-7[1m]"
         defaults = {
             "claude_code": {"model": _default_model, "reasoning_effort": ""},
             "codex": {"model": _default_model, "reasoning_effort": ""},

--- a/src/model_defaults.json
+++ b/src/model_defaults.json
@@ -1,11 +1,11 @@
 {
   "schema_version": 1,
   "claude_code": {
-    "model": "claude-opus-4-6[1m]",
-    "reasoning_effort": "",
-    "display_name": "Opus 4.6 with 1M context",
-    "recommendation_version": 1,
-    "previous_defaults": []
+    "model": "claude-opus-4-7[1m]",
+    "reasoning_effort": "max",
+    "display_name": "Opus 4.7 with 1M context",
+    "recommendation_version": 2,
+    "previous_defaults": ["claude-opus-4-6[1m]"]
   },
   "codex": {
     "model": "gpt-5.4",

--- a/src/model_defaults.py
+++ b/src/model_defaults.py
@@ -20,11 +20,11 @@ from typing import Any
 _FALLBACK: dict[str, Any] = {
     "schema_version": 1,
     "claude_code": {
-        "model": "claude-opus-4-6[1m]",
-        "reasoning_effort": "",
-        "display_name": "Opus 4.6 with 1M context",
-        "recommendation_version": 1,
-        "previous_defaults": [],
+        "model": "claude-opus-4-7[1m]",
+        "reasoning_effort": "max",
+        "display_name": "Opus 4.7 with 1M context",
+        "recommendation_version": 2,
+        "previous_defaults": ["claude-opus-4-6[1m]"],
     },
     "codex": {
         "model": "gpt-5.4",
@@ -99,15 +99,20 @@ def looks_like_claude_model(model: str) -> bool:
     return str(model or "").strip().lower().startswith(_CLAUDE_MODEL_PREFIXES)
 
 
+_OPUS_46_PREFIX = "claude-opus-4-6"
+
+
 def heal_runtime_profiles(profiles: dict) -> tuple[dict, list[str]]:
     """Detect and repair invalid models in client_runtime_profiles. Returns
-    (healed_profiles_dict, list_of_heal_messages). A Claude-family model in
-    the codex profile is the main historical corruption; we reset such a
-    profile to the current Codex default."""
+    (healed_profiles_dict, list_of_heal_messages). Handles two cases:
+    1. Claude-family model in the codex profile (historical bug).
+    2. Opus 4.6 → 4.7 auto-migration for claude_code users on a NEXO default."""
     if not isinstance(profiles, dict):
         return profiles, []
     healed = dict(profiles)
     messages: list[str] = []
+
+    # --- Codex heal (historical bug: Claude model in codex slot) ---
     codex_profile = healed.get("codex") if isinstance(healed.get("codex"), dict) else None
     if codex_profile is not None:
         current = str(codex_profile.get("model") or "").strip()
@@ -121,6 +126,26 @@ def heal_runtime_profiles(profiles: dict) -> tuple[dict, list[str]]:
                 f"Healed Codex profile: model '{current}' → '{default['model']}' "
                 f"(Claude models are invalid for Codex)."
             )
+
+    # --- Opus 4.6 → 4.7 auto-migration for claude_code ---
+    cc_profile = healed.get("claude_code") if isinstance(healed.get("claude_code"), dict) else None
+    if cc_profile is not None:
+        cc_model = str(cc_profile.get("model") or "").strip()
+        if cc_model.startswith(_OPUS_46_PREFIX):
+            default = client_default("claude_code")
+            suffix = cc_model[len(_OPUS_46_PREFIX):]
+            new_model = f"claude-opus-4-7{suffix}"
+            old_effort = str(cc_profile.get("reasoning_effort") or "").strip()
+            new_effort = default["reasoning_effort"]
+            healed["claude_code"] = dict(cc_profile)
+            healed["claude_code"]["model"] = new_model
+            if old_effort in ("", "xhigh", "enabled"):
+                healed["claude_code"]["reasoning_effort"] = new_effort
+            messages.append(
+                f"Auto-migrated Claude Code: '{cc_model}' → '{new_model}', "
+                f"effort '{old_effort or '(empty)'}' → '{healed['claude_code']['reasoning_effort']}'."
+            )
+
     return healed, messages
 
 

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -70,7 +70,7 @@ def test_build_interactive_client_command_uses_codex_when_selected(tmp_path, mon
             "automation_enabled": True,
             "automation_backend": "claude_code",
             "client_runtime_profiles": {
-                "claude_code": {"model": "claude-opus-4-6[1m]", "reasoning_effort": ""},
+                "claude_code": {"model": "claude-opus-4-7[1m]", "reasoning_effort": "max"},
                 "codex": {"model": "gpt-5.4", "reasoning_effort": "xhigh"},
             },
         },
@@ -106,7 +106,7 @@ def test_build_interactive_client_command_preserves_claude_flags(tmp_path, monke
             "automation_enabled": True,
             "automation_backend": "claude_code",
             "client_runtime_profiles": {
-                "claude_code": {"model": "claude-opus-4-6[1m]", "reasoning_effort": ""},
+                "claude_code": {"model": "claude-opus-4-7[1m]", "reasoning_effort": "max"},
                 "codex": {"model": "gpt-5.4", "reasoning_effort": "xhigh"},
             },
         },
@@ -116,7 +116,9 @@ def test_build_interactive_client_command_preserves_claude_flags(tmp_path, monke
     assert cmd == [
         "/tmp/fake-claude",
         "--model",
-        "claude-opus-4-6[1m]",
+        "claude-opus-4-7[1m]",
+        "--effort",
+        "max",
         "--dangerously-skip-permissions",
         "Start NEXO now.",
     ]
@@ -136,7 +138,7 @@ def test_run_automation_prompt_uses_claude_backend_command(monkeypatch, tmp_path
         "automation_enabled": True,
         "automation_backend": "claude_code",
         "client_runtime_profiles": {
-            "claude_code": {"model": "claude-opus-4-6[1m]", "reasoning_effort": ""},
+            "claude_code": {"model": "claude-opus-4-7[1m]", "reasoning_effort": "max"},
             "codex": {"model": "gpt-5.4", "reasoning_effort": "xhigh"},
         },
     })
@@ -172,7 +174,9 @@ def test_run_automation_prompt_uses_claude_backend_command(monkeypatch, tmp_path
         "Do the thing",
         "--dangerously-skip-permissions",
         "--model",
-        "claude-opus-4-6[1m]",
+        "claude-opus-4-7[1m]",
+        "--effort",
+        "max",
         "--output-format",
         "json",
         "--append-system-prompt",
@@ -198,7 +202,7 @@ def test_run_automation_prompt_uses_codex_exec_output_file(monkeypatch, tmp_path
         "automation_enabled": True,
         "automation_backend": "codex",
         "client_runtime_profiles": {
-            "claude_code": {"model": "claude-opus-4-6[1m]", "reasoning_effort": ""},
+            "claude_code": {"model": "claude-opus-4-7[1m]", "reasoning_effort": "max"},
             "codex": {"model": "gpt-5.4", "reasoning_effort": "xhigh"},
         },
     })
@@ -266,7 +270,7 @@ def test_run_automation_prompt_marks_public_contribution_env(monkeypatch, tmp_pa
         "automation_enabled": True,
         "automation_backend": "claude_code",
         "client_runtime_profiles": {
-            "claude_code": {"model": "claude-opus-4-6[1m]", "reasoning_effort": ""},
+            "claude_code": {"model": "claude-opus-4-7[1m]", "reasoning_effort": "max"},
             "codex": {"model": "gpt-5.4", "reasoning_effort": "xhigh"},
         },
     })
@@ -306,14 +310,14 @@ def test_run_automation_prompt_uses_fast_task_profile_for_backend_and_reasoning(
         "automation_enabled": True,
         "automation_backend": "claude_code",
         "client_runtime_profiles": {
-            "claude_code": {"model": "claude-opus-4-6[1m]", "reasoning_effort": ""},
+            "claude_code": {"model": "claude-opus-4-7[1m]", "reasoning_effort": "max"},
             "codex": {"model": "gpt-5.4", "reasoning_effort": "high"},
         },
         "automation_task_profiles": {
             "default": {"backend": "", "model": "", "reasoning_effort": ""},
             "fast": {"backend": "codex", "model": "gpt-5.4-mini", "reasoning_effort": "medium"},
             "balanced": {"backend": "", "model": "", "reasoning_effort": ""},
-            "deep": {"backend": "claude_code", "model": "claude-opus-4-6[1m]", "reasoning_effort": ""},
+            "deep": {"backend": "claude_code", "model": "claude-opus-4-7[1m]", "reasoning_effort": "max"},
         },
     })
 
@@ -356,14 +360,14 @@ def test_run_automation_prompt_falls_back_when_configured_backend_is_unavailable
         "automation_enabled": True,
         "automation_backend": "claude_code",
         "client_runtime_profiles": {
-            "claude_code": {"model": "claude-opus-4-6[1m]", "reasoning_effort": ""},
+            "claude_code": {"model": "claude-opus-4-7[1m]", "reasoning_effort": "max"},
             "codex": {"model": "gpt-5.4", "reasoning_effort": "high"},
         },
         "automation_task_profiles": {
             "default": {"backend": "", "model": "", "reasoning_effort": ""},
             "fast": {"backend": "codex", "model": "gpt-5.4-mini", "reasoning_effort": "medium"},
             "balanced": {"backend": "", "model": "", "reasoning_effort": ""},
-            "deep": {"backend": "claude_code", "model": "claude-opus-4-6[1m]", "reasoning_effort": ""},
+            "deep": {"backend": "claude_code", "model": "claude-opus-4-7[1m]", "reasoning_effort": "max"},
         },
     })
 
@@ -415,7 +419,7 @@ def test_codex_backend_maps_legacy_opus_hint_to_configured_profile(monkeypatch, 
         "automation_enabled": True,
         "automation_backend": "codex",
         "client_runtime_profiles": {
-            "claude_code": {"model": "claude-opus-4-6[1m]", "reasoning_effort": ""},
+            "claude_code": {"model": "claude-opus-4-7[1m]", "reasoning_effort": "max"},
             "codex": {"model": "gpt-5.4-mini", "reasoning_effort": "high"},
         },
     })
@@ -457,7 +461,7 @@ def test_codex_backend_uses_configured_profile_when_model_is_empty(monkeypatch, 
         "automation_enabled": True,
         "automation_backend": "codex",
         "client_runtime_profiles": {
-            "claude_code": {"model": "claude-opus-4-6[1m]", "reasoning_effort": ""},
+            "claude_code": {"model": "claude-opus-4-7[1m]", "reasoning_effort": "max"},
             "codex": {"model": "gpt-5.4-mini", "reasoning_effort": "high"},
         },
     })
@@ -502,7 +506,7 @@ def test_codex_runner_skips_inline_bootstrap_when_global_bootstrap_is_managed(mo
             "automation_enabled": True,
             "automation_backend": "codex",
             "client_runtime_profiles": {
-                "claude_code": {"model": "claude-opus-4-6[1m]", "reasoning_effort": ""},
+                "claude_code": {"model": "claude-opus-4-7[1m]", "reasoning_effort": "max"},
                 "codex": {"model": "gpt-5.4", "reasoning_effort": "xhigh"},
             },
         },
@@ -565,7 +569,7 @@ def test_build_followup_terminal_shell_command_uses_codex_interactive_flags(monk
             "automation_enabled": True,
             "automation_backend": "codex",
             "client_runtime_profiles": {
-                "claude_code": {"model": "claude-opus-4-6[1m]", "reasoning_effort": ""},
+                "claude_code": {"model": "claude-opus-4-7[1m]", "reasoning_effort": "max"},
                 "codex": {"model": "gpt-5.4", "reasoning_effort": "xhigh"},
             },
         },

--- a/tests/test_cli_scripts.py
+++ b/tests/test_cli_scripts.py
@@ -672,7 +672,7 @@ class TestChatCommand:
         assert result.returncode == 0
         assert "[NEXO] NEXO " in result.stderr
         payload = json.loads(out_file.read_text())
-        assert payload["argv"][:3] == ["--model", "claude-opus-4-6[1m]", "--dangerously-skip-permissions"]
+        assert payload["argv"][:5] == ["--model", "claude-opus-4-7[1m]", "--effort", "max", "--dangerously-skip-permissions"]
         assert "nexo_startup" in payload["argv"][-1]
         assert "nexo_heartbeat" in payload["argv"][-1]
         assert payload["cwd"] == str(workspace.resolve())
@@ -768,8 +768,8 @@ class TestChatCommand:
             "automation_backend": "claude_code",
             "client_runtime_profiles": {
                 "claude_code": {
-                    "model": "claude-opus-4-6[1m]",
-                    "reasoning_effort": "",
+                    "model": "claude-opus-4-7[1m]",
+                    "reasoning_effort": "max",
                 },
                 "codex": {
                     "model": "gpt-5.4",
@@ -836,8 +836,8 @@ class TestChatCommand:
             "automation_backend": "claude_code",
             "client_runtime_profiles": {
                 "claude_code": {
-                    "model": "claude-opus-4-6[1m]",
-                    "reasoning_effort": "",
+                    "model": "claude-opus-4-7[1m]",
+                    "reasoning_effort": "max",
                 },
                 "codex": {
                     "model": "gpt-5.4",

--- a/tests/test_client_preferences.py
+++ b/tests/test_client_preferences.py
@@ -15,7 +15,7 @@ def test_normalize_client_preferences_preserves_old_defaults(tmp_path):
     assert prefs["last_terminal_client"] == ""
     assert prefs["automation_enabled"] is True
     assert prefs["automation_backend"] == "claude_code"
-    assert prefs["client_runtime_profiles"]["claude_code"]["model"] == "claude-opus-4-6[1m]"
+    assert prefs["client_runtime_profiles"]["claude_code"]["model"] == "claude-opus-4-7[1m]"
     assert prefs["client_runtime_profiles"]["codex"]["model"] == "gpt-5.4"
     assert prefs["client_runtime_profiles"]["codex"]["reasoning_effort"] == "xhigh"
     assert prefs["automation_task_profiles"]["fast"]["backend"] == ""
@@ -69,7 +69,7 @@ def test_client_runtime_profiles_normalize_and_default():
         }
     )
 
-    assert prefs["client_runtime_profiles"]["claude_code"]["model"] == "claude-opus-4-6[1m]"
+    assert prefs["client_runtime_profiles"]["claude_code"]["model"] == "claude-opus-4-7[1m]"
     assert prefs["client_runtime_profiles"]["codex"]["model"] == "gpt-5.4-mini"
     assert prefs["client_runtime_profiles"]["codex"]["reasoning_effort"] == "high"
 
@@ -97,8 +97,8 @@ def test_resolve_automation_task_profile_uses_profile_override_and_runtime_defau
     assert deep == {
         "name": "deep",
         "backend": "claude_code",
-        "model": "claude-opus-4-6[1m]",
-        "reasoning_effort": "medium",
+        "model": "claude-opus-4-7[1m]",
+        "reasoning_effort": "max",
     }
     assert fast == {
         "name": "fast",


### PR DESCRIPTION
## Summary
- **model_defaults.json**: `claude-opus-4-7[1m]` with `reasoning_effort: "max"` (highest tier on 4.7, verified empirically)
- **Auto-migration on `nexo update`**: `heal_runtime_profiles()` detects `claude-opus-4-6*` and silently migrates to `claude-opus-4-7` preserving `[1m]` suffix. Effort bumped to `max` if empty/xhigh/legacy.
- **Codex untouched**: GPT-5.4 / xhigh remains default.
- All public surfaces bumped to 5.6.0 (README, llms.txt, plugins, SKILL.md, CHANGELOG)
- Tests updated for new defaults (58 passing)

## Test plan
- [x] `pytest tests/test_client_preferences.py tests/test_agent_runner.py tests/test_cli_scripts.py` — 58 passed
- [ ] CI status checks pass
- [ ] After merge: tag v5.6.0, GitHub release, gh-pages sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)