### PR TITLE
v6.0.7 hotfix: strict hook "unknown target" edge case

### DIFF
--- a/src/hook_guardrails.py
+++ b/src/hook_guardrails.py
@@ -158,17 +158,47 @@ def _extract_touched_files(tool_input) -> list[str]:
 
 
 def _resolve_nexo_sid(conn, external_session_id: str) -> str:
-    if not external_session_id.strip():
-        return ""
-    row = conn.execute(
+    """Resolve a Claude Code UUID to the NEXO session SID it belongs to.
+
+    Primary correlation: exact match on external_session_id / claude_session_id.
+
+    v6.0.7 hotfix — secondary correlation: when no exact match is found AND
+    there is exactly ONE NEXO session with a fresh heartbeat (last update in
+    the past 5 minutes), fall back to that session. This closes the "unknown
+    target" edge case where Claude Code rotated its internal session_id
+    mid-session (e.g. after a compaction) without rewriting the coordination
+    file. The single-session gate prevents mis-attribution when two Claude
+    instances run concurrently.
+    """
+    clean_external = external_session_id.strip()
+    if clean_external:
+        row = conn.execute(
+            """SELECT sid
+               FROM sessions
+               WHERE external_session_id = ? OR claude_session_id = ?
+               ORDER BY last_update_epoch DESC
+               LIMIT 1""",
+            (clean_external, clean_external),
+        ).fetchone()
+        if row:
+            return str(row["sid"])
+
+    # Fallback: exactly one session heartbeated in the last 5 minutes.
+    # We prefer this narrow window so we never silently attribute work to
+    # a stale session. If the caller has zero or multiple active sessions,
+    # fail closed (return "") and let the caller raise missing_startup.
+    import time as _time
+    cutoff_epoch = _time.time() - 300.0
+    rows = conn.execute(
         """SELECT sid
            FROM sessions
-           WHERE external_session_id = ? OR claude_session_id = ?
-           ORDER BY last_update_epoch DESC
-           LIMIT 1""",
-        (external_session_id.strip(), external_session_id.strip()),
-    ).fetchone()
-    return str(row["sid"]) if row else ""
+           WHERE last_update_epoch >= ?
+           ORDER BY last_update_epoch DESC""",
+        (cutoff_epoch,),
+    ).fetchall()
+    if len(rows) == 1:
+        return str(rows[0]["sid"])
+    return ""
 
 
 def _find_open_task_for_file(conn, sid: str, filepath: str) -> dict | None:

--- a/src/tools_sessions.py
+++ b/src/tools_sessions.py
@@ -273,6 +273,34 @@ def handle_session_export_bundle(sid: str = "", path: str = "") -> str:
     )
 
 
+def _autodetect_claude_session_id() -> str:
+    """Read the Claude Code UUID from the SessionStart coordination file.
+
+    SessionStart hook (see ~/.nexo/hooks/session-start.sh) writes the current
+    Claude Code session UUID to ``<NEXO_HOME>/coordination/.claude-session-id``
+    so the PreToolUse guardrail can correlate. Any nexo_startup call that
+    forgets to pass session_token would otherwise create a session row
+    without a UUID, and the strict hook would later block every edit with
+    "unknown target" (learning #411 / #403 / #404).
+
+    Mirrors the fallback logic in hook_guardrails._read_claude_session_id_from_coordination
+    so both sides of the correlation agree on the same UUID.
+    """
+    import os as _os
+    from pathlib import Path as _Path
+    # NEXO_HOME is always set when the MCP server spawned this process; prefer it.
+    # When absent (bare scripts), fall back to the default ~/.nexo path. No
+    # "check both" path — callers that explicitly set NEXO_HOME to an isolated
+    # directory want the isolation respected.
+    env = _os.environ.get("NEXO_HOME", "").strip()
+    base = _Path(env).expanduser() if env else (_Path.home() / ".nexo")
+    path = base / "coordination" / ".claude-session-id"
+    try:
+        return path.read_text().strip()
+    except (FileNotFoundError, OSError):
+        return ""
+
+
 def handle_startup(
     task: str = "Startup",
     claude_session_id: str = "",
@@ -292,8 +320,21 @@ def handle_startup(
     sid = _generate_sid()
     cleaned = clean_stale_sessions()
     linked_session_id = (session_token or claude_session_id or "").strip()
+    # v6.0.7 hotfix: when the caller did not pass an explicit UUID, fall back to
+    # the Claude Code SessionStart UUID written by the SessionStart hook to
+    # <NEXO_HOME>/coordination/.claude-session-id. This fixes the "unknown
+    # target" strict-hook block observed for operators whose scripts call
+    # nexo_startup() without propagating the hook payload (bug revisited
+    # after PR #208 — PR #208 covered the hook side; this covers the
+    # startup side so every session row is born correlated).
+    if not linked_session_id:
+        linked_session_id = _autodetect_claude_session_id()
     inferred_client = (session_client or "").strip()
     if not inferred_client and claude_session_id and not session_token:
+        inferred_client = "claude_code"
+    if not inferred_client and linked_session_id:
+        # If we recovered the UUID from the coordination file, the only
+        # client that writes there is Claude Code.
         inferred_client = "claude_code"
     register_session(
         sid,

--- a/tests/test_hook_unknown_target_v607.py
+++ b/tests/test_hook_unknown_target_v607.py
@@ -1,0 +1,160 @@
+"""Regression tests for v6.0.7 hotfix — strict hook 'unknown target' edge case.
+
+Covers two sides of the correlation:
+
+1. handle_startup without an explicit UUID reads the SessionStart
+   coordination file and stamps the row, so later correlation from the
+   PreToolUse hook succeeds on claude_session_id alone.
+
+2. _resolve_nexo_sid falls back to the single-active-session when the
+   UUID from the payload (or coordination file) does not match any
+   session — covering the case where Claude Code rotated its internal
+   session_id mid-session without rewriting the coordination file.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import time
+
+import pytest
+
+sys.path.insert(
+    0,
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")),
+)
+
+
+@pytest.fixture(autouse=True)
+def hook_hotfix_runtime(isolated_db, tmp_path, monkeypatch):
+    import db._core as db_core
+    import db._sessions as db_sessions
+    import db
+    import tools_sessions
+    import hook_guardrails
+
+    importlib.reload(db_core)
+    importlib.reload(db_sessions)
+    importlib.reload(db)
+    importlib.reload(tools_sessions)
+    importlib.reload(hook_guardrails)
+
+    # Fake NEXO_HOME so coordination file is isolated per test
+    fake_home = tmp_path / "nexo_home"
+    (fake_home / "coordination").mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("NEXO_HOME", str(fake_home))
+    yield fake_home
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Primary fix — handle_startup auto-detect from coordination file
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_startup_autodetects_uuid_when_caller_forgets(hook_hotfix_runtime):
+    from tools_sessions import handle_startup
+    from db import get_db
+    uuid = "abcdef12-3456-7890-abcd-ef1234567890"
+    (hook_hotfix_runtime / "coordination" / ".claude-session-id").write_text(uuid)
+    out = handle_startup(task="tests")
+    assert "SID:" in out
+    sid = out.split("SID:")[1].strip().split()[0]
+    row = get_db().execute(
+        "SELECT claude_session_id, external_session_id, session_client FROM sessions WHERE sid = ?",
+        (sid,),
+    ).fetchone()
+    assert row is not None
+    assert row["claude_session_id"] == uuid
+    assert row["external_session_id"] == uuid
+    assert row["session_client"] == "claude_code"
+
+
+def test_startup_explicit_token_takes_precedence(hook_hotfix_runtime):
+    from tools_sessions import handle_startup
+    from db import get_db
+    coord_uuid = "cccc1111-2222-3333-4444-555555555555"
+    explicit_uuid = "eeee9999-8888-7777-6666-444444444444"
+    (hook_hotfix_runtime / "coordination" / ".claude-session-id").write_text(coord_uuid)
+    out = handle_startup(task="tests", session_token=explicit_uuid)
+    sid = out.split("SID:")[1].strip().split()[0]
+    row = get_db().execute(
+        "SELECT claude_session_id FROM sessions WHERE sid = ?", (sid,)
+    ).fetchone()
+    assert row["claude_session_id"] == explicit_uuid
+
+
+def test_startup_no_coordination_no_crash(hook_hotfix_runtime):
+    """Coordination file missing (non-Claude client, fresh install) still works."""
+    from tools_sessions import handle_startup
+    from db import get_db
+    out = handle_startup(task="tests")
+    sid = out.split("SID:")[1].strip().split()[0]
+    row = get_db().execute("SELECT claude_session_id FROM sessions WHERE sid = ?", (sid,)).fetchone()
+    assert row is not None
+    assert row["claude_session_id"] == ""
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Secondary fix — _resolve_nexo_sid single-session fallback
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_resolve_matches_exact_uuid(hook_hotfix_runtime):
+    from hook_guardrails import _resolve_nexo_sid
+    from tools_sessions import handle_startup
+    from db import get_db
+    uuid = "11111111-2222-3333-4444-555555555555"
+    (hook_hotfix_runtime / "coordination" / ".claude-session-id").write_text(uuid)
+    out = handle_startup(task="tests")
+    sid = out.split("SID:")[1].strip().split()[0]
+    resolved = _resolve_nexo_sid(get_db(), uuid)
+    assert resolved == sid
+
+
+def test_resolve_falls_back_when_single_recent_session(hook_hotfix_runtime):
+    from hook_guardrails import _resolve_nexo_sid
+    from tools_sessions import handle_startup
+    from db import get_db
+    # Start a session without a coordination UUID
+    out = handle_startup(task="tests")
+    sid = out.split("SID:")[1].strip().split()[0]
+    # UUID the payload passes does NOT match anything in the table.
+    resolved = _resolve_nexo_sid(get_db(), "totally-unknown-uuid-99999")
+    # Single session heartbeated < 5 min ago → fallback attributes to it.
+    assert resolved == sid
+
+
+def test_resolve_blocks_when_multiple_active_sessions(hook_hotfix_runtime):
+    """With >1 active session we must NOT guess — fall back to "" (block)."""
+    from hook_guardrails import _resolve_nexo_sid
+    from tools_sessions import handle_startup
+    from db import get_db
+    handle_startup(task="session A")
+    handle_startup(task="session B")
+    resolved = _resolve_nexo_sid(get_db(), "unknown-uuid")
+    assert resolved == ""
+
+
+def test_resolve_blocks_when_session_is_stale(hook_hotfix_runtime):
+    """Even with a single session, if it's older than 5 min, do not fall back."""
+    from hook_guardrails import _resolve_nexo_sid
+    from tools_sessions import handle_startup
+    from db import get_db
+    out = handle_startup(task="stale")
+    sid = out.split("SID:")[1].strip().split()[0]
+    # Force last_update_epoch 10 min in the past
+    get_db().execute(
+        "UPDATE sessions SET last_update_epoch = ? WHERE sid = ?",
+        (time.time() - 600, sid),
+    )
+    get_db().commit()
+    resolved = _resolve_nexo_sid(get_db(), "another-unknown-uuid")
+    assert resolved == ""
+
+
+def test_resolve_empty_input_without_sessions(hook_hotfix_runtime):
+    """No sessions at all and empty input → blocks."""
+    from hook_guardrails import _resolve_nexo_sid
+    from db import get_db
+    assert _resolve_nexo_sid(get_db(), "") == ""


### PR DESCRIPTION
## Resumen

Cierra el edge case que PR #208 no cubrió: el hook PreToolUse en strict mode bloquea cualquier edición con "unknown target" incluso cuando `nexo_startup` sí se llamó.

## Root cause

Dos caminos de código que cada uno cubría media causa:

1. **`handle_startup` (src/tools_sessions.py)** — si el caller no pasaba `session_token` / `claude_session_id`, la fila en `sessions` quedaba con `claude_session_id=""`. Cualquier PreToolUse posterior no podía correlar el UUID del payload → `missing_startup`.
2. **`_resolve_nexo_sid` (src/hook_guardrails.py)** — sólo matcheaba UUIDs exactos. Si Claude Code rotaba su internal session_id mid-session (observado tras compactación / subagent handoff) sin reescribir el coordination file, la correlación fallaba silenciosamente aunque hubiera una única sesión NEXO activa claramente objetivo.

## Fixes

- `handle_startup` ahora autodetecta el UUID de Claude Code desde `<NEXO_HOME>/coordination/.claude-session-id` si no recibió token explícito.
- Nuevo helper `_autodetect_claude_session_id()` respeta `NEXO_HOME` exclusivamente cuando está seteado (isolation tests y multi-tenant), fallback a `~/.nexo` sólo cuando ausente.
- `_resolve_nexo_sid` gana correlación secundaria: si exact match falla y hay **exactamente una** sesión NEXO con heartbeat <5 min, atribuye la call. El gate de single-session previene mis-attribution con dos Claudes concurrentes; sesiones stale (>5 min) también se ignoran.

## Tests

- Nuevo `tests/test_hook_unknown_target_v607.py` — 8 casos:
  - autodetect / explicit / no-coordination paths
  - exact match / single-session fallback / multi-session block / stale-session block / empty input

## Verificación

```bash
NEXO_HOME=/tmp/nexo-hotfix-test PYTHONPATH=src python3 -m pytest tests/test_hook_unknown_target_v607.py -v
# 8 passed in 1.70s

NEXO_HOME=/tmp/nexo-hotfix-test PYTHONPATH=src python3 -m pytest tests/ -q   --ignore=tests/test_agent_runner.py --ignore=tests/test_agent_runner_bare_mode.py   --ignore=tests/test_v6_fresh_install_skip.py
# 1078 passed, 1 skipped, 2 xfailed in 84.80s — zero regressions
```

## Test plan

- [x] Unit tests aislados pasan
- [x] Suite completa aislada pasa
- [ ] Review manual del diff por Francisco
- [ ] Smoke test en runtime real tras merge + tag v6.0.7

## Origen

Detectado durante implementación de Protocol Enforcer Fase 2 (worktree `fase2-impl`). Workaround vigente: edits via Bash + Python heredoc. Este fix elimina el workaround para cualquier operador con strict mode.

Refs: PR #208 (prior hotfix), learnings #403 / #404 / #411.