### PR TITLE
brain: route auto_update name fallbacks through DEFAULT_ASSISTANT_NAME

### DIFF
--- a/src/auto_update.py
+++ b/src/auto_update.py
@@ -3007,10 +3007,11 @@ def _check_npm_version() -> str | None:
             return None
         if latest != current and not current.endswith(latest):
             try:
-                from user_context import get_context
-                _name = get_context().assistant_name
+                from user_context import get_context, DEFAULT_ASSISTANT_NAME
+                _name = get_context().assistant_name or DEFAULT_ASSISTANT_NAME
             except Exception:
-                _name = "NEXO"
+                from user_context import DEFAULT_ASSISTANT_NAME
+                _name = DEFAULT_ASSISTANT_NAME
             return f"{_name} update available: {current} -> {latest}. Run: npm update -g {pkg_name}"
     except Exception:
         pass
@@ -3385,12 +3386,17 @@ def _find_user_claude_md() -> Path | None:
 
 def _resolve_placeholders(template_text: str) -> str:
     """Fill {{NAME}} and {{NEXO_HOME}} from the user's existing CLAUDE.md or config."""
-    # Read operator name from calibration/version
+    # Read operator name from calibration/version. The fallback must never be a
+    # reserved product identity ("NEXO", "NEXO Brain", "NEXO Desktop"); those
+    # are rejected by desktop_bridge.RESERVED_ASSISTANT_NAME_VALUES and leaking
+    # them into the managed CLAUDE.md would conflate the agent (Nova/Nero/etc.)
+    # with the product itself.
     try:
-        from user_context import get_context
-        name = get_context().assistant_name
+        from user_context import get_context, DEFAULT_ASSISTANT_NAME
+        name = get_context().assistant_name or DEFAULT_ASSISTANT_NAME
     except Exception:
-        name = "NEXO"
+        from user_context import DEFAULT_ASSISTANT_NAME
+        name = DEFAULT_ASSISTANT_NAME
 
     return (
         template_text

--- a/tests/test_assistant_name_reserved_fallbacks.py
+++ b/tests/test_assistant_name_reserved_fallbacks.py
@@ -1,0 +1,83 @@
+"""Contract: no reserved product identity (NEXO/NEXO Brain/NEXO Desktop)
+should ever leak as a fallback agent name. The agent identity must always
+resolve to either the user-chosen name stored in calibration, the canonical
+default, or an equivalent neutral placeholder — never the product name.
+"""
+from __future__ import annotations
+
+import importlib
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+SRC = Path(__file__).resolve().parent.parent / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+def _reload(name: str):
+    if name in sys.modules:
+        return importlib.reload(sys.modules[name])
+    return importlib.import_module(name)
+
+
+def test_default_assistant_name_is_not_reserved():
+    user_context = _reload("user_context")
+    desktop_bridge = _reload("desktop_bridge")
+    assert user_context.DEFAULT_ASSISTANT_NAME not in desktop_bridge.RESERVED_ASSISTANT_NAME_VALUES
+
+
+def test_reserved_values_cover_nexo_product_identities():
+    desktop_bridge = _reload("desktop_bridge")
+    reserved = set(desktop_bridge.RESERVED_ASSISTANT_NAME_VALUES)
+    # NEXO, NEXO Brain, and NEXO Desktop are the three canonical product names.
+    assert "NEXO" in reserved
+    assert "NEXO Brain" in reserved
+    assert "NEXO Desktop" in reserved
+
+
+def test_resolve_placeholders_does_not_leak_reserved_name(monkeypatch, tmp_path):
+    # Force _resolve_placeholders to exercise its except-path: pretend
+    # user_context.get_context explodes. The fallback must route through
+    # DEFAULT_ASSISTANT_NAME, never a hard-coded "NEXO".
+    user_context = _reload("user_context")
+    auto_update = _reload("auto_update")
+    desktop_bridge = _reload("desktop_bridge")
+
+    class _Boom(Exception):
+        pass
+
+    def _boom():
+        raise _Boom("intentional")
+
+    monkeypatch.setattr(auto_update, "NEXO_HOME", tmp_path)
+    monkeypatch.setattr(user_context, "get_context", _boom)
+
+    out = auto_update._resolve_placeholders("hi {{NAME}}, home={{NEXO_HOME}}")
+
+    # The rendered name must not be a reserved product identity.
+    for reserved in desktop_bridge.RESERVED_ASSISTANT_NAME_VALUES:
+        # Use word-boundary so "NEXO Brain" inside a longer sentence still
+        # gets caught, but the literal "{{NAME}}" placeholder obviously never
+        # survives rendering.
+        assert re.search(rf"\b{re.escape(reserved)}\b", out) is None, (
+            f"Fallback leaked reserved product identity {reserved!r}: {out!r}"
+        )
+    assert user_context.DEFAULT_ASSISTANT_NAME in out
+
+
+def test_auto_update_sourcefile_has_no_nexo_name_literal():
+    """Regression against the two hard-coded ``_name = 'NEXO'`` fallbacks that
+    used to live in ``src/auto_update.py``. Keeping this as an explicit grep
+    stops future refactors from reintroducing the reserved product identity
+    as an agent-name fallback. Matches are allowed inside comments only when
+    they refer to the reserved identity set, not as an assignment to ``name``.
+    """
+    source = (SRC / "auto_update.py").read_text()
+    # No assignment ``_name = "NEXO"`` / ``name = "NEXO"`` at any indent.
+    for pattern in (r'^\s*_name\s*=\s*"NEXO"\s*$', r'^\s*name\s*=\s*"NEXO"\s*$'):
+        assert re.search(pattern, source, flags=re.MULTILINE) is None, (
+            f"auto_update.py re-introduced a reserved NEXO fallback via {pattern!r}"
+        )


### PR DESCRIPTION
## Summary
- `src/auto_update.py` had two except-paths that hard-coded the literal `"NEXO"` as agent-name fallback. `desktop_bridge.RESERVED_ASSISTANT_NAME_VALUES` already blocks operators from picking `"NEXO"` / `"NEXO Brain"` / `"NEXO Desktop"`, so the fallbacks themselves must route through the canonical `DEFAULT_ASSISTANT_NAME` instead.
- Covers Block E.1 / E.2 identity coherence gap listed in `~/Desktop/NEXO/NEXO-MASTER-CHECKLIST.md`.

## Test plan
- [x] `pytest tests/test_assistant_name_reserved_fallbacks.py -q` → 4 passed
- [x] `pytest tests/test_auto_update_bootstrap_profile.py tests/test_desktop_bridge.py -q` → 14 passed
- [ ] CI required checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)