### PR TITLE
brain: block agentic writes to NEXO-managed LaunchAgent plists

### DIFF
--- a/src/hook_guardrails.py
+++ b/src/hook_guardrails.py
@@ -291,6 +291,10 @@ def _extract_bash_touched_files(tool_input) -> list[str]:
         ".py", ".md", ".json", ".jsonl", ".sh", ".txt", ".toml", ".yaml", ".yml",
         ".js", ".ts", ".tsx", ".jsx", ".php", ".sql", ".rs", ".go", ".c", ".cpp",
         ".h", ".css", ".html",
+        # ``.plist`` is needed so that ``_collect_launchagent_write_blocks``
+        # can see managed LaunchAgent plists inside Bash commands such as
+        # ``chmod 755 ~/Library/LaunchAgents/com.nexo.runner-health-check.plist``.
+        ".plist",
     }
 
     def add(candidate: str) -> None:
@@ -746,6 +750,79 @@ def _collect_runtime_core_write_blocks(
     return blocks
 
 
+# ``_normalize_path_token`` lower-cases the path, so the regex and substring
+# checks here must also be lower-case. We intentionally omit the leading
+# ``/`` so that both ``/Users/.../Library/...`` and ``~/Library/...`` shapes
+# match — ``_normalize_file_path`` does not expand the user home.
+_LAUNCHAGENT_PLIST_RE = re.compile(
+    r"library/launchagents/com\.nexo\.[^/]+\.plist$"
+)
+
+
+def _is_protected_launchagent_path(filepath: str) -> bool:
+    """True when ``filepath`` resolves to a NEXO-managed LaunchAgent plist.
+
+    Matches any absolute or tilde-prefixed path that ends with
+    ``Library/LaunchAgents/com.nexo.<name>.plist``. Other plists in the same
+    directory (e.g. third-party agents) are left untouched.
+    """
+    if not filepath:
+        return False
+    normalized = _normalize_file_path(filepath)
+    if "library/launchagents/com.nexo." not in normalized:
+        return False
+    return _LAUNCHAGENT_PLIST_RE.search(normalized) is not None
+
+
+def _collect_launchagent_write_blocks(
+    conn,
+    *,
+    sid: str,
+    tool_name: str,
+    files: list[str],
+) -> list[dict]:
+    """Block agent-driven writes to NEXO-managed LaunchAgent plists.
+
+    Core flows (``auto_update.py`` re-generating plists, ``nexo_migrate``,
+    product controllers) set ``NEXO_CORE_WRITES_ALLOWED=1`` via
+    ``product_mode.core_writes_allowed()``, which bypasses this gate. Agentic
+    edits (an operator prompting Claude Code to "fix this LaunchAgent"
+    manually) go through the check and are rejected with a pointer to the
+    canonical surfaces: ``nexo scripts ensure-schedules``,
+    ``nexo core-schedules``, or the source repo release flow.
+    """
+    if core_writes_allowed():
+        return []
+    blocks: list[dict] = []
+    for filepath in files:
+        if not _is_protected_launchagent_path(filepath):
+            continue
+        debt = _ensure_protocol_debt(
+            conn,
+            session_id=sid,
+            task_id="",
+            debt_type="launchagent_plist_write_blocked",
+            severity="error",
+            evidence=(
+                f"{tool_name} attempted on managed LaunchAgent plist {filepath}. "
+                "NEXO-managed plists must be regenerated through "
+                "`nexo scripts ensure-schedules`, `nexo core-schedules`, or the "
+                "source repo release flow, not edited in place."
+            ),
+            file_token=filepath,
+        )
+        blocks.append(
+            {
+                "file": filepath,
+                "task_id": "",
+                "debt_id": debt.get("id"),
+                "debt_type": "launchagent_plist_write_blocked",
+                "reason_code": "launchagent_plist_protected",
+            }
+        )
+    return blocks
+
+
 def _read_claude_session_id_from_coordination() -> str:
     """Fallback claude_session_id when Claude Code's PreToolUse payload omits it.
 
@@ -852,6 +929,23 @@ def process_pre_tool_event(payload: dict) -> dict:
             "operation": op,
             "strictness": strictness,
             "blocks": core_blocks,
+            "status": "blocked",
+        }
+
+    launchagent_blocks = _collect_launchagent_write_blocks(
+        conn,
+        sid=sid,
+        tool_name=tool_name,
+        files=files,
+    )
+    if launchagent_blocks:
+        return {
+            "ok": True,
+            "session_id": sid,
+            "tool_name": tool_name,
+            "operation": op,
+            "strictness": strictness,
+            "blocks": launchagent_blocks,
             "status": "blocked",
         }
 

--- a/tests/test_hook_guardrails.py
+++ b/tests/test_hook_guardrails.py
@@ -677,3 +677,139 @@ def test_process_pre_tool_event_allows_python_inline_read_from_runtime_core(guar
 
     assert result["ok"] is True
     assert result["skipped"] is True
+
+
+# --- LaunchAgent plist protection -----------------------------------------
+# Agentic edits to ~/Library/LaunchAgents/com.nexo.*.plist must be blocked
+# so that the plist regeneration flow remains the canonical surface
+# (``nexo scripts ensure-schedules`` / auto_update regenerator). Core flows
+# that *should* regenerate plists set NEXO_CORE_WRITES_ALLOWED=1 via
+# ``product_mode.core_writes_allowed()`` and bypass this gate.
+
+
+_FAKE_LAUNCHAGENT = "/Users/testop/Library/LaunchAgents/com.nexo.runner-health-check.plist"
+
+
+def test_is_protected_launchagent_path_matches_nexo_plists():
+    db, hook_guardrails = _reload_guardrail_stack()
+    assert hook_guardrails._is_protected_launchagent_path(_FAKE_LAUNCHAGENT) is True
+    assert hook_guardrails._is_protected_launchagent_path(
+        "~/Library/LaunchAgents/com.nexo.morning-agent.plist"
+    ) is True
+
+
+def test_is_protected_launchagent_path_ignores_foreign_plists():
+    db, hook_guardrails = _reload_guardrail_stack()
+    assert hook_guardrails._is_protected_launchagent_path(
+        "/Users/testop/Library/LaunchAgents/com.apple.itunes.plist"
+    ) is False
+    assert hook_guardrails._is_protected_launchagent_path(
+        "/Users/testop/Documents/com.nexo.fake.plist"
+    ) is False
+    assert hook_guardrails._is_protected_launchagent_path("") is False
+
+
+def test_process_pre_tool_event_blocks_edit_on_launchagent_plist(guardrail_env, monkeypatch):
+    monkeypatch.setenv("NEXO_HOME", str(guardrail_env))
+    db, hook_guardrails = _reload_guardrail_stack()
+    db.init_db()
+    monkeypatch.setattr(hook_guardrails, "get_protocol_strictness", lambda: "strict")
+    monkeypatch.setattr(hook_guardrails, "core_writes_allowed", lambda: False)
+    db.register_session(
+        "nexo-2030-3030",
+        "launchagent edit block",
+        external_session_id="claude-launchagent-1",
+        session_client="claude_code",
+    )
+
+    result = hook_guardrails.process_pre_tool_event(
+        {
+            "session_id": "claude-launchagent-1",
+            "tool_name": "Edit",
+            "tool_input": {"file_path": _FAKE_LAUNCHAGENT},
+        }
+    )
+
+    assert result["status"] == "blocked"
+    assert result["blocks"][0]["debt_type"] == "launchagent_plist_write_blocked"
+    assert result["blocks"][0]["file"] == _FAKE_LAUNCHAGENT
+
+
+def test_process_pre_tool_event_blocks_bash_write_to_launchagent_plist(guardrail_env, monkeypatch):
+    monkeypatch.setenv("NEXO_HOME", str(guardrail_env))
+    db, hook_guardrails = _reload_guardrail_stack()
+    db.init_db()
+    monkeypatch.setattr(hook_guardrails, "get_protocol_strictness", lambda: "strict")
+    monkeypatch.setattr(hook_guardrails, "core_writes_allowed", lambda: False)
+    db.register_session(
+        "nexo-2031-3031",
+        "launchagent bash block",
+        external_session_id="claude-launchagent-2",
+        session_client="claude_code",
+    )
+
+    command = f"echo 'stuff' > {_FAKE_LAUNCHAGENT}"
+    result = hook_guardrails.process_pre_tool_event(
+        {
+            "session_id": "claude-launchagent-2",
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+        }
+    )
+
+    assert result["status"] == "blocked"
+    assert result["blocks"][0]["debt_type"] == "launchagent_plist_write_blocked"
+
+
+def test_process_pre_tool_event_allows_launchagent_write_under_core_writes_allowed(guardrail_env, monkeypatch):
+    monkeypatch.setenv("NEXO_HOME", str(guardrail_env))
+    db, hook_guardrails = _reload_guardrail_stack()
+    db.init_db()
+    monkeypatch.setattr(hook_guardrails, "get_protocol_strictness", lambda: "lenient")
+    monkeypatch.setattr(hook_guardrails, "core_writes_allowed", lambda: True)
+    db.register_session(
+        "nexo-2032-3032",
+        "launchagent core bypass",
+        external_session_id="claude-launchagent-3",
+        session_client="claude_code",
+    )
+
+    result = hook_guardrails.process_pre_tool_event(
+        {
+            "session_id": "claude-launchagent-3",
+            "tool_name": "Edit",
+            "tool_input": {"file_path": _FAKE_LAUNCHAGENT},
+        }
+    )
+
+    # Lenient mode + core_writes_allowed => hook_guardrails returns skipped,
+    # not a launchagent block.
+    assert result.get("status") != "blocked"
+
+
+def test_process_pre_tool_event_does_not_block_foreign_plists(guardrail_env, monkeypatch):
+    monkeypatch.setenv("NEXO_HOME", str(guardrail_env))
+    db, hook_guardrails = _reload_guardrail_stack()
+    db.init_db()
+    monkeypatch.setattr(hook_guardrails, "get_protocol_strictness", lambda: "lenient")
+    monkeypatch.setattr(hook_guardrails, "core_writes_allowed", lambda: False)
+    db.register_session(
+        "nexo-2033-3033",
+        "foreign plist untouched",
+        external_session_id="claude-foreign-plist",
+        session_client="claude_code",
+    )
+
+    result = hook_guardrails.process_pre_tool_event(
+        {
+            "session_id": "claude-foreign-plist",
+            "tool_name": "Edit",
+            "tool_input": {"file_path": "/Users/testop/Library/LaunchAgents/com.apple.itunes.plist"},
+        }
+    )
+
+    # Foreign plist must not be reported as launchagent_plist_write_blocked.
+    blocks = result.get("blocks", []) or []
+    assert all(
+        b.get("debt_type") != "launchagent_plist_write_blocked" for b in blocks
+    )


### PR DESCRIPTION
## Summary
- Pre-tool hook now rejects agentic `Edit`/`Write`/`MultiEdit`/`Delete`/`Bash` mutations against `~/Library/LaunchAgents/com.nexo.*.plist`, routing operators to the canonical surfaces (`nexo scripts ensure-schedules`, `nexo core-schedules`, source repo flow).
- Core flows that legitimately regenerate plists keep their bypass via `product_mode.core_writes_allowed()`.
- Foreign plists stay untouched.
- Closes NF-DS-917B7D14 and the LaunchAgent gap listed in Block E.6 of `~/Desktop/NEXO/NEXO-MASTER-CHECKLIST.md`.

## Test plan
- [x] `pytest tests/test_hook_guardrails.py -q` → 24 passed
- [ ] CI required checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)