### PR TITLE
brain: drop francisco_emails leak from email_config dict export

### DIFF
--- a/src/email_config.py
+++ b/src/email_config.py
@@ -122,9 +122,15 @@ def _account_to_legacy_shape(
         "password": runtime_account["password"],
         "operator_email": default_operator_email,
         "operator_aliases": list(extra_operator_emails or []),
-        # Transitional compatibility for older scripts that still read the
-        # pre-F2 alias key directly.
-        "francisco_emails": list(extra_operator_emails or []),
+        # Historical note: earlier versions exported the same list under the
+        # ``francisco_emails`` key for scripts that still referenced the
+        # operator's email by a personal name. The key leaked the operator
+        # identity into anything consuming the email config dict, so it has
+        # been removed. Callers must read ``operator_aliases`` instead. The
+        # legacy ``francisco_emails`` key inside ~/.nexo/nexo-email/config.json
+        # is still tolerated at ingest time (see _operator_aliases in
+        # automation_controls.py and nexo-email-monitor.py) so upgrades from
+        # old runtimes do not break; it just no longer round-trips here.
         "trusted_domains": runtime_account["trusted_domains"],
         "sender_policy": runtime_account["sender_policy"],
         "sent_folder": runtime_account["sent_folder"],

--- a/tests/test_email_accounts.py
+++ b/tests/test_email_accounts.py
@@ -229,7 +229,11 @@ def test_loader_prefers_table_over_legacy_json(isolated_home):
     assert cfg["_source"] == "email_accounts"
     assert cfg["operator_email"] == "owner@company.com"
     assert cfg["operator_aliases"] == ["owner@company.com"]
-    assert cfg["francisco_emails"] == ["owner@company.com"]
+    # ``francisco_emails`` no longer round-trips through email_config.py:
+    # it leaked an operator identity and callers must now read
+    # ``operator_aliases`` instead. The legacy key is still tolerated at
+    # ingest time (see other tests) to preserve upgrades from old JSON.
+    assert "francisco_emails" not in cfg
     assert cfg["default_operator_account"]["email"] == "owner@company.com"
     assert len(cfg["operator_accounts"]) == 1
 


### PR DESCRIPTION
## Summary
- `email_config.load_email_config()` exported the operator's aliases twice — once under `operator_aliases` and once under the pre-F2 legacy key `francisco_emails`. The duplicate leaked an operator identity into every consumer of the dict without adding any capability.
- Remove the export. Ingest-time tolerance for the legacy key inside `~/.nexo/nexo-email/config.json` stays intact via `automation_controls.py` and `nexo-email-monitor.py`, so upgrades from pre-F2 runtimes still migrate cleanly.
- Update `tests/test_email_accounts.py` to assert the key is gone from the output.
- Block E.1 item in `~/Desktop/NEXO/NEXO-MASTER-CHECKLIST.md`.

## Test plan
- [x] `pytest tests/test_email_accounts.py tests/test_cli_email.py tests/test_core_automation_productization.py -q` → 43 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)