### PR TITLE
brain: task_open accepts ack_rules for inline guard acknowledgement (G7)

### DIFF
--- a/src/plugins/protocol.py
+++ b/src/plugins/protocol.py
@@ -972,6 +972,7 @@ def handle_task_open(
     stakes: str = "",
     context_hint: str = "",
     description: str = "",
+    ack_rules: str = "",
 ) -> str:
     """Open a protocol task with heartbeat, guard, rules, and Cortex already captured.
 
@@ -1216,6 +1217,46 @@ def handle_task_open(
         "preventive_followup": preventive_followup,
         "next_action": next_action,
     }
+
+    # G7 (Francisco 2026-04-22): allow inline acknowledgement of blocking
+    # guard rules so the operator does not have to chain a separate
+    # `nexo_task_acknowledge_guard` call. ``ack_rules`` accepts any of:
+    #   "#95,#156"   "95,156"   "95 156"   "[95, 156]"
+    # and delegates to ``handle_task_acknowledge_guard`` which already
+    # validates that every blocking rule is covered.
+    if ack_rules and isinstance(ack_rules, str) and ack_rules.strip():
+        raw = ack_rules.replace("#", "").strip()
+        _resolved_task_id = str(response.get("task_id") or "").strip()
+        _has_blocking = bool(
+            (response.get("guard") or {}).get("has_blocking")
+        )
+        if _has_blocking and _resolved_task_id:
+            ack_result_raw = handle_task_acknowledge_guard(
+                sid=sid,
+                task_id=_resolved_task_id,
+                learning_ids=raw,
+            )
+            try:
+                ack_payload = json.loads(ack_result_raw)
+            except Exception:
+                ack_payload = {"ok": False, "error": "ack_guard_parse_failed"}
+            response["ack_guard"] = ack_payload
+            if ack_payload.get("ok"):
+                # Refresh the blocking flag + next_action so the caller
+                # sees the post-ack state instead of the stale pre-ack one.
+                response["guard"] = response.get("guard") or {}
+                response["guard"]["acknowledged_inline"] = True
+                response["next_action"] = (
+                    "Blocking guard rules acknowledged inline via task_open."
+                )
+        else:
+            response["ack_guard"] = {
+                "ok": False,
+                "skipped": True,
+                "reason": (
+                    "No blocking guard rules on this task — ack_rules had nothing to acknowledge."
+                ),
+            }
     return json.dumps(response, ensure_ascii=False, indent=2)
 
 

--- a/src/server.py
+++ b/src/server.py
@@ -386,8 +386,14 @@ def nexo_task_open(
     stakes: str = "",
     context_hint: str = "",
     description: str = "",
+    ack_rules: str = "",
 ) -> str:
-    """Open a protocol task for non-trivial work."""
+    """Open a protocol task for non-trivial work.
+
+    ``ack_rules`` accepts "#95,#156" / "95,156" / "[95, 156]" and, when
+    the guard surfaces blocking rules, acknowledges them inline instead
+    of requiring a separate ``nexo_task_acknowledge_guard`` call.
+    """
     return handle_task_open(
         sid,
         goal,
@@ -404,6 +410,7 @@ def nexo_task_open(
         stakes,
         context_hint,
         description,
+        ack_rules,
     )
 
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -196,6 +196,99 @@ def test_task_open_with_blocking_guard_sets_pending_ack_state_without_opening_de
     assert debt_count == 0
 
 
+def test_task_open_ack_rules_inline_acknowledges_blocking_guard(monkeypatch):
+    """Block K G7: ``nexo_task_open(..., ack_rules="#41")`` must acknowledge
+    the blocking rules inline so the operator does not have to chain a
+    second ``nexo_task_acknowledge_guard`` call."""
+    from db import get_db
+    from plugins.protocol import handle_task_open
+
+    sid = _register_session("nexo-1004-3004")
+    monkeypatch.setattr(
+        "plugins.protocol.handle_guard_check",
+        lambda **kwargs: "BLOCKING RULES (resolve BEFORE writing):\n  #41 [FILE RULE:/tmp/x]: Read the canonical rule first\n",
+    )
+    payload = json.loads(
+        handle_task_open(
+            sid=sid,
+            goal="Edit guarded file, ack inline",
+            task_type="edit",
+            area="nexo-ops",
+            files="/tmp/x",
+            ack_rules="#41",
+        )
+    )
+
+    # Inline ack payload present + ok.
+    assert payload["ack_guard"]["ok"] is True
+    assert payload["guard"]["acknowledged_inline"] is True
+    # next_action updates to reflect post-ack state.
+    assert payload["next_action"] == (
+        "Blocking guard rules acknowledged inline via task_open."
+    )
+    # DB row reflects the acknowledged flag.
+    row = get_db().execute(
+        "SELECT guard_has_blocking, guard_acknowledged FROM protocol_tasks WHERE task_id = ?",
+        (payload["task_id"],),
+    ).fetchone()
+    assert row["guard_has_blocking"] == 1
+    assert row["guard_acknowledged"] == 1
+
+
+def test_task_open_ack_rules_without_blocking_is_a_noop(monkeypatch):
+    """When there are no blocking rules, ``ack_rules`` must report a
+    graceful no-op instead of failing the open."""
+    from plugins.protocol import handle_task_open
+
+    sid = _register_session("nexo-1004-3005")
+    monkeypatch.setattr(
+        "plugins.protocol.handle_guard_check",
+        lambda **kwargs: "",  # no blocking rules
+    )
+    payload = json.loads(
+        handle_task_open(
+            sid=sid,
+            goal="answer without guard",
+            task_type="answer",
+            area="nexo-ops",
+            ack_rules="#99",
+        )
+    )
+    # Task opens fine, ack_guard reports the skip.
+    assert payload["ok"] is True
+    assert payload["ack_guard"]["ok"] is False
+    assert payload["ack_guard"]["skipped"] is True
+
+
+def test_task_open_ack_rules_mismatched_ids_surface_error(monkeypatch):
+    """If the operator passes an ack list that does not cover every
+    blocking rule, the inline ack must fail with the validator's
+    ``expected_ids`` / ``provided_ids`` payload so the operator can
+    correct the call without a second round-trip."""
+    from plugins.protocol import handle_task_open
+
+    sid = _register_session("nexo-1004-3006")
+    monkeypatch.setattr(
+        "plugins.protocol.handle_guard_check",
+        lambda **kwargs: "BLOCKING RULES (resolve BEFORE writing):\n"
+        "  #41 [FILE RULE:/tmp/x]: alpha\n"
+        "  #156 [FILE RULE:/tmp/x]: beta\n",
+    )
+    payload = json.loads(
+        handle_task_open(
+            sid=sid,
+            goal="Edit guarded file, partial ack",
+            task_type="edit",
+            area="nexo-ops",
+            files="/tmp/x",
+            ack_rules="#41",  # missing #156
+        )
+    )
+    assert payload["ack_guard"]["ok"] is False
+    assert set(payload["ack_guard"]["expected_ids"]) == {41, 156}
+    assert payload["ack_guard"]["provided_ids"] == [41]
+
+
 def test_task_open_passes_project_hint_to_guard_check(monkeypatch):
     from plugins.protocol import handle_task_open
 


### PR DESCRIPTION
## Summary
- Block K G7: ack_guard was a separate MCP call that kept getting forgotten, causing `unacknowledged_guard_blocking` debts to pile up.
- `nexo_task_open(..., ack_rules='#95,#156')` now delegates to `handle_task_acknowledge_guard` inline. Response carries an `ack_guard` block + `guard.acknowledged_inline` flag + refreshed `next_action`.
- Accepted shapes: `#95,#156`, `95,156`, `95 156`, `[95, 156]`. No-blocking-rules → no-op report. Partial ack → validator surfaces `expected_ids` / `provided_ids` for single-shot correction.

## Test plan
- [x] `pytest tests/test_server_protocol_exports.py tests/test_protocol.py -q` → 48 passed + 3 xpassed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)