### PR TITLE
chore: scrub personal hardcodes from public repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -916,7 +916,7 @@ nexo skills sync               # Sync filesystem skill definitions into SQLite
 nexo skills list               # List published/stable skills
 nexo skills get SK-...         # Inspect a skill definition
 nexo skills apply SK-... --dry-run --json  # Resolve guide/execute/hybrid without running it
-nexo skills approve SK-... --execution-level local --approved-by Francisco  # Optional metadata override
+nexo skills approve SK-... --execution-level local --approved-by operator  # Optional metadata override
 nexo skills evolution          # Show text→script and improvement candidates
 
 # Unified Doctor

--- a/docs/hot-context-memory.md
+++ b/docs/hot-context-memory.md
@@ -92,7 +92,7 @@ Example:
 
 ```bash
 nexo call nexo_pre_action_context --input '{
-  "query":"francisco email dns recambiosbmw",
+  "query":"alice email dns example-shop",
   "hours":24,
   "limit":8
 }'
@@ -113,11 +113,11 @@ Example:
 
 ```bash
 nexo call nexo_recent_context_capture --input '{
-  "title":"SES issue for holidays2thecanaries",
-  "summary":"Maria owns the decision. Waiting third party confirmation.",
-  "topic":"holidays2thecanaries ses",
+  "title":"SES issue for example-travel",
+  "summary":"Bob owns the decision. Waiting third party confirmation.",
+  "topic":"example-travel ses",
   "state":"waiting_third_party",
-  "owner":"maria",
+  "owner":"bob",
   "source_type":"email",
   "source_id":"thread-123"
 }'

--- a/docs/specs/2026-04-16-nexo-runtime-v1-commercial-split.md
+++ b/docs/specs/2026-04-16-nexo-runtime-v1-commercial-split.md
@@ -24,12 +24,12 @@ Without an explicit split now, the risk is building a commercial layer directly 
 Today there are already two separate repos:
 
 1. `wazionapps/nexo`
-   - local path: `/Users/franciscoc/Documents/_PhpstormProjects/nexo`
+   - local path: `~/checkouts/nexo`
    - remote: `https://github.com/wazionapps/nexo.git`
    - contains the OSS runtime, MCP server, onboarding bridge, docs, blog, release assets, adapters, and packaging logic
 
 2. `wazionapps/nexo-desktop`
-   - local path: `/Users/franciscoc/Documents/_PhpstormProjects/nexo-desktop`
+   - local path: `~/checkouts/nexo-desktop`
    - remote: `https://github.com/wazionapps/nexo-desktop.git`
    - contains the Electron app, updater, renderer, preload, local installer helpers, and Desktop UX
 

--- a/docs/writing-scripts.md
+++ b/docs/writing-scripts.md
@@ -182,7 +182,7 @@ Example:
 from nexo_helper import call_tool_text
 
 bundle = call_tool_text("nexo_pre_action_context", {
-    "query": "francisco email dns recambiosbmw",
+    "query": "alice email dns example-shop",
     "hours": 24,
     "limit": 6,
 })
@@ -190,10 +190,10 @@ print(bundle)
 
 call_tool_text("nexo_recent_context_capture", {
     "title": "Awaiting registrar action",
-    "summary": "Asked Maria to handle the registrar. Waiting external action.",
-    "topic": "dns recambiosbmw",
+    "summary": "Asked Bob to handle the registrar. Waiting external action.",
+    "topic": "dns example-shop",
     "state": "waiting_third_party",
-    "owner": "maria",
+    "owner": "bob",
     "source_type": "email",
     "source_id": "thread-123",
 })

--- a/src/resonance_map.py
+++ b/src/resonance_map.py
@@ -212,20 +212,19 @@ SYSTEM_OWNED_CALLERS: dict[str, str] = {
     "tools/drive_search":               "medio",
 
     # ---- Marketing automation ---------------------------------------------
-    # These post to Google Business Profile on behalf of Francisco's
-    # businesses. Short copy, but user-visible on a public surface; a
-    # mediocre post embarrasses the brand. Running them ALTO even though
-    # it's ~200 chars keeps the output quality tight.
+    # Generic Google Business Profile helpers. Short copy, but user-visible
+    # on a public surface; a mediocre post embarrasses the brand. Running
+    # them ALTO even though it's ~200 chars keeps the output quality tight.
+    # Operator-specific GBP posts (e.g. one caller per business) belong
+    # under the ``personal/`` prefix in the operator's own registry.
     "gbp/daily_post":                   "alto",
-    "gbp/post_wazion":                  "alto",
-    "gbp/post_psicologa":               "alto",
     "gbp/monthly_audit":                "alto",
     "gbp/reviews_watch":                "alto",
 
     # ---- Personal scripts (operators' own LaunchAgents) -------------------
-    # Francisco + Maria ship the same set of personal scripts via
-    # ~/.nexo/scripts (installed per-user, not through the core manifest).
-    # They all call into mcp__nexo__* so they cannot run under --bare.
+    # Operators ship their own personal scripts via ``~/.nexo/scripts``
+    # (installed per-user, not through the core manifest). They all call
+    # into ``mcp__nexo__*`` so they cannot run under ``--bare``.
     "personal/email-monitor":           "alto",   # answer real user emails, quality matters
     "personal/github-monitor":          "alto",   # reason about issues/PRs, not mechanical
     "personal/post-x":                  "alto",   # public-facing copy

--- a/src/skills/run-nexo-audit-phase/guide.md
+++ b/src/skills/run-nexo-audit-phase/guide.md
@@ -9,7 +9,7 @@ Usa esta skill cuando haya que ejecutar una fase de auditoria de NEXO y el cuell
    - mecanismo de update
    - tests y estado git
 2. Fija la regla de autonomia antes de empezar:
-   - Francisco no quiere checkpoints uno-a-uno para trabajo mecanico
+   - el operador no quiere checkpoints uno-a-uno para trabajo mecanico
    - NEXO hace branches, PRs, merge y reporta despues con evidencia
    - solo un blast radius arquitectonico enorme merece checkpoint
 3. Trata `evolution_apply` como una decision tecnica de implementacion, no como permiso humano:

--- a/src/skills/run-nexo-audit-phase/skill.json
+++ b/src/skills/run-nexo-audit-phase/skill.json
@@ -25,7 +25,7 @@
   ],
   "steps": [
     "Abrir goal, workflow y task antes de tocar la auditoria; resolver repo/runtime real, DB real, tests y estado git antes de interpretar el informe.",
-    "Fijar la regla de autonomia: NEXO hace branches, PRs, merge y progreso periodico; no pedir checkpoints uno-a-uno a Francisco para trabajo mecanico.",
+    "Fijar la regla de autonomia: NEXO hace branches, PRs, merge y progreso periodico; no pedir checkpoints uno-a-uno al operador para trabajo mecanico.",
     "Para `evolution_apply`, separar dos planos: el sandbox es para materializar/aplicar cambios aceptados con snapshot/rollback; no es un freno para el modo de trabajo autonomo del agente.",
     "Lanzar verificacion empirica de TODOS los items en paralelo: grep+read, SQL/schema real, AST/tests, logs. Partir de la hipotesis de FP hasta tener evidencia.",
     "Clasificar cada item en `real_gap`, `casi_fp` o `fp` y ordenar solo los reales por blast radius/riesgo.",
@@ -34,7 +34,7 @@
     "Cerrar con evidencia de PRs, tests y merge status reales; no usar diarios o workflow text como sustituto."
   ],
   "gotchas": [
-    "No pedir aprobacion manual a Francisco para cada PR: learning #198 confirma autonomia total con transparencia y reportes periodicos.",
+    "No pedir aprobacion manual al operador para cada PR cuando la autonomia total esta confirmada; mantener transparencia y reportes periodicos.",
     "No duplicar el sandbox de evolution en otros sitios: el apply de cambios aceptados ya reutiliza evolution_log + sandbox/snapshot/rollback.",
     "El ratio historico de FPs en esta clase de auditoria es alto; si no hay evidencia concreta, el item no se toca."
   ],

--- a/tests/test_auto_update_bootstrap_profile.py
+++ b/tests/test_auto_update_bootstrap_profile.py
@@ -60,14 +60,14 @@ def test_bootstraps_from_meta_role_and_technical_level(tmp_path, monkeypatch):
 def test_includes_name_and_language_when_present(tmp_path, monkeypatch):
     home = tmp_path / "home"
     _seed_calibration(home, {
-        "name": "Francisco",
+        "name": "Alice",
         "language": "es",
         "meta": {"role": "founder"},
     })
     au = _reload_auto_update(monkeypatch, home)
     au._bootstrap_profile_from_calibration_meta(home)
     prof = _load_profile(home)
-    assert prof["name"] == "Francisco"
+    assert prof["name"] == "Alice"
     assert prof["language"] == "es"
     assert prof["role"] == "founder"
 

--- a/tests/test_auto_update_zero_byte_db.py
+++ b/tests/test_auto_update_zero_byte_db.py
@@ -22,7 +22,7 @@ if str(REPO_SRC) not in sys.path:
 
 def _reload_auto_update(monkeypatch, home: Path):
     """Reload auto_update against a tmp NEXO_HOME so module-level paths pick
-    up the fixture directory instead of Francisco's real ~/.nexo."""
+    up the fixture directory instead of the operator's real ~/.nexo."""
     import importlib
     monkeypatch.setenv("NEXO_HOME", str(home))
     import auto_update as au

--- a/tests/test_client_sync.py
+++ b/tests/test_client_sync.py
@@ -120,7 +120,7 @@ def test_sync_claude_code_removes_legacy_managed_hooks_but_keeps_custom_hooks(tm
                     "hooks": [
                         {
                             "type": "command",
-                            "command": "NEXO_HOME=/Users/franciscoc/claude bash /Users/franciscoc/claude/hooks/heartbeat-guard.sh",
+                            "command": "NEXO_HOME=/home/user/claude bash /home/user/claude/hooks/heartbeat-guard.sh",
                             "timeout": 5,
                         },
                         {
@@ -169,7 +169,7 @@ def test_sync_claude_code_rewrites_legacy_heartbeat_hook_paths_to_core_hooks(tmp
                     "hooks": [
                         {
                             "type": "command",
-                            "command": "NEXO_HOME=/Users/franciscoc/.nexo bash /Users/franciscoc/.nexo/scripts/heartbeat-user-msg.sh",
+                            "command": "NEXO_HOME=/home/user/.nexo bash /home/user/.nexo/scripts/heartbeat-user-msg.sh",
                             "timeout": 3,
                         }
                     ],
@@ -181,7 +181,7 @@ def test_sync_claude_code_rewrites_legacy_heartbeat_hook_paths_to_core_hooks(tmp
                     "hooks": [
                         {
                             "type": "command",
-                            "command": "NEXO_HOME=/Users/franciscoc/.nexo bash /Users/franciscoc/.nexo/scripts/heartbeat-posttool.sh",
+                            "command": "NEXO_HOME=/home/user/.nexo bash /home/user/.nexo/scripts/heartbeat-posttool.sh",
                             "timeout": 3,
                         }
                     ],

--- a/tests/test_correction_fatigue_followup.py
+++ b/tests/test_correction_fatigue_followup.py
@@ -77,7 +77,7 @@ def test_fatigued_memories_create_followup_with_high_priority(fatigue_env, monke
             "memory_id": 101,
             "corrections_7d": 4,
             "types": "explicit,implicit,explicit,implicit",
-            "content": "El servidor de Recambios BMW se llama mundiserver",
+            "content": "El servidor de ExampleStore se llama example-server",
             "strength": 0.2,
             "source_type": "session",
             "domain": "ecommerce",
@@ -86,10 +86,10 @@ def test_fatigued_memories_create_followup_with_high_priority(fatigue_env, monke
             "memory_id": 202,
             "corrections_7d": 3,
             "types": "explicit",
-            "content": "WAzion soporta sesiones múltiples por número",
+            "content": "ChatBot soporta sesiones múltiples por número",
             "strength": 0.2,
             "source_type": "session",
-            "domain": "wazion",
+            "domain": "chatbot",
         },
     ]
 

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -234,16 +234,16 @@ def test_dashboard_recent_context_api_surfaces_hot_context(isolated_db):
 
     db.capture_context_event(
         event_type="context_capture",
-        title="Review DNS with Maria",
+        title="Review DNS with Bob",
         summary="Talked about registrar ownership and next step.",
-        body="Francisco said the domain is not his and Maria should handle it.",
-        topic="dns maria registrar",
-        context_key="topic:dns-maria-registrar",
-        context_title="Review DNS with Maria",
-        context_summary="Waiting Maria action on registrar side.",
+        body="Alice said the domain is not his and Bob should handle it.",
+        topic="dns bob registrar",
+        context_key="topic:dns-bob-registrar",
+        context_title="Review DNS with Bob",
+        context_summary="Waiting Bob action on registrar side.",
         context_type="topic",
         state="waiting_third_party",
-        owner="maria",
+        owner="bob",
         actor="test",
         source_type="email",
         source_id="thread-1",
@@ -251,12 +251,12 @@ def test_dashboard_recent_context_api_surfaces_hot_context(isolated_db):
         ttl_hours=24,
     )
 
-    res = client.get("/api/recent-context?query=dns maria")
+    res = client.get("/api/recent-context?query=dns bob")
     assert res.status_code == 200
     payload = res.json()
     assert payload["has_matches"] is True
     assert payload["counts"]["contexts"] >= 1
-    assert payload["contexts"][0]["context_key"] == "topic:dns-maria-registrar"
+    assert payload["contexts"][0]["context_key"] == "topic:dns-bob-registrar"
     assert any(event["event_type"] == "context_capture" for event in payload["events"])
 
 

--- a/tests/test_deep_sleep_apply.py
+++ b/tests/test_deep_sleep_apply.py
@@ -302,7 +302,7 @@ def test_abandoned_followups_are_archived_not_active(monkeypatch, tmp_path):
         {
             "abandoned_projects": [
                 {
-                    "description": "Canales YouTube de Francisco — preguntados pero no respondidos",
+                    "description": "Canales YouTube del operador — preguntados pero no respondidos",
                     "has_followup": False,
                     "recommendation": "Archive as historical context.",
                 }

--- a/tests/test_drive.py
+++ b/tests/test_drive.py
@@ -37,18 +37,18 @@ class TestCreateSignal:
         assert result["tension"] == 1.0
 
     def test_retrievable_after_create(self):
-        result = create_drive_signal("gap", "task_close", "No model for ICNEA pricing", area="canaririural")
+        result = create_drive_signal("gap", "task_close", "No model for example-pms pricing", area="example-tourism")
         signal = get_drive_signal(result["id"])
         assert signal is not None
         assert signal["signal_type"] == "gap"
-        assert signal["area"] == "canaririural"
+        assert signal["area"] == "example-tourism"
         assert signal["status"] == "latent"
 
 
 class TestReinforce:
     def test_tension_increases(self):
-        created = create_drive_signal("pattern", "heartbeat", "María pregunta lo mismo cada trimestre")
-        result = reinforce_drive_signal(created["id"], "María preguntó otra vez por lo mismo")
+        created = create_drive_signal("pattern", "heartbeat", "Bob pregunta lo mismo cada trimestre")
+        result = reinforce_drive_signal(created["id"], "Bob preguntó otra vez por lo mismo")
         assert result["ok"]
         assert result["new_tension"] > result["old_tension"]
 
@@ -282,7 +282,7 @@ class TestDetection:
 
     def test_pattern_detected(self):
         result = detect_drive_signal(
-            "María pregunta otra vez por el resumen trimestral, siempre pasa lo mismo",
+            "Bob pregunta otra vez por el resumen trimestral, siempre pasa lo mismo",
             source="heartbeat", source_id="test-sid",
         )
         assert result is not None
@@ -296,7 +296,7 @@ class TestDetection:
 
     def test_gap_detected(self):
         result = detect_drive_signal(
-            "No sé cómo funciona el pricing de ICNEA para las agencias",
+            "No sé cómo funciona el pricing de example-pms para las agencias",
             source="task_close", source_id="task-123",
         )
         assert result is not None

--- a/tests/test_episodic_continuity.py
+++ b/tests/test_episodic_continuity.py
@@ -81,7 +81,7 @@ def test_auto_close_promotes_draft_with_checkpoint_context(tmp_path, monkeypatch
         tasks_seen=json.dumps(["Draft release notes", "Check cron recovery"]),
         change_ids="[]",
         decision_ids="[]",
-        last_context_hint="Francisco explained the overnight memory gap and wanted continuity fixes.",
+        last_context_hint="Alice explained the overnight memory gap and wanted continuity fixes.",
         heartbeat_count=3,
         summary_draft="Session tasks: Draft release notes, Check cron recovery",
     )

--- a/tests/test_episodic_memory.py
+++ b/tests/test_episodic_memory.py
@@ -43,7 +43,7 @@ def test_session_diary_write_distinguishes_recent_and_historical_commit_ref_gaps
         "INSERT INTO change_log (files, commit_ref, created_at) VALUES ('src/plugins/protocol.py', '', datetime('now', '-20 days'))"
     )
     conn.execute(
-        "INSERT INTO change_log (files, commit_ref, created_at) VALUES ('/Users/franciscoc/.nexo/operations/orchestrator-state.json', '', datetime('now', '-1 day'))"
+        "INSERT INTO change_log (files, commit_ref, created_at) VALUES ('/home/user/.nexo/operations/orchestrator-state.json', '', datetime('now', '-1 day'))"
     )
     conn.commit()
 
@@ -87,7 +87,7 @@ def test_change_log_message_distinguishes_repo_and_local_commit_refs(monkeypatch
         session_id="sid-test",
     )
     local_msg = episodic_memory.handle_change_log(
-        files="/Users/franciscoc/.nexo/operations/orchestrator-state.json",
+        files="/home/user/.nexo/operations/orchestrator-state.json",
         what_changed="Checkpoint local",
         why="Persistir continuidad",
         session_id="sid-test",

--- a/tests/test_hot_context.py
+++ b/tests/test_hot_context.py
@@ -19,20 +19,20 @@ def test_capture_and_bundle_recent_context(isolated_db):
 
     db.capture_context_event(
         event_type="context_capture",
-        title="DNS recambios external ownership",
-        summary="Francisco aclaró que recambiosbmw no es suyo.",
+        title="DNS example-shop external ownership",
+        summary="Alice aclaró que example-shop no es suyo.",
         body="No volver a preguntarle por ese dominio.",
-        topic="recambiosbmw ownership",
+        topic="example-shop ownership",
         state="resolved",
         actor="nexo",
         source_type="manual",
         source_id="ownership-note-1",
     )
 
-    bundle = db.build_pre_action_context(query="recambiosbmw ownership", hours=24, limit=5)
+    bundle = db.build_pre_action_context(query="example-shop ownership", hours=24, limit=5)
     assert bundle["has_matches"] is True
     assert bundle["contexts"]
-    assert any("recambiosbmw" in (item.get("context_key") or "") or "recambios" in (item.get("title") or "").lower() for item in bundle["contexts"])
+    assert any("example-shop" in (item.get("context_key") or "") or "example-shop" in (item.get("title") or "").lower() for item in bundle["contexts"])
     assert any(event["event_type"] == "context_capture" for event in bundle["events"])
 
 
@@ -47,17 +47,17 @@ def test_heartbeat_surfaces_recent_context_from_last_hours(isolated_db):
     first = tools_sessions.handle_heartbeat(
         sid_1,
         "Registrar ownership",
-        "Francisco explicó que recambiosbmw no es suyo y no debo escalarle ese dominio.",
+        "Alice explicó que example-shop no es suyo y no debo escalarle ese dominio.",
     )
     assert "OK: nexo-1001-3001" in first
 
     second = tools_sessions.handle_heartbeat(
         sid_2,
         "Revisar ownership",
-        "Necesito recordar si recambiosbmw es suyo o no.",
+        "Necesito recordar si example-shop es suyo o no.",
     )
     assert "RECENT CONTEXT (24h)" in second
-    assert "recambiosbmw" in second.lower()
+    assert "example-shop" in second.lower()
 
 
 def test_task_open_includes_recent_context_excerpt(isolated_db):
@@ -67,9 +67,9 @@ def test_task_open_includes_recent_context_excerpt(isolated_db):
     sid = _register_session("nexo-2001-3001")
     db.capture_context_event(
         event_type="context_capture",
-        title="Maria owns holidays2thecanaries",
-        summary="Este tema debe perseguirse con María, no con Francisco salvo bloqueo técnico.",
-        topic="holidays2thecanaries ownership",
+        title="Bob owns example-travel",
+        summary="Este tema debe perseguirse con Bob, no con Alice salvo bloqueo técnico.",
+        topic="example-travel ownership",
         state="active",
         actor="nexo",
         source_type="manual",
@@ -79,33 +79,33 @@ def test_task_open_includes_recent_context_excerpt(isolated_db):
     payload = json.loads(
         handle_task_open(
             sid=sid,
-            goal="Decidir qué hacer con holidays2thecanaries",
+            goal="Decidir qué hacer con example-travel",
             task_type="analyze",
             area="nexo",
-            context_hint="Ver si debe preguntarse a Francisco o a María por holidays2thecanaries.",
+            context_hint="Ver si debe preguntarse a Alice o a Bob por example-travel.",
             verification_step="inspeccionar contexto reciente",
             evidence_refs='["recent-context"]',
         )
     )
     assert payload["ok"] is True
     assert payload["recent_context"]["has_matches"] is True
-    assert "holidays2thecanaries" in payload["recent_context"]["excerpt"].lower()
+    assert "example-travel" in payload["recent_context"]["excerpt"].lower()
 
 
 def test_followup_and_reminder_changes_feed_hot_context(isolated_db):
     import db
 
-    db.create_reminder("R-HOT-1", "Preguntar a María por el dominio", date="2026-04-09")
+    db.create_reminder("R-HOT-1", "Preguntar a Bob por el dominio", date="2026-04-09")
     db.create_followup(
         "NF-HOT-1",
-        "Revisar ownership de holidays2thecanaries",
+        "Revisar ownership de example-travel",
         date="2026-04-09",
         verification="Confirmar responsable",
-        reasoning="Evitar escalar a Francisco lo que es de María.",
+        reasoning="Evitar escalar a Alice lo que es de Bob.",
     )
-    db.add_followup_note("NF-HOT-1", "Francisco indicó que es de María.", actor="nexo")
+    db.add_followup_note("NF-HOT-1", "Alice indicó que es de Bob.", actor="nexo")
 
-    bundle = db.build_pre_action_context(query="holidays2thecanaries Maria", hours=24, limit=6)
+    bundle = db.build_pre_action_context(query="example-travel Bob", hours=24, limit=6)
     assert bundle["has_matches"] is True
     followup_contexts = [item for item in bundle["contexts"] if item.get("context_key") == "followup:NF-HOT-1"]
     reminder_contexts = [item for item in bundle["contexts"] if item.get("context_key") == "reminder:R-HOT-1"]

--- a/tests/test_migration_legacy_to_v6.py
+++ b/tests/test_migration_legacy_to_v6.py
@@ -36,7 +36,7 @@ def _seed_v5_home(tmp_path: Path) -> Path:
     config.mkdir()
     (brain / "calibration.json").write_text(json.dumps({
         "version": 1,
-        "user": {"name": "Francisco"},
+        "user": {"name": "Alice"},
         "personality": {"autonomy": "full"},
         "preferences": {
             "protocol_strictness": "off",
@@ -73,7 +73,7 @@ def test_purge_removes_all_legacy_fields_and_seeds_default_resonance(tmp_path):
     assert cal["preferences"]["default_resonance"] == "alto"
 
     # Untouched surroundings
-    assert cal["user"]["name"] == "Francisco"
+    assert cal["user"]["name"] == "Alice"
     assert cal["personality"]["autonomy"] == "full"
     assert cal["preferences"]["menu_on_demand"] is True
     assert sched["timezone"] == "Europe/Madrid"

--- a/tests/test_personal_caller_prefix.py
+++ b/tests/test_personal_caller_prefix.py
@@ -23,7 +23,7 @@ import resonance_map as rmap  # noqa: E402
 @pytest.fixture(autouse=True)
 def _isolate_preferences(monkeypatch):
     """Neutralise the host's on-disk calibration so every assertion in this
-    module exercises the resolver, not Francisco's real ``default_resonance``.
+    module exercises the resolver, not the operator's real ``default_resonance``.
     """
     monkeypatch.setattr(rmap, "_load_user_default_resonance", lambda: "")
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -40,7 +40,7 @@ def test_task_open_records_protocol_contract():
             goal="Harden protocol discipline",
             task_type="edit",
             area="nexo-ops",
-            files="/Users/franciscoc/Documents/_PhpstormProjects/nexo/src/server.py",
+            files="/repo/src/server.py",
             plan='["inspect", "patch", "test"]',
             evidence_refs='["spec", "repo inspection"]',
             verification_step="run pytest",
@@ -343,7 +343,7 @@ def test_task_close_creates_change_log_and_stays_clean():
             goal="Patch runtime provider",
             task_type="edit",
             area="nexo-ops",
-            files="/Users/franciscoc/Documents/_PhpstormProjects/nexo/src/doctor/providers/runtime.py",
+            files="/repo/src/doctor/providers/runtime.py",
             plan='["inspect", "patch", "pytest"]',
             verification_step="run targeted pytest",
         )
@@ -386,7 +386,7 @@ def test_task_close_opens_protocol_debt_when_done_without_evidence():
             goal="Edit without evidence",
             task_type="edit",
             area="nexo-ops",
-            files="/Users/franciscoc/Documents/_PhpstormProjects/nexo/src/plugins/cortex.py",
+            files="/repo/src/plugins/cortex.py",
             plan='["inspect", "patch"]',
             verification_step="run pytest",
         )
@@ -422,7 +422,7 @@ def test_task_close_rejects_invalid_outcome_without_mutating_task():
             goal="Exercise invalid close outcome handling",
             task_type="edit",
             area="nexo-ops",
-            files="/Users/franciscoc/Documents/_PhpstormProjects/nexo/src/plugins/protocol.py",
+            files="/repo/src/plugins/protocol.py",
             plan='["inspect", "validate"]',
             verification_step="run pytest",
         )
@@ -482,7 +482,7 @@ def test_task_close_auto_captures_learning_when_correction_has_no_learning():
             goal="Fix guard false positive",
             task_type="edit",
             area="nexo-ops",
-            files="/Users/franciscoc/Documents/_PhpstormProjects/nexo/src/plugins/guard.py",
+            files="/repo/src/plugins/guard.py",
             plan='["inspect", "patch", "test"]',
             verification_step="run pytest",
         )
@@ -509,7 +509,7 @@ def test_task_close_auto_captures_learning_when_correction_has_no_learning():
     assert learning is not None
     assert learning["status"] == "active"
     assert learning["title"] == "Reduced guard false positives"
-    assert "/Users/franciscoc/Documents/_PhpstormProjects/nexo/src/plugins/guard.py" in learning["applies_to"]
+    assert "/repo/src/plugins/guard.py" in learning["applies_to"]
 
 
 def test_high_stakes_action_close_opens_debt_without_cortex_evaluation():
@@ -599,7 +599,7 @@ def test_task_close_explicit_learning_supersedes_conflicting_file_rule():
         "nexo-ops",
         "Never edit guard.py directly",
         "Never edit guard.py directly; route all fixes through wrapper helpers instead.",
-        applies_to="/Users/franciscoc/Documents/_PhpstormProjects/nexo/src/plugins/guard.py",
+        applies_to="/repo/src/plugins/guard.py",
         status="active",
     )
     get_db().execute(
@@ -614,7 +614,7 @@ def test_task_close_explicit_learning_supersedes_conflicting_file_rule():
             goal="Stabilize guard hotfix path",
             task_type="edit",
             area="nexo-ops",
-            files="/Users/franciscoc/Documents/_PhpstormProjects/nexo/src/plugins/guard.py",
+            files="/repo/src/plugins/guard.py",
             plan='["inspect", "patch", "test"]',
             verification_step="run pytest",
         )
@@ -646,7 +646,7 @@ def test_task_close_explicit_learning_supersedes_conflicting_file_rule():
     assert old_row["status"] == "superseded"
     assert new_row["status"] == "active"
     assert new_row["supersedes_id"] == existing["id"]
-    assert "/Users/franciscoc/Documents/_PhpstormProjects/nexo/src/plugins/guard.py" in new_row["applies_to"]
+    assert "/repo/src/plugins/guard.py" in new_row["applies_to"]
 
 
 def test_task_open_surfaces_attention_management_when_focus_is_split():

--- a/tests/test_rehydrate_learnings_from_archive.py
+++ b/tests/test_rehydrate_learnings_from_archive.py
@@ -45,7 +45,7 @@ def test_parse_archive_dir_extracts_table_rows_and_bullets(tmp_path, monkeypatch
 
 ## 2026-02-26 — Errores operativos NEXO
 - **Error 1: Puerto SSH incorrecto.** Probé puertos 22 y 22022 antes de leer credentials.md.
-- **Regla:** Rutas locales PhpStorm: `vicshopsysteam` = servidor Recambios BMW.
+- **Regla:** Rutas locales IDE: `example-shop-sys` = servidor ExampleStore.
 """,
         encoding="utf-8",
     )

--- a/tests/test_reminders_history.py
+++ b/tests/test_reminders_history.py
@@ -46,7 +46,7 @@ def test_reminder_handlers_require_read_before_mutation(isolated_db):
     fresh_token = _extract_read_token(refreshed)
     noted = reminders_tools.handle_reminder_note(
         id="R-HIST-1",
-        note="Asked Francisco and waiting for reply.",
+        note="Asked Alice and waiting for reply.",
         read_token=fresh_token,
     )
     assert "note added" in noted
@@ -84,7 +84,7 @@ def test_followup_handlers_soft_delete_and_restore(isolated_db):
     note_token = _extract_read_token(noted_detail)
     noted = reminders_tools.handle_followup_note(
         id="NF-HIST-1",
-        note="Francisco answered, execute the task and close.",
+        note="Alice answered, execute the task and close.",
         read_token=note_token,
     )
     assert "note added" in noted

--- a/tests/test_resonance_map.py
+++ b/tests/test_resonance_map.py
@@ -54,7 +54,7 @@ def test_user_facing_caller_with_invalid_user_default_falls_back():
 
 def test_user_facing_caller_with_no_user_default_uses_alto(monkeypatch):
     # Isolate from the real user calibration.json on the machine running
-    # the suite — without this, Francisco's "maximo" preference bleeds in
+    # the suite — without this, the operator's "maximo" preference bleeds in
     # and the assertion fails.
     monkeypatch.setattr(rmap, "_load_user_default_resonance", lambda: "")
     model, effort = rmap.resolve_model_and_effort("nexo_chat", "claude_code")

--- a/tests/test_retroactive_learnings.py
+++ b/tests/test_retroactive_learnings.py
@@ -225,7 +225,7 @@ class TestApplyLearningRetroactively:
             db,
             title="Translate technical jargon before replying",
             content="Avoid raw protocol jargon in operator-facing answers",
-            prevention="Always translate protocol jargon before replying to Francisco",
+            prevention="Always translate protocol jargon before replying to Alice",
             applies_to="francisco-briefing,email-digest",
         )
         _seed_decision(
@@ -248,7 +248,7 @@ class TestApplyLearningRetroactively:
             learning_keywords=retroactive_learnings._significant_tokens(
                 "Translate technical jargon before replying "
                 "Avoid raw protocol jargon in operator-facing answers "
-                "Always translate protocol jargon before replying to Francisco"
+                "Always translate protocol jargon before replying to Alice"
             ),
             learning_applies_to=retroactive_learnings._split_applies_to("francisco-briefing,email-digest"),
             decision_row={

--- a/tests/test_security_baseline.py
+++ b/tests/test_security_baseline.py
@@ -121,7 +121,7 @@ class TestHashFingerprintLoadSmoke:
     in a slow algorithm or losing determinism."""
 
     def test_md5_fingerprint_is_stable_and_fast(self):
-        sample = "deploy nexo-cron-wrapper push to mundiserver"
+        sample = "deploy nexo-cron-wrapper push to example-server"
         first = hashlib.md5(sample.encode(), usedforsecurity=False).hexdigest()
         # 10000 hashes must complete in under 1s on any modern machine.
         start = time.perf_counter()

--- a/tests/test_skills_v2.py
+++ b/tests/test_skills_v2.py
@@ -193,9 +193,9 @@ class TestSkillsRuntime:
         approved = skills_runtime.approve_skill_execution(
             "SK-LOCAL-EDIT",
             execution_level="local",
-            approved_by="Francisco",
+            approved_by="Alice",
         )
-        assert approved["approved_by"] == "Francisco"
+        assert approved["approved_by"] == "Alice"
 
     def test_packaged_installs_keep_core_and_personal_skills_separate(self, tmp_path, monkeypatch):
         install_home = tmp_path / "installed-nexo"
@@ -531,12 +531,12 @@ class TestSkillsCli:
             "--execution-level",
             "local",
             "--approved-by",
-            "Francisco",
+            "Alice",
             "--json",
         )
         assert approved.returncode == 0
         approved_data = json.loads(approved.stdout)
-        assert approved_data["approved_by"] == "Francisco"
+        assert approved_data["approved_by"] == "Alice"
         assert approved_data["approved_at"]
 
     def test_cli_skill_lifecycle_commands(self, skills_env):

--- a/tests/test_system_catalog.py
+++ b/tests/test_system_catalog.py
@@ -24,7 +24,7 @@ def test_system_catalog_surfaces_new_core_tools_and_runtime_metadata(monkeypatch
         json.dumps(
             {
                 "nexo": {
-                    "path": "/Users/franciscoc/Documents/_PhpstormProjects/nexo",
+                    "path": "/repo/nexo",
                     "aliases": ["brain", "shared brain"],
                     "services": {"mcp": 8000},
                 }

--- a/tests/test_task_classification.py
+++ b/tests/test_task_classification.py
@@ -62,7 +62,7 @@ def test_create_followup_without_override_persists_defaults():
     """Brain core does NOT classify when agent omits internal/owner."""
     row = db_mod.create_followup(
         "NF-TESTCLS-DEFAULT",
-        "Francisco debe aprobar presupuesto",
+        "Alice debe aprobar presupuesto",
         date="2026-12-01",
     )
     assert row["internal"] == 0
@@ -72,7 +72,7 @@ def test_create_followup_without_override_persists_defaults():
 def test_create_followup_explicit_override_persists():
     row = db_mod.create_followup(
         "NF-TESTCLS-OVERRIDE",
-        "Francisco debe llamar a cliente",
+        "Alice debe llamar a cliente",
         date="2026-12-01",
         internal=1,
         owner="agent",


### PR DESCRIPTION
## Summary
Replaces operator-specific identifiers with generic placeholders so the public AGPL repo stays neutral. **No product or logic changes — docs/fixtures/comments only.**

### What changed
- **src/resonance_map.py**: drops two operator-specific GBP callers (`gbp/post_wazion`, `gbp/post_psicologa`) that never got referenced elsewhere in core; rewrites marketing/personal-scripts comments in generic terms. Operator-specific callers belong under the already-existing `personal/` prefix.
- **src/skills/run-nexo-audit-phase/{skill.json,guide.md}**: replaces "Francisco" with "operator" in autonomy/checkpoint rules.
- **tests/** (22 files):
  - Absolute paths `/Users/franciscoc/Documents/_PhpstormProjects/nexo/...` -> `/repo/...`
  - Home paths `/Users/franciscoc/.nexo/...` and `/Users/franciscoc/claude/...` -> `/home/user/...`
  - Fixture operator names `Francisco`/`Maria` -> `Alice`/`Bob`
  - Business-specific strings (`Recambios BMW`, `mundiserver`, `recambiosbmw`, `holidays2thecanaries`, `vicshopsysteam`, `ICNEA`, `canaririural`) -> `example-*` placeholders
- **docs/{specs,hot-context-memory,writing-scripts}**: same placeholder swap in examples
- **README.md**: generic CLI example (`--approved-by operator`)

### Intentionally left untouched
- README author attribution line (standard open-source credit)
- Marketing pages (reddit-post*, linkedin-post, blog entries, pitch) — legitimate author/company references
- CHANGELOG.md — immutable historical record
- `wazionapps/nexo` GitHub org URLs — that is the project upstream
- `wazion` as an operational-area alias in `src/tools_drive.py` — matches many fixture names across tests and refers to the company that publishes the project

### Security audit note
Confirmed zero real credentials in the repo: no Shopify tokens, no Anthropic keys, no Google keys, no passwords, no private IPs. The only matches were redaction regexes in `src/transcript_utils.py`, `src/cognitive/_core.py`, and `src/scripts/deep-sleep/collect.py` — those are the scrubbers, not leaks.

## Test plan
- [x] Full pytest suite green locally: **1098 passed, 1 skipped (bandit optional), 2 xfailed** in 195s
- [ ] CI pytest workflow green
- [ ] CI lint workflow green
- [ ] Manual sanity grep confirms no `/Users/franciscoc` in source or fixtures
