### PR TITLE
fix: heartbeat re-syncs claude_session_id from coord file (NF-SESSION-CID-RESYNC)

### DIFF
--- a/src/tools_sessions.py
+++ b/src/tools_sessions.py
@@ -463,6 +463,42 @@ def handle_heartbeat(sid: str, task: str, context_hint: str = '') -> str:
         return _handle_heartbeat_inner(sid, task, context_hint)
 
 
+def _sync_claude_session_id(sid: str) -> None:
+    """Re-sync sessions.claude_session_id from the coordination file.
+
+    Claude Code rotates its PreToolUse session_id mid-run; long-lived NEXO
+    sessions then diverge from the current coordination file and the hook
+    fallback in hook_guardrails resolves to no row → surfaces as
+    'unknown target'. Called on every heartbeat so the mapping stays fresh.
+    """
+    try:
+        coord_file = NEXO_HOME / "coordination" / ".claude-session-id"
+        if not coord_file.exists():
+            return
+        current_cid = coord_file.read_text(encoding="utf-8").strip()
+        if not current_cid:
+            return
+        from db import get_db as _get_db
+        conn = _get_db()
+        row = conn.execute(
+            "SELECT claude_session_id, external_session_id FROM sessions WHERE sid = ?",
+            (sid,),
+        ).fetchone()
+        if not row:
+            return
+        stored_cid = (row["claude_session_id"] or "").strip()
+        stored_ext = (row["external_session_id"] or "").strip()
+        if stored_cid == current_cid and stored_ext == current_cid:
+            return
+        conn.execute(
+            "UPDATE sessions SET claude_session_id = ?, external_session_id = ? WHERE sid = ?",
+            (current_cid, current_cid, sid),
+        )
+        conn.commit()
+    except Exception:
+        pass
+
+
 def _handle_heartbeat_inner(sid: str, task: str, context_hint: str = '') -> str:
     """Inner body of handle_heartbeat — wrapped by tool_span above."""
     from db import get_db, update_last_heartbeat_ts
@@ -474,6 +510,9 @@ def _handle_heartbeat_inner(sid: str, task: str, context_hint: str = '') -> str:
         update_last_heartbeat_ts(sid)
     except Exception:
         pass
+    # v6.0.7 — keep claude_session_id aligned with Claude Code's rotating
+    # PreToolUse UUID so the hook guardrail can always resolve the NEXO sid.
+    _sync_claude_session_id(sid)
 
     # Temporal anchor — surface authoritative UTC time so clients never drift
     # on date/day-of-week across long sessions. Neutral ISO-8601, no locale,

--- a/tests/test_heartbeat_cid_resync.py
+++ b/tests/test_heartbeat_cid_resync.py
@@ -1,0 +1,118 @@
+"""v6.0.7 — nexo_heartbeat re-syncs sessions.claude_session_id.
+
+Verifies that when Claude Code rotates its PreToolUse session UUID and
+writes the new value to ``$NEXO_HOME/coordination/.claude-session-id``,
+the next heartbeat updates ``sessions.claude_session_id`` / ``external_session_id``
+to match. Without this sync, the hook guardrail's coordination-file
+fallback resolves to no row and surfaces "unknown target".
+"""
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC = REPO_ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+@pytest.fixture
+def isolated_home(tmp_path, monkeypatch):
+    import db._core as _core
+
+    tmp_db = str(tmp_path / "nexo.db")
+    monkeypatch.setenv("NEXO_HOME", str(tmp_path))
+    monkeypatch.setenv("NEXO_DB", tmp_db)
+    monkeypatch.setenv("NEXO_TEST_DB", tmp_db)
+    monkeypatch.setattr(_core, "DB_PATH", tmp_db, raising=False)
+    monkeypatch.setattr(_core, "_shared_conn", None, raising=False)
+
+    import importlib
+    import tools_sessions as _ts
+    importlib.reload(_ts)
+    monkeypatch.setattr(_ts, "NEXO_HOME", tmp_path, raising=False)
+
+    import db as db_pkg
+    db_pkg.init_db()
+    try:
+        yield tmp_path
+    finally:
+        try:
+            _core.close_db()
+        except Exception:
+            pass
+
+
+def _read_cid(sid: str) -> tuple[str, str]:
+    import db as db_pkg
+    conn = db_pkg.get_db()
+    row = conn.execute(
+        "SELECT claude_session_id, external_session_id FROM sessions WHERE sid = ?",
+        (sid,),
+    ).fetchone()
+    return (row["claude_session_id"] or "", row["external_session_id"] or "")
+
+
+def test_heartbeat_updates_claude_session_id_from_coord_file(isolated_home):
+    import db as db_pkg
+    from tools_sessions import handle_heartbeat
+
+    sid = f"nexo-{int(time.time())}-10001"
+    db_pkg.register_session(sid, "boot", claude_session_id="old-uuid-aaaa")
+    assert _read_cid(sid) == ("old-uuid-aaaa", "old-uuid-aaaa")
+
+    coord_dir = isolated_home / "coordination"
+    coord_dir.mkdir(parents=True, exist_ok=True)
+    (coord_dir / ".claude-session-id").write_text("new-uuid-bbbb\n", encoding="utf-8")
+
+    handle_heartbeat(sid, "work after rotation")
+
+    assert _read_cid(sid) == ("new-uuid-bbbb", "new-uuid-bbbb")
+
+
+def test_heartbeat_no_coord_file_leaves_cid_unchanged(isolated_home):
+    import db as db_pkg
+    from tools_sessions import handle_heartbeat
+
+    sid = f"nexo-{int(time.time())}-10002"
+    db_pkg.register_session(sid, "boot", claude_session_id="stable-uuid-cccc")
+
+    handle_heartbeat(sid, "work without rotation")
+
+    assert _read_cid(sid) == ("stable-uuid-cccc", "stable-uuid-cccc")
+
+
+def test_heartbeat_empty_coord_file_leaves_cid_unchanged(isolated_home):
+    import db as db_pkg
+    from tools_sessions import handle_heartbeat
+
+    sid = f"nexo-{int(time.time())}-10003"
+    db_pkg.register_session(sid, "boot", claude_session_id="stable-uuid-dddd")
+
+    coord_dir = isolated_home / "coordination"
+    coord_dir.mkdir(parents=True, exist_ok=True)
+    (coord_dir / ".claude-session-id").write_text("   \n", encoding="utf-8")
+
+    handle_heartbeat(sid, "work with empty coord")
+
+    assert _read_cid(sid) == ("stable-uuid-dddd", "stable-uuid-dddd")
+
+
+def test_heartbeat_same_cid_no_op(isolated_home):
+    import db as db_pkg
+    from tools_sessions import handle_heartbeat
+
+    sid = f"nexo-{int(time.time())}-10004"
+    db_pkg.register_session(sid, "boot", claude_session_id="same-uuid-eeee")
+
+    coord_dir = isolated_home / "coordination"
+    coord_dir.mkdir(parents=True, exist_ok=True)
+    (coord_dir / ".claude-session-id").write_text("same-uuid-eeee\n", encoding="utf-8")
+
+    handle_heartbeat(sid, "work same cid")
+
+    assert _read_cid(sid) == ("same-uuid-eeee", "same-uuid-eeee")


### PR DESCRIPTION
## Summary
- Complements v6.0.5 server-side fix for learning #411 (hook_guardrails coordination-file fallback).
- Long-lived Claude Code sessions (>1h) still surfaced "unknown target" because Claude Code rotates its PreToolUse UUID mid-session, so the stored `sessions.claude_session_id` diverged from the current coordination file.
- Adds `_sync_claude_session_id()` to `tools_sessions.py`, invoked inside `_handle_heartbeat_inner` — re-reads `$NEXO_HOME/coordination/.claude-session-id` and UPDATEs the row only when it differs. Best-effort (never throws).

Closes NF-SESSION-CID-RESYNC.

## Test plan
- [x] `pytest tests/test_heartbeat_cid_resync.py` — 4/4 pass (rotation applies, no-file preserves, empty-file preserves, same-cid no-op)
- [x] `pytest tests/test_heartbeat_updates_last_ts.py tests/test_heartbeat_adaptive_log_wire.py tests/test_tools_sessions_launchagents.py` — 10/10 still green
- [ ] Manual: long-lived Claude Code session, force UUID rotation, next Edit tool call succeeds without 'unknown target'

## Release note
Target v6.0.7. Before tagging, run `sync_release_artifacts.py` per learning #314.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
