### PR TITLE
Fix v7.1.3 release portability gate

### DIFF
--- a/tests/test_user_data_portability.py
+++ b/tests/test_user_data_portability.py
@@ -240,5 +240,5 @@ def test_import_user_bundle_bypasses_export_rate_limit_for_safety_backup(portabi
     result = mod.import_user_bundle(str(archive_path))
     assert result["ok"] is True
     assert export_calls == [False]
-    assert result["warning_codes"] == ["no_sections"]
+    assert result["warning_codes"] == ["bundle_older", "no_sections"]
     assert "init_db" in calls


### PR DESCRIPTION
## Summary
- align the portability regression with the new bundle-version warning behavior on 7.1.3

## Validation
- pytest -q tests/test_user_data_portability.py tests/test_backup_rate_limit.py