### PR TITLE
brain: route backfill_task_owner textual classification through local LLM

### DIFF
--- a/src/scripts/backfill_task_owner.py
+++ b/src/scripts/backfill_task_owner.py
@@ -87,6 +87,70 @@ def _load_user_name(calibration_path: Path) -> str:
         return ""
 
 
+_CLASSIFIER_LABELS = (
+    "user_decision_required",
+    "waiting_for_external_response",
+    "agent_automation_cron",
+    "other_shared",
+)
+_CLASSIFIER_CONFIDENCE_FLOOR = 0.55
+
+
+def _load_local_classifier():
+    """Lazy import the zero-shot classifier. Returns None if unavailable."""
+    try:
+        # classifier_local lives next to the ``scripts`` dir at runtime; add
+        # the parent so both in-repo (``src/``) and installed
+        # (``~/.nexo/core/``) layouts find it.
+        here = Path(__file__).resolve().parent
+        for candidate in (here.parent, here.parent.parent):
+            sys_path = str(candidate)
+            if sys_path not in sys.path:
+                sys.path.insert(0, sys_path)
+        from classifier_local import (  # type: ignore
+            LocalZeroShotClassifier,
+            is_local_classifier_available_with_install_state,
+        )
+    except Exception:
+        return None
+    try:
+        if not is_local_classifier_available_with_install_state():
+            return None
+        return LocalZeroShotClassifier()
+    except Exception:
+        return None
+
+
+def _classify_with_local_llm(description: str, classifier) -> str | None:
+    """Ask the local zero-shot classifier to pick a semantic owner label.
+
+    Returns the mapped owner string ('user', 'waiting', 'agent', 'shared')
+    or None when the classifier is unavailable, low-confidence, or the text
+    is too short to be worth invoking the model. The 40-character floor
+    mirrors classifier_local's own noise-discard threshold and keeps the
+    migration-time batch cheap.
+    """
+    if classifier is None:
+        return None
+    text = (description or "").strip()
+    if len(text) < 40:
+        return None
+    try:
+        result = classifier.classify(text, _CLASSIFIER_LABELS)
+    except Exception:
+        return None
+    if result is None:
+        return None
+    if result.confidence < _CLASSIFIER_CONFIDENCE_FLOOR:
+        return None
+    return {
+        "user_decision_required": "user",
+        "waiting_for_external_response": "waiting",
+        "agent_automation_cron": "agent",
+        "other_shared": "shared",
+    }.get(result.label)
+
+
 def classify(
     *,
     item_id: str,
@@ -94,8 +158,17 @@ def classify(
     category: str,
     recurrence: str,
     user_name: str,
+    classifier=None,
 ) -> str:
-    """Return one of 'user', 'waiting', 'agent', 'shared'."""
+    """Return one of 'user', 'waiting', 'agent', 'shared'.
+
+    The structural signals (id prefix, category, recurrence) stay rule-based
+    because they are unambiguous and cheap. The textual signals (waiting /
+    agent / user intent from the description) prefer the local zero-shot
+    classifier when available; the Spanish/English keyword regexes stay as
+    a graceful fallback so installs without the classifier model still
+    migrate correctly.
+    """
     tid = (item_id or "").strip().lower()
     if tid.startswith("nf-protocol-"):
         return "user"
@@ -110,6 +183,9 @@ def classify(
     desc = description or ""
     desc_low = desc.lower()
 
+    # Operator-name proximity remains a structural signal — if the row
+    # explicitly calls out <OperatorName> deciding/reviewing/etc., we trust
+    # that without burning an LLM call.
     if user_name:
         name_low = user_name.lower()
         user_verbs = "|".join(re.escape(v) for v in _USER_VERBS_ES + _USER_VERBS_EN)
@@ -119,6 +195,10 @@ def classify(
         )
         if name_verb_rx.search(desc_low):
             return "user"
+
+    llm_label = _classify_with_local_llm(desc, classifier)
+    if llm_label is not None:
+        return llm_label
 
     for rx in _compile(_WAITING_PHRASES):
         if rx.search(desc_low):
@@ -189,6 +269,10 @@ def run(
     if not db_path.exists():
         raise SystemExit(f"nexo.db not found at {db_path}")
     user_name = _load_user_name(calibration_path)
+    # Load the zero-shot classifier once up front so the migration loop does
+    # not pay repeated import/init overhead. Returns None on installs without
+    # transformers/model — the regex fallback still produces correct owners.
+    classifier = _load_local_classifier()
 
     conn = sqlite3.connect(str(db_path))
     try:
@@ -207,6 +291,7 @@ def run(
                     category=row["category"],
                     recurrence=row["recurrence"],
                     user_name=user_name,
+                    classifier=classifier,
                 )
                 plans.append({"table": table, "id": row["id"], "owner": owner})
 

--- a/tests/test_backfill_task_owner_classifier_hook.py
+++ b/tests/test_backfill_task_owner_classifier_hook.py
@@ -1,0 +1,169 @@
+"""Contracts for the backfill_task_owner classifier hook.
+
+The migration script used to rely on Spanish/English keyword regexes to
+infer ``owner`` for legacy followups/reminders. Block D.1 directive
+(Francisco 2026-04-22): prefer the local zero-shot classifier for text
+intent, keep the regex set only as a fallback for installs without the
+model.
+"""
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import pytest
+
+SRC = Path(__file__).resolve().parent.parent / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from scripts.backfill_task_owner import classify  # noqa: E402
+
+
+@dataclass
+class _FakeResult:
+    label: str
+    confidence: float
+    scores: dict
+    latency_ms: float = 0.0
+
+
+class _FakeClassifier:
+    """Minimal stub mimicking LocalZeroShotClassifier.classify(text, labels)."""
+
+    def __init__(self, label: str, confidence: float) -> None:
+        self._label = label
+        self._confidence = confidence
+
+    def classify(self, text: str, labels: Iterable[str]):
+        labels = list(labels)
+        scores = {l: 0.0 for l in labels}
+        scores[self._label] = self._confidence
+        return _FakeResult(label=self._label, confidence=self._confidence, scores=scores)
+
+
+def test_classify_structural_signals_skip_classifier():
+    """Structural signals (id prefix, category, recurrence, operator-name)
+    stay rule-based and never invoke the LLM path."""
+    # NF-PROTOCOL-* always routes to user without the classifier.
+    assert classify(
+        item_id="NF-PROTOCOL-xyz",
+        description="anything at all",
+        category="",
+        recurrence="",
+        user_name="Francisco",
+        classifier=_FakeClassifier("agent_automation_cron", 0.99),
+    ) == "user"
+
+    # ``category='waiting'`` wins over classifier.
+    assert classify(
+        item_id="NF-ABC",
+        description="anything",
+        category="waiting",
+        recurrence="",
+        user_name="Francisco",
+        classifier=_FakeClassifier("agent_automation_cron", 0.99),
+    ) == "waiting"
+
+    # Non-empty recurrence routes to agent, classifier ignored.
+    assert classify(
+        item_id="NF-ABC",
+        description="anything",
+        category="",
+        recurrence="daily",
+        user_name="Francisco",
+        classifier=_FakeClassifier("user_decision_required", 0.99),
+    ) == "agent"
+
+
+def test_classify_uses_classifier_for_ambiguous_text():
+    """On rows without structural signals, a confident classifier verdict
+    drives the owner (LLM > regex fallback)."""
+    description = (
+        "Coordinar con el equipo de soporte externo para que confirmen el "
+        "calendario antes del cierre trimestral y publicar resultados."
+    )
+    assert classify(
+        item_id="NF-X",
+        description=description,
+        category="",
+        recurrence="",
+        user_name="Francisco",
+        classifier=_FakeClassifier("waiting_for_external_response", 0.82),
+    ) == "waiting"
+
+
+def test_classify_falls_back_to_regex_when_classifier_low_confidence():
+    """Low-confidence classifier output must defer to the regex ladder."""
+    # Description triggers the waiting regex — classifier below floor must
+    # not override it.
+    assert classify(
+        item_id="NF-X",
+        description="Esperando respuesta de Maria sobre el presupuesto.",
+        category="",
+        recurrence="",
+        user_name="",
+        classifier=_FakeClassifier("user_decision_required", 0.30),
+    ) == "waiting"
+
+
+def test_classify_falls_back_when_classifier_missing():
+    """No classifier at all ⇒ regex ladder. Plain imperatives still route
+    to user; agent keywords still route to agent; unknown text lands in
+    shared."""
+    assert classify(
+        item_id="NF-X",
+        description="revisar implementación del módulo nuevo",
+        category="",
+        recurrence="",
+        user_name="",
+        classifier=None,
+    ) == "user"
+    assert classify(
+        item_id="NF-X",
+        description="cron que monitoriza la cola cada minuto",
+        category="",
+        recurrence="",
+        user_name="",
+        classifier=None,
+    ) == "agent"
+    assert classify(
+        item_id="NF-X",
+        description="nota corta sin señales fuertes",
+        category="",
+        recurrence="",
+        user_name="",
+        classifier=None,
+    ) == "shared"
+
+
+def test_classify_skips_classifier_for_very_short_text():
+    """The classifier hook ignores texts shorter than the noise floor so
+    the migration does not burn an LLM call on one-liners."""
+    # Even a "high-confidence" classifier verdict must be skipped because
+    # the text is below the 40-character floor; regex fallback applies.
+    assert classify(
+        item_id="NF-X",
+        description="ok",
+        category="",
+        recurrence="",
+        user_name="",
+        classifier=_FakeClassifier("waiting_for_external_response", 0.99),
+    ) == "shared"
+
+
+def test_classify_user_name_signal_wins_over_classifier():
+    """Explicit ``<OperatorName> decide/revisa/aprueba`` takes priority."""
+    assert classify(
+        item_id="NF-X",
+        description=(
+            "Francisco decide si escalamos el presupuesto o pausamos la campaña "
+            "hasta recibir más datos de conversión del equipo externo."
+        ),
+        category="",
+        recurrence="",
+        user_name="Francisco",
+        classifier=_FakeClassifier("agent_automation_cron", 0.95),
+    ) == "user"


### PR DESCRIPTION
## Summary
- Implements Block D.1 directive: hardcoded ES/EN keyword lists in `backfill_task_owner.py` (`revisar`, `approve`, `esperando respuesta`, `cron`, `monitoriza`, …) now defer to the local zero-shot classifier when available. Regex ladder stays as graceful fallback.
- Structural signals (`NF-PROTOCOL` prefix, `category=waiting`, non-empty recurrence, operator-name-plus-verb proximity) stay rule-based — they are unambiguous and cheap.
- New test suite covers structural-wins, confident-LLM override, low-confidence fallback, no-classifier fallback, short-text noise floor, and operator-name precedence.

## Test plan
- [x] `pytest tests/test_backfill_task_owner_classifier_hook.py -q` → 6 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)