### PR TITLE
fix: bootstrap packaged auto-close-sessions imports

### DIFF
--- a/src/auto_close_sessions.py
+++ b/src/auto_close_sessions.py
@@ -11,8 +11,15 @@ import os
 import sys
 import datetime
 
-# Ensure we can import from the source directory
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# Ensure imports work both from ``src/auto_close_sessions.py`` and from the
+# packaged runtime copy under ``core/scripts/auto_close_sessions.py``.
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_IMPORT_ROOTS = [_THIS_DIR]
+if os.path.basename(_THIS_DIR) == "scripts":
+    _IMPORT_ROOTS.append(os.path.dirname(_THIS_DIR))
+for _candidate in _IMPORT_ROOTS:
+    if _candidate and _candidate not in sys.path:
+        sys.path.insert(0, _candidate)
 os.environ["NEXO_SKIP_FS_INDEX"] = "1"  # Skip FTS rebuild on import
 
 from db import (

--- a/tests/test_auto_close_sessions_packaged.py
+++ b/tests/test_auto_close_sessions_packaged.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SOURCE_SCRIPT = REPO_ROOT / "src" / "auto_close_sessions.py"
+
+
+def test_packaged_auto_close_sessions_imports_db_from_core_parent(tmp_path):
+    runtime_root = tmp_path / "runtime"
+    core_dir = runtime_root / "core"
+    scripts_dir = core_dir / "scripts"
+    db_dir = core_dir / "db"
+    scripts_dir.mkdir(parents=True)
+    db_dir.mkdir(parents=True)
+
+    (scripts_dir / "auto_close_sessions.py").write_text(SOURCE_SCRIPT.read_text())
+    (db_dir / "__init__.py").write_text(
+        "def init_db():\n    return None\n"
+        "def get_db():\n    return None\n"
+        "def get_diary_draft(_sid):\n    return None\n"
+        "def delete_diary_draft(_sid):\n    return None\n"
+        "def get_orphan_sessions(_ttl):\n    return []\n"
+        "def read_checkpoint(_sid):\n    return {}\n"
+        "def write_session_diary(**_kwargs):\n    return None\n"
+        "def now_epoch():\n    return 0\n"
+        "SESSION_STALE_SECONDS = 900\n"
+    )
+
+    probe = (
+        "import importlib.util, pathlib; "
+        f"p = pathlib.Path({str(scripts_dir / 'auto_close_sessions.py')!r}); "
+        "spec = importlib.util.spec_from_file_location('auto_close_sessions_packaged', p); "
+        "mod = importlib.util.module_from_spec(spec); "
+        "spec.loader.exec_module(mod); "
+        "print('ok')"
+    )
+    env = {
+        **os.environ,
+        "NEXO_HOME": str(runtime_root),
+        "NEXO_CODE": str(runtime_root),
+        "PYTHONPATH": str(runtime_root),
+    }
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"


### PR DESCRIPTION
## Summary
- fix packaged auto-close-sessions.py bootstrap so runtime cron imports db from core/
- add regression test for packaged runtime import path
- closes release blocker found on live installed runtime before v7.1.0 publish

## Validation
- pytest -q tests/test_auto_close_sessions_packaged.py tests/test_cli_scripts.py tests/test_runtime_update_contract.py
- pytest -q
- bash scripts/check_no_personal_data.sh
- python3 scripts/verify_release_readiness.py --ci