### PR TITLE
brain: expose protocol/cortex/guard/workflow as MCP tools + migration m49

### DIFF
--- a/src/db/_schema.py
+++ b/src/db/_schema.py
@@ -1222,6 +1222,21 @@ def _m45_personal_scripts_origin(conn):
     _migrate_add_index(conn, "idx_personal_scripts_origin", "personal_scripts", "origin")
 
 
+def _m49_protocol_guard_ack_backfill(conn):
+    """Backfill protocol guard-ack columns for installs that already marked
+    migration v22 as applied before those columns were added to the migration
+    body.
+
+    This must remain a standalone migration instead of reusing v22 because
+    real runtimes can legitimately sit at schema version 48 with an older
+    ``protocol_tasks`` shape. Re-running ``init_db()`` skips v22 once it is
+    recorded in ``schema_migrations``, so the missing columns never land
+    without a new version.
+    """
+    _migrate_add_column(conn, "protocol_tasks", "guard_acknowledged", "INTEGER NOT NULL DEFAULT 0")
+    _migrate_add_column(conn, "protocol_tasks", "guard_acknowledged_at", "TEXT DEFAULT NULL")
+
+
 def _m44_entities_extended_schema(conn):
     """Plan Consolidado 0.3 — extend entities with aliases/metadata/source/confidence/access_mode.
 
@@ -1291,6 +1306,7 @@ MIGRATIONS = [
     (46, "email_accounts", _m46_email_accounts),
     (47, "email_operator_accounts", _m47_email_operator_accounts),
     (48, "email_agent_contract_backfill", _m48_email_agent_contract_backfill),
+    (49, "protocol_guard_ack_backfill", _m49_protocol_guard_ack_backfill),
 ]
 
 

--- a/src/server.py
+++ b/src/server.py
@@ -68,6 +68,17 @@ from tools_automation_sessions import (
     handle_session_log_create,
     handle_session_log_close,
 )
+from plugins.cortex import handle_cortex_check
+from plugins.guard import handle_guard_check
+from plugins.protocol import (
+    handle_task_acknowledge_guard,
+    handle_task_close,
+    handle_task_open,
+)
+from plugins.workflow import (
+    handle_workflow_open,
+    handle_workflow_update,
+)
 from plugin_loader import load_all_plugins, load_plugin, remove_plugin, list_plugins
 from tools_guardian import handle_guardian_rule_override
 
@@ -326,6 +337,220 @@ def nexo_stop(sid: str) -> str:
         sid: Session ID to close."""
     from tools_sessions import handle_stop
     return handle_stop(sid)
+
+
+@mcp.tool
+def nexo_cortex_check(
+    goal: str,
+    task_type: str = "answer",
+    plan: str = "[]",
+    known_facts: str = "[]",
+    unknowns: str = "[]",
+    constraints: str = "[]",
+    evidence_refs: str = "[]",
+    verification_step: str = "",
+) -> str:
+    """Cognitive pre-action check. Call before significant actions."""
+    return handle_cortex_check(
+        goal,
+        task_type,
+        plan,
+        known_facts,
+        unknowns,
+        constraints,
+        evidence_refs,
+        verification_step,
+    )
+
+
+@mcp.tool
+def nexo_guard_check(files: str = "", area: str = "") -> str:
+    """Check learnings relevant to files/area before reading or editing code."""
+    return handle_guard_check(files, area)
+
+
+@mcp.tool
+def nexo_task_open(
+    sid: str,
+    goal: str = "",
+    task_type: str = "answer",
+    area: str = "",
+    files: str = "",
+    project_hint: str = "",
+    plan: str = "[]",
+    known_facts: str = "[]",
+    unknowns: str = "[]",
+    constraints: str = "[]",
+    evidence_refs: str = "[]",
+    verification_step: str = "",
+    stakes: str = "",
+    context_hint: str = "",
+    description: str = "",
+) -> str:
+    """Open a protocol task for non-trivial work."""
+    return handle_task_open(
+        sid,
+        goal,
+        task_type,
+        area,
+        files,
+        project_hint,
+        plan,
+        known_facts,
+        unknowns,
+        constraints,
+        evidence_refs,
+        verification_step,
+        stakes,
+        context_hint,
+        description,
+    )
+
+
+@mcp.tool
+def nexo_task_acknowledge_guard(
+    sid: str,
+    task_id: str,
+    learning_ids: str = "",
+    note: str = "",
+) -> str:
+    """Acknowledge blocking guard rules on an open protocol task."""
+    return handle_task_acknowledge_guard(sid, task_id, learning_ids, note)
+
+
+@mcp.tool
+def nexo_task_close(
+    sid: str,
+    task_id: str,
+    outcome: str = "",
+    evidence: str = "",
+    files_changed: str = "",
+    correction_happened: bool = False,
+    change_summary: str = "",
+    change_why: str = "",
+    change_risks: str = "",
+    change_verify: str = "",
+    triggered_by: str = "",
+    followup_needed: bool = False,
+    followup_id: str = "",
+    followup_description: str = "",
+    followup_date: str = "",
+    followup_verification: str = "",
+    followup_reasoning: str = "",
+    learning_category: str = "",
+    learning_title: str = "",
+    learning_content: str = "",
+    learning_reasoning: str = "",
+    outcome_notes: str = "",
+    result: str = "",
+    summary: str = "",
+    verification: str = "",
+    evidence_refs: str = "",
+) -> str:
+    """Close a protocol task with evidence and optional artifacts."""
+    return handle_task_close(
+        sid,
+        task_id,
+        outcome,
+        evidence,
+        files_changed,
+        correction_happened,
+        change_summary,
+        change_why,
+        change_risks,
+        change_verify,
+        triggered_by,
+        followup_needed,
+        followup_id,
+        followup_description,
+        followup_date,
+        followup_verification,
+        followup_reasoning,
+        learning_category,
+        learning_title,
+        learning_content,
+        learning_reasoning,
+        outcome_notes,
+        result,
+        summary,
+        verification,
+        evidence_refs,
+    )
+
+
+@mcp.tool
+def nexo_workflow_open(
+    sid: str,
+    goal: str,
+    goal_id: str = "",
+    workflow_kind: str = "general",
+    protocol_task_id: str = "",
+    idempotency_key: str = "",
+    priority: str = "normal",
+    steps: str = "[]",
+    shared_state: str = "{}",
+    next_action: str = "",
+    owner: str = "",
+) -> str:
+    """Open a durable workflow run for long multi-step work."""
+    return handle_workflow_open(
+        sid,
+        goal,
+        goal_id,
+        workflow_kind,
+        protocol_task_id,
+        idempotency_key,
+        priority,
+        steps,
+        shared_state,
+        next_action,
+        owner,
+    )
+
+
+@mcp.tool
+def nexo_workflow_update(
+    run_id: str,
+    step_key: str = "",
+    step_title: str = "",
+    step_status: str = "",
+    run_status: str = "",
+    checkpoint_label: str = "",
+    summary: str = "",
+    shared_state: str = "",
+    state_patch: str = "",
+    evidence: str = "",
+    next_action: str = "",
+    retry_after: str = "",
+    max_retries: int = 0,
+    retry_policy: str = "",
+    requires_approval: bool = False,
+    compensation: str = "",
+    actor: str = "",
+    owner: str = "",
+) -> str:
+    """Update a workflow run with a replayable checkpoint."""
+    return handle_workflow_update(
+        run_id,
+        step_key,
+        step_title,
+        step_status,
+        run_status,
+        checkpoint_label,
+        summary,
+        shared_state,
+        state_patch,
+        evidence,
+        next_action,
+        retry_after,
+        max_retries,
+        retry_policy,
+        requires_approval,
+        compensation,
+        actor,
+        owner,
+    )
+
 
 @mcp.tool
 def nexo_status(keyword: str = "") -> str:

--- a/tests/test_protocol_guard_ack_backfill_migration.py
+++ b/tests/test_protocol_guard_ack_backfill_migration.py
@@ -1,0 +1,111 @@
+"""Regression test for runtimes stuck at schema version 48 without the
+protocol guard-ack columns.
+
+This reproduces the real-world drift where migration v22 was recorded long
+before ``guard_acknowledged`` / ``guard_acknowledged_at`` were added to its
+body, so subsequent ``init_db()`` calls skipped the missing columns forever.
+"""
+from __future__ import annotations
+
+import importlib
+import sqlite3
+
+
+def _column_exists(conn, table: str, column: str) -> bool:
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return any(r[1] == column for r in rows)
+
+
+def test_v49_backfills_protocol_guard_columns_for_v48_runtime(tmp_path, monkeypatch):
+    test_db = str(tmp_path / "nexo.db")
+
+    monkeypatch.setenv("NEXO_HOME", str(tmp_path))
+    monkeypatch.setenv("NEXO_DB", test_db)
+    monkeypatch.setenv("NEXO_TEST_DB", test_db)
+
+    import db._core as db_core
+    import db as db_pkg
+
+    db_core.close_db()
+    monkeypatch.setattr(db_core, "DB_PATH", test_db, raising=False)
+    monkeypatch.setattr(db_core, "_shared_conn", None, raising=False)
+
+    conn = sqlite3.connect(test_db)
+    conn.execute(
+        """
+        CREATE TABLE protocol_tasks (
+            task_id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL,
+            goal TEXT NOT NULL,
+            task_type TEXT NOT NULL DEFAULT 'answer',
+            area TEXT DEFAULT '',
+            project_hint TEXT DEFAULT '',
+            context_hint TEXT DEFAULT '',
+            files TEXT DEFAULT '[]',
+            plan TEXT DEFAULT '[]',
+            known_facts TEXT DEFAULT '[]',
+            unknowns TEXT DEFAULT '[]',
+            constraints TEXT DEFAULT '[]',
+            evidence_refs TEXT DEFAULT '[]',
+            verification_step TEXT DEFAULT '',
+            cortex_mode TEXT DEFAULT '',
+            cortex_check_id TEXT DEFAULT '',
+            cortex_blocked_reason TEXT DEFAULT '',
+            cortex_warnings TEXT DEFAULT '[]',
+            cortex_rules TEXT DEFAULT '[]',
+            opened_with_guard INTEGER NOT NULL DEFAULT 0,
+            opened_with_rules INTEGER NOT NULL DEFAULT 0,
+            guard_has_blocking INTEGER NOT NULL DEFAULT 0,
+            guard_summary TEXT DEFAULT '',
+            must_verify INTEGER NOT NULL DEFAULT 0,
+            must_change_log INTEGER NOT NULL DEFAULT 0,
+            must_learning_if_corrected INTEGER NOT NULL DEFAULT 1,
+            must_write_diary_on_close INTEGER NOT NULL DEFAULT 0,
+            status TEXT NOT NULL DEFAULT 'open',
+            close_evidence TEXT DEFAULT '',
+            files_changed TEXT DEFAULT '[]',
+            correction_happened INTEGER NOT NULL DEFAULT 0,
+            change_log_id INTEGER,
+            learning_id INTEGER,
+            followup_id TEXT DEFAULT '',
+            outcome_notes TEXT DEFAULT '',
+            opened_at TEXT DEFAULT (datetime('now')),
+            closed_at TEXT DEFAULT NULL,
+            response_mode TEXT DEFAULT '',
+            response_confidence INTEGER DEFAULT 0,
+            response_reasons TEXT DEFAULT '[]',
+            response_high_stakes INTEGER DEFAULT 0
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE schema_migrations (
+            version INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            applied_at TEXT DEFAULT (datetime('now'))
+        )
+        """
+    )
+    conn.executemany(
+        "INSERT INTO schema_migrations (version, name) VALUES (?, ?)",
+        [(version, f"migration_{version}") for version in range(1, 49)],
+    )
+    conn.commit()
+    conn.close()
+
+    importlib.reload(db_core)
+    importlib.reload(db_pkg)
+    monkeypatch.setattr(db_core, "DB_PATH", test_db, raising=False)
+    monkeypatch.setattr(db_core, "_shared_conn", None, raising=False)
+
+    db_pkg.init_db()
+
+    conn = db_pkg.get_db()
+    assert _column_exists(conn, "protocol_tasks", "guard_acknowledged")
+    assert _column_exists(conn, "protocol_tasks", "guard_acknowledged_at")
+
+    count = conn.execute(
+        "SELECT COUNT(*) FROM schema_migrations WHERE version = 49"
+    ).fetchone()[0]
+    assert count == 1

--- a/tests/test_server_protocol_exports.py
+++ b/tests/test_server_protocol_exports.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_SRC = Path(__file__).resolve().parents[1] / "src"
+if str(REPO_SRC) not in sys.path:
+    sys.path.insert(0, str(REPO_SRC))
+
+
+def test_server_exposes_protocol_runtime_tools(isolated_db):
+    import server
+
+    for name in (
+        "nexo_cortex_check",
+        "nexo_guard_check",
+        "nexo_task_open",
+        "nexo_task_acknowledge_guard",
+        "nexo_task_close",
+        "nexo_workflow_open",
+        "nexo_workflow_update",
+    ):
+        assert hasattr(server, name), f"{name} missing from server.py"
+        assert callable(getattr(server, name)), f"{name} is not callable"


### PR DESCRIPTION
## Summary
- Registers `nexo_cortex_check`, `nexo_guard_check`, `nexo_task_open`, `nexo_task_acknowledge_guard`, `nexo_task_close`, `nexo_workflow_open`, `nexo_workflow_update` as `@mcp.tool` handlers in `src/server.py`. Completes the product contract already captured in `tool-enforcement-map.json`.
- Adds migration v49 `_m49_protocol_guard_ack_backfill` for installs that marked v22 applied before the `protocol_tasks.guard_acknowledged` columns landed. Standalone migration because re-running `init_db()` skips v22 once recorded.
- Ships two contract tests covering the new exports and the v49 backfill path.

## Test plan
- [x] `pytest tests/test_protocol_guard_ack_backfill_migration.py tests/test_server_protocol_exports.py tests/test_protocol.py tests/test_hook_guardrails.py -q` → 64 passed, 3 xpassed
- [ ] CI green on required checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)