### PR TITLE
fix: v5.6.1 — auto_update hardening (0-byte DB purge + Claude Code model sync)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/.well-known/llms.txt
+++ b/.well-known/llms.txt
@@ -1,6 +1,6 @@
 # NEXO Brain
 
-> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.6.0).
+> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.6.1).
 
 NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. It adds a local shared brain across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, smarter retrieval defaults, long-horizon overnight analysis, and 150+ MCP tools.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [5.6.1] - 2026-04-17
+
+### Fix: `nexo update` hardening — 0-byte DB orphans + Claude Code `settings.json` model sync
+
+Two small-but-sharp fixes in the update path. Both follow up on v5.6.0 (the
+Opus 4.6 → 4.7 default model upgrade) and unblock users who hit interrupted
+installs or noticed their Claude Code boot model was not actually changing.
+
+- **`src/auto_update.py`**: new `_purge_zero_byte_db_files()` scans
+  `NEXO_HOME` and `NEXO_HOME/data/` for 0-byte `.db` files and deletes
+  them before the pre-update backup runs. These are leftover shells from
+  interrupted installs or aborted `sqlite3.connect` calls. They were
+  breaking backup validation by masking the real DB during
+  `_find_primary_db_path` selection and by being copied into the backup
+  as empty DBs that later confused `_restore_dbs` on rollback. The
+  helper is called at the top of `_backup_dbs()`, never touches
+  `SRC_DIR` or `backups/`, and swallows errors so backup never aborts
+  on orphan cleanup.
+- **`src/client_sync.py` + `src/auto_update.py`**: new
+  `sync_claude_code_model()` helper keeps `~/.claude/settings.json` in
+  sync with the NEXO-recommended model. Claude Code reads its default
+  model from that file, **not** from `client_runtime_profiles`, so a
+  v5.6.0 heal was updating NEXO's internal profile while Claude Code
+  kept booting on the old model. The helper is called right after
+  `heal_runtime_profiles()` migrates the `claude_code` profile, and is
+  deliberately conservative: if `settings.json` is missing or has no
+  top-level `"model"` field it is a no-op (never seeds a field the user
+  never opted in to). Supersedes learning #391.
+
 ## [5.6.0] - 2026-04-16
 
 ### Feature: Default model upgrade — Opus 4.6 → 4.7

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@
 
 [Watch the overview video](https://nexo-brain.com/watch/) · [Watch on YouTube](https://www.youtube.com/watch?v=i2lkGhKyVqI) · [Open the infographic](https://nexo-brain.com/assets/nexo-brain-infographic-v5.png)
 
-Version `5.6.0` is the current packaged-runtime line: default model upgrade from Opus 4.6 to **Opus 4.7** with `reasoning_effort: "max"` (the new highest tier). Auto-migration on `nexo update` silently upgrades existing users from `claude-opus-4-6*` to `claude-opus-4-7` preserving the 1M context suffix. Codex profiles are untouched.
+Version `5.6.1` is the current packaged-runtime line: two small-but-sharp fixes in the `nexo update` path. 0-byte `.db` orphans from interrupted installs are now purged from `~/.nexo/` and `~/.nexo/data/` before the pre-update backup runs, so backup validation no longer trips over empty shells. And when `heal_runtime_profiles()` migrates the `claude_code` default (e.g. Opus 4.6 → 4.7), the new `sync_claude_code_model()` helper also updates the `model` field in `~/.claude/settings.json` — the file Claude Code actually reads — so the boot model matches NEXO's recommendation on the next launch.
+
+Previously in `5.6.0`: default model upgrade from Opus 4.6 to **Opus 4.7** with `reasoning_effort: "max"` (the new highest tier). Auto-migration on `nexo update` silently upgrades existing users from `claude-opus-4-6*` to `claude-opus-4-7` preserving the 1M context suffix. Codex profiles are untouched.
 
 Previously in `5.5.5`: data-loss guardrails + automatic self-heal. The updater now refuses to capture an already-wiped `nexo.db` into a `pre-update-*` snapshot (validated `sqlite3.backup` + pre-flight wipe guard + post-migration row-count gate), and an auto-heal restores `data/nexo.db` from the newest hourly backup on the next server boot when a wipe is detected. New `nexo recover` CLI + `nexo_recover` MCP tool.
 

--- a/blog/index.html
+++ b/blog/index.html
@@ -173,6 +173,13 @@
         <div class="blog-grid">
 
             <div class="blog-card">
+                <div class="blog-card-date">April 17, 2026</div>
+                <h2><a href="/blog/nexo-5-6-1/">NEXO 5.6.1: Update Path Hardening — 0-Byte DB Orphans + Claude Code Model Sync</a></h2>
+                <p>Two small-but-sharp fixes in <code>nexo update</code>. 0-byte <code>.db</code> orphans left behind by interrupted installs or aborted <code>sqlite3.connect</code> calls now get purged from <code>~/.nexo/</code> and <code>~/.nexo/data/</code> before the pre-update backup runs, so backup validation no longer trips over empty shells. And the new <code>sync_claude_code_model()</code> helper propagates the NEXO-recommended model into <code>~/.claude/settings.json</code> — the file Claude Code actually reads — when <code>heal_runtime_profiles()</code> migrates the <code>claude_code</code> default.</p>
+                <a href="/blog/nexo-5-6-1/" class="read-more">Read more &rarr;</a>
+            </div>
+
+            <div class="blog-card">
                 <div class="blog-card-date">April 16, 2026</div>
                 <h2><a href="/blog/nexo-5-5-6/">NEXO 5.5.6: Rate-Limiting the Backup/Restore/Export Tools</a></h2>
                 <p>Same-day follow-up to v5.5.5. The data-loss guardrails in v5.5.5 neutralised the <em>consequences</em> of the 2026-04-16 incident; v5.5.6 closes the <em>cause</em>. <code>nexo_backup_now</code>, <code>nexo_backup_restore</code>, and <code>export_user_bundle</code> now refuse reentrant calls inside 30 s / 60 s / 120 s windows, so a runaway MCP client stuck in a tool-use loop can no longer hammer <code>sqlite3.Connection.backup()</code> the way it did when this incident first struck.</p>

--- a/blog/nexo-5-6-1/index.html
+++ b/blog/nexo-5-6-1/index.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <title>NEXO 5.6.1: Update path hardening — 0-byte DB orphans + Claude Code model sync</title>
+    <meta name="description" content="NEXO Brain 5.6.1 hardens the update path: 0-byte DB orphans from interrupted installs are purged before backup, and the Claude Code settings.json model is kept in sync when NEXO migrates its recommended default.">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://nexo-brain.com/blog/nexo-5-6-1/">
+
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://nexo-brain.com/blog/nexo-5-6-1/">
+    <meta property="og:title" content="NEXO 5.6.1: Update path hardening — 0-byte DB orphans + Claude Code model sync">
+    <meta property="og:description" content="Two small-but-sharp fixes in the update path: purge 0-byte DB orphans before backup, and keep ~/.claude/settings.json model in sync with NEXO's recommended default.">
+    <meta property="og:image" content="https://nexo-brain.com/assets/og/og-blog.png">
+    <meta property="article:published_time" content="2026-04-17">
+    <meta property="article:author" content="Francisco Cerda Puigserver">
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="NEXO 5.6.1: Update path hardening — 0-byte DB orphans + Claude Code model sync">
+    <meta name="twitter:description" content="Purge 0-byte DB orphans before backup; keep Claude Code settings.json model in sync after a NEXO default-model migration.">
+    <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-blog.png">
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-1LNEMCJMS7"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-1LNEMCJMS7');
+    </script>
+
+    <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicon-32.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="192x192" href="/assets/icon-192.png">
+    <link rel="stylesheet" href="/assets/style.css">
+
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "NEXO 5.6.1: Update path hardening — 0-byte DB orphans + Claude Code model sync",
+        "description": "NEXO Brain 5.6.1 purges 0-byte DB orphans before the pre-update backup and propagates the NEXO-recommended model into ~/.claude/settings.json so Claude Code actually boots on the migrated model.",
+        "datePublished": "2026-04-17",
+        "dateModified": "2026-04-17",
+        "author": {
+            "@type": "Person",
+            "name": "Francisco Cerda Puigserver"
+        },
+        "publisher": {
+            "@type": "Organization",
+            "name": "WAzion",
+            "url": "https://www.wazion.com"
+        },
+        "mainEntityOfPage": {
+            "@type": "WebPage",
+            "@id": "https://nexo-brain.com/blog/nexo-5-6-1/"
+        },
+        "url": "https://nexo-brain.com/blog/nexo-5-6-1/",
+        "image": "https://nexo-brain.com/assets/og/og-blog.png",
+        "keywords": ["NEXO 5.6.1", "auto_update", "backup validation", "settings.json", "Claude Code", "model sync"]
+    }
+    </script>
+
+    <style>
+        .article-header { padding-top: 128px; padding-bottom: 40px; text-align: center; }
+        .article-meta { font-size: 14px; color: var(--text-muted); margin-bottom: 16px; }
+        .article-body {
+            max-width: 720px; margin: 0 auto; padding: 0 24px 80px;
+            font-size: 17px; line-height: 1.8; color: var(--text);
+        }
+        .article-body h2 { font-size: 28px; font-weight: 700; margin: 48px 0 16px; letter-spacing: -0.01em; }
+        .article-body p { margin-bottom: 20px; color: var(--text-muted); }
+        .article-body strong { color: var(--text); }
+        .article-body a { color: var(--purple-light); }
+        .article-body a:hover { color: var(--pink); }
+        .article-body code {
+            font-family: 'SF Mono', 'Fira Code', monospace;
+            font-size: 14px; color: var(--pink);
+            background: rgba(236, 72, 153, 0.1);
+            padding: 2px 8px; border-radius: 4px;
+        }
+        .article-back {
+            display: inline-flex; align-items: center; gap: 6px;
+            font-size: 14px; font-weight: 600; color: var(--text-muted);
+            margin-bottom: 24px;
+        }
+        .article-back:hover { color: var(--purple-light); }
+    </style>
+</head>
+<body>
+
+<nav>
+    <div class="container">
+        <a href="/" class="nav-logo">
+            <img src="/assets/logo-64.png" alt="NEXO Brain" class="logo-image">
+            <span class="logo-text">NEXO Brain</span>
+        </a>
+        <button class="mobile-menu-toggle" aria-label="Toggle navigation" onclick="toggleMobileMenu()">
+            <span></span><span></span><span></span>
+        </button>
+        <div class="nav-links">
+            <a href="/">Home</a>
+            <a href="/features/">Features</a>
+            <a href="/evolution/">Evolution</a>
+            <a href="/compare/">Compare</a>
+            <a href="/blog/">Blog</a>
+            <a href="/changelog/">Changelog</a>
+            <a href="/docs/">Docs</a>
+            <a href="https://github.com/wazionapps/nexo" class="nav-cta">GitHub</a>
+        </div>
+    </div>
+</nav>
+
+<section class="article-header">
+    <div class="container">
+        <a href="/blog/" class="article-back">&larr; Back to blog</a>
+        <div class="article-meta">April 17, 2026 &middot; Fix &middot; Update path hardening</div>
+        <h1 class="section-title" style="font-size:clamp(28px,4.5vw,48px);max-width:920px;margin:0 auto 16px;">NEXO 5.6.1: Update path hardening &mdash; 0-byte DB orphans + Claude Code model sync</h1>
+        <p class="section-subtitle" style="max-width:760px;margin:0 auto;">Two small-but-sharp fixes in <code>nexo update</code>. Both follow up on v5.6.0 (the Opus 4.6 &rarr; 4.7 default-model upgrade) and unblock users who hit interrupted installs or noticed Claude Code was still booting on the old model.</p>
+    </div>
+</section>
+
+<section>
+    <div class="article-body">
+
+        <h2>Fix 1: purge 0-byte <code>.db</code> orphans before backup</h2>
+        <p>Interrupted installs and aborted <code>sqlite3.connect</code> calls sometimes leave a <strong>0-byte <code>nexo.db</code></strong> file behind in <code>~/.nexo/</code> or <code>~/.nexo/data/</code>. Those empty shells broke the pre-update backup two different ways: they masked the real DB during <code>_find_primary_db_path</code> selection (whichever path was scanned first won), and they got copied into the backup as empty DBs that later confused <code>_restore_dbs</code> on rollback.</p>
+        <p>The new <code>_purge_zero_byte_db_files()</code> helper runs at the top of <code>_backup_dbs()</code>. It scans <code>NEXO_HOME</code> and its <code>data/</code> subdir, removes any <code>.db</code> file whose <code>st_size</code> is zero, never touches <code>SRC_DIR</code> (the repo checkout) or the <code>backups/</code> tree, and swallows errors so backup never aborts on orphan cleanup.</p>
+
+        <h2>Fix 2: keep <code>~/.claude/settings.json</code> in sync with the NEXO default</h2>
+        <p>Claude Code reads its default model from <code>~/.claude/settings.json</code>, <strong>not</strong> from NEXO&rsquo;s internal <code>client_runtime_profiles</code>. After v5.6.0 shipped, the 4.6 &rarr; 4.7 heal was correctly updating NEXO&rsquo;s profile while Claude Code happily kept booting on the old model until someone noticed and edited <code>settings.json</code> by hand.</p>
+        <p>The new <code>sync_claude_code_model()</code> helper in <code>client_sync.py</code> is called right after <code>heal_runtime_profiles()</code> migrates the <code>claude_code</code> profile. It is deliberately conservative:</p>
+        <p>&bull; If <code>settings.json</code> is missing, it is a no-op.<br>
+           &bull; If <code>settings.json</code> exists but has no top-level <code>&quot;model&quot;</code> field, it is a no-op (never seeds a field the user did not opt in to).<br>
+           &bull; If the value already matches, no rewrite happens.<br>
+           &bull; Otherwise the <code>model</code> field is updated and everything else in the file is preserved.</p>
+
+        <h2>How to upgrade</h2>
+        <p>Run <code>nexo update</code>. The two fixes land on your next update. Nothing else to do.</p>
+
+    </div>
+</section>
+
+<footer style="padding:48px 24px;text-align:center;font-size:13px;color:var(--text-muted);">
+    &copy; 2026 <a href="https://www.wazion.com" style="color:var(--purple-light);">WAzion</a>. NEXO Brain is open-source under <a href="https://github.com/wazionapps/nexo/blob/main/LICENSE" style="color:var(--purple-light);">AGPL-3.0</a>.
+</footer>
+
+<script src="/assets/main.js"></script>
+</body>
+</html>

--- a/changelog/index.html
+++ b/changelog/index.html
@@ -181,6 +181,17 @@
     </div>
 </section>
 
+<!-- v5.6.1 Update path hardening — 0-byte DB purge + Claude Code model sync -->
+<section id="v561" class="section-compact" style="background:linear-gradient(135deg,#09111f 0%,#14253a 50%,#1e3a5f 100%);">
+    <div class="container">
+        <div class="section-label">New in v5.6.1 <span style="opacity:.5;font-weight:400;">&mdash; April 17, 2026</span></div>
+        <h2 class="section-title">Update Path Hardening: 0-Byte DB Orphans + Claude Code Model Sync</h2>
+        <p class="section-subtitle">
+            Two small-but-sharp fixes in <code>nexo update</code>. 0-byte <code>.db</code> orphans from interrupted installs are now purged from <code>~/.nexo/</code> and <code>~/.nexo/data/</code> before the pre-update backup runs, so backup validation no longer trips over empty shells. And when <code>heal_runtime_profiles()</code> migrates the <code>claude_code</code> default, the new <code>sync_claude_code_model()</code> helper also updates the <code>model</code> field in <code>~/.claude/settings.json</code> &mdash; the file Claude Code actually reads &mdash; so the boot model matches NEXO&rsquo;s recommendation on the next launch.
+        </p>
+    </div>
+</section>
+
 <!-- v5.6.0 Default model upgrade Opus 4.6 → 4.7 -->
 <section id="v560" class="section-compact" style="background:linear-gradient(135deg,#09111f 0%,#14253a 50%,#1e3a5f 100%);">
     <div class="container">

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 5.6.0
+version: 5.6.1
 metadata:
   openclaw:
     requires:

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
         "operatingSystem": "macOS, Linux, Windows",
         "url": "https://nexo-brain.com",
         "downloadUrl": "https://www.npmjs.com/package/nexo-brain",
-        "softwareVersion": "5.6.0",
+        "softwareVersion": "5.6.1",
         "license": "https://www.gnu.org/licenses/agpl-3.0",
         "author": {
             "@type": "Organization",
@@ -697,7 +697,7 @@
     <div class="container">
         <div class="hero-badge fade-up">
             <span class="dot"></span>
-            <span id="version-badge">v5.6.0</span> &mdash; Default model upgrade: Opus 4.7 with reasoning_effort max
+            <span id="version-badge">v5.6.1</span> &mdash; Update-path hardening: 0-byte DB purge + Claude Code model sync
         </div>
         <div class="fade-up" style="display:flex;gap:8px;justify-content:center;margin-bottom:12px;">
             <img src="https://img.shields.io/npm/v/nexo-brain?color=7C3AED&label=npm" alt="npm version">

--- a/llms.txt
+++ b/llms.txt
@@ -1,9 +1,10 @@
 # NEXO Brain
 
-> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.6.0).
+> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v5.6.1).
 
 NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. It adds a local shared brain across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, smarter retrieval defaults, long-horizon overnight analysis, and 150+ MCP tools.
 
+v5.6.1: update-path hardening. Purge 0-byte .db orphans (interrupted installs) from ~/.nexo/ and ~/.nexo/data/ before the pre-update backup — they were masking the real DB and breaking validation. New sync_claude_code_model() helper propagates the NEXO-recommended model into ~/.claude/settings.json (which Claude Code actually reads) when heal_runtime_profiles() migrates the claude_code default. No-op when settings.json is missing or has no top-level "model" field.
 v5.6.0: default model upgrade Opus 4.6 → 4.7 with reasoning_effort "max". Auto-migration on `nexo update` silently upgrades users from claude-opus-4-6* to claude-opus-4-7, preserving 1M suffix. Codex untouched.
 v5.5.6: rate-limit the backup/restore/export tools in the MCP boundary. `nexo_backup_now` capped at 1/30s, `nexo_backup_restore` at 1/60s, `export_user_bundle` at 1/120s. A runaway MCP client (tool-use loop) can no longer hammer sqlite3.Connection.backup() the way the 2026-04-16 incident did. Same-day follow-up to v5.5.5.
 v5.5.5: data-loss guardrails + automatic self-heal. The updater now refuses to capture an already-wiped nexo.db into a pre-update snapshot (validated sqlite3.backup + pre-flight wipe guard + post-migration row-count gate), and an auto-heal restores ~/.nexo/data/nexo.db from the newest hourly backup on the next server boot when a wipe is detected. New `nexo recover` CLI + `nexo_recover` MCP tool with mandatory kill-MCP, pre-recover snapshot, and post-restore row-count validation.

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.6.0" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "5.6.1" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain \u2014 Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -157,6 +157,12 @@
     <priority>0.75</priority>
   </url>
   <url>
+    <loc>https://nexo-brain.com/blog/nexo-5-6-1/</loc>
+    <lastmod>2026-04-17</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.75</priority>
+  </url>
+  <url>
     <loc>https://nexo-brain.com/blog/nexo-5-6-0/</loc>
     <lastmod>2026-04-16</lastmod>
     <changefreq>monthly</changefreq>

--- a/src/auto_update.py
+++ b/src/auto_update.py
@@ -836,10 +836,53 @@ def _self_heal_if_wiped() -> dict | None:
     }
 
 
+def _purge_zero_byte_db_files() -> list[Path]:
+    """Delete 0-byte .db files in NEXO_HOME and its ``data/`` subdir.
+
+    These are orphans from interrupted installs / aborted ``sqlite3.connect``
+    calls. They break backup validation by (a) masking the real DB during
+    :func:`_find_primary_db_path` selection when two ``nexo.db`` paths
+    coexist, and (b) being copied into the backup as empty shells that later
+    confuse :func:`_restore_dbs` on rollback.
+
+    Never touches SRC_DIR (the repo checkout) or the ``backups/`` tree.
+    Returns the list of removed paths for logging; failures are swallowed
+    so backup never aborts because of orphan cleanup.
+    """
+    removed: list[Path] = []
+    scan_dirs: list[Path] = []
+    if NEXO_HOME.is_dir():
+        scan_dirs.append(NEXO_HOME)
+    if DATA_DIR.is_dir() and DATA_DIR != NEXO_HOME:
+        scan_dirs.append(DATA_DIR)
+    for scan_dir in scan_dirs:
+        try:
+            candidates = [f for f in scan_dir.glob("*.db") if f.is_file()]
+        except Exception:
+            continue
+        for path in candidates:
+            try:
+                if path.stat().st_size != 0:
+                    continue
+            except Exception:
+                continue
+            try:
+                path.unlink()
+                removed.append(path)
+                _log(f"Purged zero-byte DB orphan: {path}")
+            except Exception as e:
+                _log(f"Failed to purge zero-byte DB {path}: {e}")
+    return removed
+
+
 def _backup_dbs() -> str | None:
     """Snapshot all .db files before migration. Returns backup dir or None."""
     import sqlite3
     import time as _time
+    # Drop 0-byte .db orphans first — they mask the real DB during primary
+    # path selection and turn into empty shells in the backup, breaking both
+    # validation and rollback paths. Safe no-op when there are none.
+    _purge_zero_byte_db_files()
     timestamp = _time.strftime("%Y-%m-%d-%H%M%S")
     backup_dir = NEXO_HOME / "backups" / f"pre-autoupdate-{timestamp}"
 
@@ -2271,6 +2314,32 @@ def _run_runtime_post_sync(dest: Path = NEXO_HOME, progress_fn=None) -> tuple[bo
             for msg in heal_messages:
                 _emit_progress(progress_fn, msg)
                 actions.append("model-heal")
+            # Claude Code reads the default model from ~/.claude/settings.json,
+            # not from client_runtime_profiles. If the heal migrated the
+            # claude_code model (e.g. Opus 4.6 → 4.7) the internal profile is
+            # now correct but Claude Code keeps booting on the old model until
+            # settings.json is also updated. Propagate conservatively: only
+            # touch settings.json when it already has a "model" field.
+            existing_cc = existing_profiles.get("claude_code") if isinstance(existing_profiles.get("claude_code"), dict) else None
+            healed_cc = healed_profiles.get("claude_code") if isinstance(healed_profiles.get("claude_code"), dict) else None
+            old_cc_model = str((existing_cc or {}).get("model") or "")
+            new_cc_model = str((healed_cc or {}).get("model") or "")
+            if new_cc_model and new_cc_model != old_cc_model:
+                try:
+                    from client_sync import sync_claude_code_model
+                    sync_result = sync_claude_code_model(new_cc_model)
+                    if sync_result.get("action") == "updated":
+                        _emit_progress(
+                            progress_fn,
+                            f"Synced Claude Code settings.json model → '{new_cc_model}'.",
+                        )
+                        actions.append("claude-settings-model")
+                    elif not sync_result.get("ok"):
+                        actions.append(
+                            f"claude-settings-model-warning:{sync_result.get('reason', 'unknown')}"
+                        )
+                except Exception as e:
+                    actions.append(f"claude-settings-model-warning:{e}")
         normalized_preferences = normalize_client_preferences(schedule_payload)
         if normalized_preferences != {
             key: schedule_payload.get(key)

--- a/src/client_sync.py
+++ b/src/client_sync.py
@@ -802,6 +802,70 @@ def _sync_claude_code_settings(path: Path, server_config: dict) -> dict:
     }
 
 
+def sync_claude_code_model(
+    model: str,
+    *,
+    user_home: str | os.PathLike[str] | None = None,
+) -> dict:
+    """Propagate the NEXO-recommended ``model`` into ``~/.claude/settings.json``.
+
+    Claude Code actually reads the default model from ``settings.json``, not
+    from NEXO's internal ``client_runtime_profiles``. When a NEXO update
+    migrates a user's recommended default (e.g. Opus 4.6 → 4.7) the internal
+    profile changes but Claude Code keeps booting on the old model until this
+    file is rewritten.
+
+    Intentionally conservative — do NOT seed a field the user never had:
+      - ``settings.json`` missing              → skip.
+      - ``settings.json`` exists but has no
+        top-level ``"model"`` key              → skip.
+      - Current value already equals ``model`` → skip (no write).
+      - JSON read/write error                  → ``ok=False``, skip.
+      - Otherwise replace the value.
+
+    Returns a small result dict: ``{ok, action, path, reason?, previous_model?, new_model?}``.
+    ``action`` is ``"updated"`` only when the file was actually rewritten.
+    """
+    result: dict = {"ok": True, "action": "skipped", "path": ""}
+    if not model:
+        result["reason"] = "empty model"
+        return result
+    home_path = Path(user_home).expanduser() if user_home else None
+    path = _claude_code_settings_path(home_path)
+    result["path"] = str(path)
+    if not path.is_file():
+        result["reason"] = "settings.json missing"
+        return result
+    try:
+        raw = path.read_text()
+        payload = json.loads(raw) if raw.strip() else {}
+    except Exception as e:
+        result["ok"] = False
+        result["reason"] = f"read failed: {e}"
+        return result
+    if not isinstance(payload, dict):
+        result["reason"] = "settings.json is not a JSON object"
+        return result
+    if "model" not in payload:
+        result["reason"] = "no model field in settings.json"
+        return result
+    current = payload.get("model")
+    if current == model:
+        result["reason"] = "already matches"
+        return result
+    payload["model"] = model
+    try:
+        _write_json_object(path, payload)
+    except Exception as e:
+        result["ok"] = False
+        result["reason"] = f"write failed: {e}"
+        return result
+    result["action"] = "updated"
+    result["previous_model"] = current
+    result["new_model"] = model
+    return result
+
+
 def sync_claude_code(
     *,
     nexo_home: str | os.PathLike[str] | None = None,

--- a/tests/test_auto_update_zero_byte_db.py
+++ b/tests/test_auto_update_zero_byte_db.py
@@ -1,0 +1,120 @@
+"""Regression tests for auto_update._purge_zero_byte_db_files.
+
+Interrupted installs leave 0-byte nexo.db orphans in NEXO_HOME or its data/
+subdir. These orphans break backup validation: they look like an empty
+source to _validate_db_backup and mask the real DB in
+_find_primary_db_path. The purge helper must remove them before the
+backup runs, and must never touch non-empty .db files.
+"""
+
+from __future__ import annotations
+
+import sys
+import sqlite3
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REPO_SRC = REPO_ROOT / "src"
+
+if str(REPO_SRC) not in sys.path:
+    sys.path.insert(0, str(REPO_SRC))
+
+
+def _reload_auto_update(monkeypatch, home: Path):
+    """Reload auto_update against a tmp NEXO_HOME so module-level paths pick
+    up the fixture directory instead of Francisco's real ~/.nexo."""
+    import importlib
+    monkeypatch.setenv("NEXO_HOME", str(home))
+    import auto_update as au
+    importlib.reload(au)
+    return au
+
+
+def test_purge_removes_zero_byte_db_in_nexo_home(tmp_path, monkeypatch):
+    home = tmp_path / "nexo_home"
+    (home / "data").mkdir(parents=True)
+    orphan = home / "nexo.db"
+    orphan.touch()  # 0 bytes
+    assert orphan.stat().st_size == 0
+
+    au = _reload_auto_update(monkeypatch, home)
+    removed = au._purge_zero_byte_db_files()
+
+    assert orphan in removed
+    assert not orphan.exists()
+
+
+def test_purge_removes_zero_byte_db_in_data_subdir(tmp_path, monkeypatch):
+    home = tmp_path / "nexo_home"
+    data = home / "data"
+    data.mkdir(parents=True)
+    orphan = data / "nexo.db"
+    orphan.touch()
+
+    au = _reload_auto_update(monkeypatch, home)
+    removed = au._purge_zero_byte_db_files()
+
+    assert orphan in removed
+    assert not orphan.exists()
+
+
+def test_purge_keeps_non_empty_db(tmp_path, monkeypatch):
+    home = tmp_path / "nexo_home"
+    data = home / "data"
+    data.mkdir(parents=True)
+    good = data / "nexo.db"
+    conn = sqlite3.connect(str(good))
+    try:
+        conn.execute("CREATE TABLE t (id INTEGER)")
+        conn.execute("INSERT INTO t VALUES (1)")
+        conn.commit()
+    finally:
+        conn.close()
+    assert good.stat().st_size > 0
+    size_before = good.stat().st_size
+
+    au = _reload_auto_update(monkeypatch, home)
+    removed = au._purge_zero_byte_db_files()
+
+    assert removed == []
+    assert good.exists()
+    assert good.stat().st_size == size_before
+
+
+def test_purge_is_noop_when_no_db_files(tmp_path, monkeypatch):
+    home = tmp_path / "nexo_home"
+    (home / "data").mkdir(parents=True)
+
+    au = _reload_auto_update(monkeypatch, home)
+    removed = au._purge_zero_byte_db_files()
+
+    assert removed == []
+
+
+def test_backup_dbs_skips_zero_byte_orphan(tmp_path, monkeypatch):
+    """End-to-end: _backup_dbs must not copy a 0-byte orphan into the backup."""
+    home = tmp_path / "nexo_home"
+    data = home / "data"
+    data.mkdir(parents=True)
+    (home / "backups").mkdir()
+
+    orphan = home / "nexo.db"
+    orphan.touch()
+    real = data / "nexo.db"
+    conn = sqlite3.connect(str(real))
+    try:
+        conn.execute("CREATE TABLE learnings (id INTEGER)")
+        conn.commit()
+    finally:
+        conn.close()
+
+    au = _reload_auto_update(monkeypatch, home)
+    backup_dir = au._backup_dbs()
+
+    assert backup_dir is not None
+    backup_path = Path(backup_dir)
+    # The orphan has been purged from disk and must NOT appear in the backup.
+    assert not orphan.exists()
+    # The real DB IS in the backup.
+    assert (backup_path / "nexo.db").is_file()
+    assert (backup_path / "nexo.db").stat().st_size > 0

--- a/tests/test_client_sync_model.py
+++ b/tests/test_client_sync_model.py
@@ -1,0 +1,111 @@
+"""Tests for client_sync.sync_claude_code_model.
+
+Claude Code reads the default model from ~/.claude/settings.json, not from
+NEXO's internal client_runtime_profiles. When a NEXO default changes, this
+helper must propagate the new model — but only conservatively: never seed
+a "model" field the user did not already have.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REPO_SRC = REPO_ROOT / "src"
+
+if str(REPO_SRC) not in sys.path:
+    sys.path.insert(0, str(REPO_SRC))
+
+from client_sync import sync_claude_code_model  # noqa: E402
+
+
+def _settings_path(user_home: Path) -> Path:
+    return user_home / ".claude" / "settings.json"
+
+
+def _write_settings(user_home: Path, payload: dict) -> Path:
+    path = _settings_path(user_home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n")
+    return path
+
+
+def test_updates_model_when_field_present(tmp_path):
+    path = _write_settings(tmp_path, {
+        "model": "claude-opus-4-6[1m]",
+        "permissions": {"allow": ["Bash"]},
+    })
+
+    result = sync_claude_code_model("claude-opus-4-7[1m]", user_home=tmp_path)
+
+    assert result["ok"] is True
+    assert result["action"] == "updated"
+    assert result["previous_model"] == "claude-opus-4-6[1m]"
+    assert result["new_model"] == "claude-opus-4-7[1m]"
+    payload = json.loads(path.read_text())
+    assert payload["model"] == "claude-opus-4-7[1m]"
+    # Must preserve unrelated fields.
+    assert payload["permissions"] == {"allow": ["Bash"]}
+
+
+def test_skips_when_settings_missing(tmp_path):
+    result = sync_claude_code_model("claude-opus-4-7[1m]", user_home=tmp_path)
+
+    assert result["ok"] is True
+    assert result["action"] == "skipped"
+    assert result["reason"] == "settings.json missing"
+    # Must NOT create the file.
+    assert not _settings_path(tmp_path).exists()
+
+
+def test_skips_when_no_model_field(tmp_path):
+    """User never opted in to NEXO managing their model → do not seed it."""
+    path = _write_settings(tmp_path, {"permissions": {"allow": ["Bash"]}})
+
+    result = sync_claude_code_model("claude-opus-4-7[1m]", user_home=tmp_path)
+
+    assert result["ok"] is True
+    assert result["action"] == "skipped"
+    assert result["reason"] == "no model field in settings.json"
+    payload = json.loads(path.read_text())
+    assert "model" not in payload
+
+
+def test_skips_when_already_matches(tmp_path):
+    """No-op when model is already correct — avoid spurious rewrites/mtime bumps."""
+    path = _write_settings(tmp_path, {"model": "claude-opus-4-7[1m]"})
+    mtime_before = path.stat().st_mtime_ns
+
+    result = sync_claude_code_model("claude-opus-4-7[1m]", user_home=tmp_path)
+
+    assert result["action"] == "skipped"
+    assert result["reason"] == "already matches"
+    assert path.stat().st_mtime_ns == mtime_before
+
+
+def test_skips_empty_model_arg(tmp_path):
+    _write_settings(tmp_path, {"model": "claude-opus-4-6[1m]"})
+
+    result = sync_claude_code_model("", user_home=tmp_path)
+
+    assert result["action"] == "skipped"
+    assert result["reason"] == "empty model"
+    # Original value untouched.
+    payload = json.loads(_settings_path(tmp_path).read_text())
+    assert payload["model"] == "claude-opus-4-6[1m]"
+
+
+def test_handles_malformed_json_gracefully(tmp_path):
+    path = _settings_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{ this is not json")
+
+    result = sync_claude_code_model("claude-opus-4-7[1m]", user_home=tmp_path)
+
+    assert result["ok"] is False
+    assert result["action"] == "skipped"
+    assert "read failed" in result["reason"]
+    # Must not overwrite the malformed file.
+    assert path.read_text() == "{ this is not json"


### PR DESCRIPTION
## Summary

Two small-but-sharp fixes in `nexo update`, both follow-ups to v5.6.0:

- **FIX 1 (`src/auto_update.py`)**: new `_purge_zero_byte_db_files()` deletes 0-byte `.db` orphans from `~/.nexo/` and `~/.nexo/data/` before the pre-update backup runs. These were leftover shells from interrupted installs that masked the real DB during `_find_primary_db_path` selection and got copied into the backup as empty DBs, breaking validation and `_restore_dbs` rollback.
- **FIX 2 (`src/client_sync.py` + `src/auto_update.py`)**: new `sync_claude_code_model()` helper propagates the NEXO-recommended model into `~/.claude/settings.json` when `heal_runtime_profiles()` migrates the `claude_code` default. Claude Code reads the boot model from that file, not from `client_runtime_profiles`, so v5.6.0 users were getting the internal profile upgraded to Opus 4.7 but Claude Code kept booting on 4.6. Conservative by design: no-op when `settings.json` is missing, no-op when there is no top-level `"model"` field. Supersedes learning #391.

All public surfaces bumped to 5.6.1 (README, llms.txt, .well-known/llms.txt, index.html, blog, changelog, sitemap). New blog post at `/blog/nexo-5-6-1/`.

## Test plan

- [x] `pytest tests/test_auto_update_zero_byte_db.py tests/test_client_sync_model.py` — 11 new tests, all pass
- [x] `pytest tests/test_auto_update_* tests/test_client_sync* tests/test_packaged_update_runtime.py tests/test_update_*.py` — 71 tests, all green
- [x] `scripts/verify_release_readiness.py --ci` — passes (168 tests, changelog + public surfaces OK)
- [ ] CI (`Publish to all channels` / `lint` / `verify-*`) passes on the PR
- [ ] gh-pages website sync commit before tag push (learning #315)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
