### PR TITLE
brain: rescue autonomy-mandate expansion + post/pre-compact hooks + checkpoint_policy

### DIFF
--- a/src/autonomy_mandate.py
+++ b/src/autonomy_mandate.py
@@ -45,8 +45,15 @@ MARKERS = (
     "autonomía total",
     "autonomia total",
     "sin esperas",
+    "hazlo todo",
     "todo ya",
+    "no pares",
+    "estás al mando",
+    "estas al mando",
+    "te dejo al mando",
     "no esperes",
+    "sigue sin parar",
+    "haz el plan completo",
     "no te escondas",
     "llevo 3 veces",
     "lo quiero ya",
@@ -81,6 +88,9 @@ class MandateState:
     expires_at: float
     marker: str
     source: str
+    execute_until_blocker: bool = True
+    suppress_mid_task_menus: bool = True
+    revalidate_after_compaction: bool = True
 
     def remaining_seconds(self, now: Optional[float] = None) -> float:
         now = time.time() if now is None else now
@@ -94,6 +104,9 @@ class MandateState:
             "expires_at": self.expires_at,
             "marker": self.marker,
             "source": self.source,
+            "execute_until_blocker": self.execute_until_blocker,
+            "suppress_mid_task_menus": self.suppress_mid_task_menus,
+            "revalidate_after_compaction": self.revalidate_after_compaction,
         }
 
 
@@ -137,6 +150,9 @@ def load_state() -> Optional[MandateState]:
             expires_at=float(raw.get("expires_at", 0.0)),
             marker=str(raw.get("marker", "")),
             source=str(raw.get("source", "")),
+            execute_until_blocker=bool(raw.get("execute_until_blocker", True)),
+            suppress_mid_task_menus=bool(raw.get("suppress_mid_task_menus", True)),
+            revalidate_after_compaction=bool(raw.get("revalidate_after_compaction", True)),
         )
     except (TypeError, ValueError):
         return None
@@ -150,6 +166,9 @@ def set_mandate(
     marker: str,
     source: str = "manual",
     ttl_seconds: int = DEFAULT_TTL_SECONDS,
+    execute_until_blocker: bool = True,
+    suppress_mid_task_menus: bool = True,
+    revalidate_after_compaction: bool = True,
 ) -> MandateState:
     _ensure_dir()
     now = time.time()
@@ -160,6 +179,9 @@ def set_mandate(
         expires_at=now + max(60, int(ttl_seconds)),
         marker=marker,
         source=source,
+        execute_until_blocker=bool(execute_until_blocker),
+        suppress_mid_task_menus=bool(suppress_mid_task_menus),
+        revalidate_after_compaction=bool(revalidate_after_compaction),
     )
     STATE_PATH.write_text(json.dumps(st.to_dict(), ensure_ascii=False, indent=2))
     return st
@@ -194,6 +216,46 @@ def maybe_ingest_from_text(
         source=source,
         ttl_seconds=ttl_seconds,
     )
+
+
+def _state_applies_to_session(state: MandateState, session_id: str = "") -> bool:
+    clean_sid = str(session_id or "").strip()
+    if not clean_sid:
+        return True
+    return not state.session_id or state.session_id == clean_sid
+
+
+def is_execute_until_blocker_active(
+    session_id: str = "",
+    state: Optional[MandateState] = None,
+) -> bool:
+    st = state if state is not None else load_state()
+    if st is None or not _state_applies_to_session(st, session_id):
+        return False
+    return bool(st.active and st.execute_until_blocker)
+
+
+def format_execution_latch_notice(
+    session_id: str = "",
+    state: Optional[MandateState] = None,
+) -> str:
+    st = state if state is not None else load_state()
+    if st is None or not _state_applies_to_session(st, session_id):
+        return ""
+    if not st.active or not st.execute_until_blocker:
+        return ""
+
+    lines = [
+        (
+            "EXECUTION MODE: execute-until-blocker active "
+            f"(marker='{st.marker}', source={st.source})."
+        ),
+        "Do not stop for option menus, reprioritization, summaries, or audits.",
+        "Pause only for a real blocker, an explicit approval gate, or a requested report.",
+    ]
+    if st.revalidate_after_compaction:
+        lines.append("Re-validate this latch after compaction and continue from the stored next step.")
+    return "\n".join(lines)
 
 
 def _description_has_exception(description: str, exception: str) -> bool:

--- a/src/checkpoint_policy.py
+++ b/src/checkpoint_policy.py
@@ -1,0 +1,302 @@
+"""Durable checkpoint policy for long-running multi-step work.
+
+This module turns task/workflow milestones into a small persistent state file
+and periodically flushes that state into ``session_checkpoints`` so compaction
+and phase switches recover a richer next-step snapshot than the heartbeat-only
+goal stub.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+NEXO_HOME = Path(os.environ.get("NEXO_HOME", str(Path.home() / ".nexo")))
+STATE_PATH = NEXO_HOME / "runtime" / "data" / "durable_checkpoint_state.json"
+DEFAULT_MILESTONE_INTERVAL = 3
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _ensure_dir() -> None:
+    STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _load_all() -> dict[str, dict[str, Any]]:
+    try:
+        raw = json.loads(STATE_PATH.read_text())
+    except FileNotFoundError:
+        return {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return raw if isinstance(raw, dict) else {}
+
+
+def _save_all(payload: dict[str, dict[str, Any]]) -> None:
+    _ensure_dir()
+    STATE_PATH.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+
+
+def _blank_session_state(session_id: str) -> dict[str, Any]:
+    return {
+        "session_id": session_id,
+        "milestone_count": 0,
+        "updated_at": _now_iso(),
+        "last_reason": "",
+        "task": "",
+        "task_status": "active",
+        "active_files": [],
+        "current_goal": "",
+        "decisions_summary": "",
+        "blockers": "",
+        "reasoning_thread": "",
+        "next_step": "",
+        "last_flushed_at": "",
+        "last_flush_reason": "",
+    }
+
+
+def _coalesce_text(new_value: str, old_value: str = "") -> str:
+    clean = str(new_value or "").strip()
+    return clean or str(old_value or "").strip()
+
+
+def _normalize_active_files(active_files: Any) -> list[str]:
+    if active_files is None:
+        return []
+    if isinstance(active_files, str):
+        stripped = active_files.strip()
+        if not stripped:
+            return []
+        if stripped.startswith("["):
+            try:
+                parsed = json.loads(stripped)
+            except json.JSONDecodeError:
+                parsed = [part.strip() for part in stripped.split(",") if part.strip()]
+        else:
+            parsed = [part.strip() for part in stripped.split(",") if part.strip()]
+    elif isinstance(active_files, (list, tuple, set)):
+        parsed = list(active_files)
+    else:
+        parsed = [str(active_files).strip()]
+
+    seen: list[str] = []
+    for item in parsed:
+        clean = str(item or "").strip()
+        if clean and clean not in seen:
+            seen.append(clean)
+    return seen
+
+
+def _session_state(all_state: dict[str, dict[str, Any]], session_id: str) -> dict[str, Any]:
+    existing = all_state.get(session_id)
+    if not isinstance(existing, dict):
+        return _blank_session_state(session_id)
+    base = _blank_session_state(session_id)
+    base.update(existing)
+    base["session_id"] = session_id
+    base["active_files"] = _normalize_active_files(base.get("active_files"))
+    try:
+        base["milestone_count"] = max(0, int(base.get("milestone_count", 0)))
+    except (TypeError, ValueError):
+        base["milestone_count"] = 0
+    return base
+
+
+def _extract_active_files_from_payload(payload: dict[str, Any] | None) -> list[str]:
+    if not isinstance(payload, dict):
+        return []
+    for key in ("active_files", "files", "tracked_files"):
+        files = _normalize_active_files(payload.get(key))
+        if files:
+            return files
+    return []
+
+
+def _flush_state(
+    all_state: dict[str, dict[str, Any]],
+    session_id: str,
+    state: dict[str, Any],
+    *,
+    reason: str,
+) -> dict[str, Any]:
+    from db import save_checkpoint
+
+    decisions_summary = _coalesce_text(state.get("decisions_summary", ""))
+    if reason:
+        reason_note = f"checkpoint_reason={reason}"
+        decisions_summary = f"{decisions_summary} | {reason_note}".strip(" |")
+
+    active_files = _normalize_active_files(state.get("active_files"))
+    save_result = save_checkpoint(
+        sid=session_id,
+        task=_coalesce_text(state.get("task", ""), state.get("current_goal", "")),
+        task_status=_coalesce_text(state.get("task_status", ""), "active"),
+        active_files=json.dumps(active_files, ensure_ascii=False),
+        current_goal=_coalesce_text(state.get("current_goal", ""), state.get("task", "")),
+        decisions_summary=decisions_summary,
+        errors_found=_coalesce_text(state.get("blockers", "")),
+        reasoning_thread=_coalesce_text(state.get("reasoning_thread", "")),
+        next_step=_coalesce_text(state.get("next_step", "")),
+    )
+
+    state["active_files"] = active_files
+    state["milestone_count"] = 0
+    state["last_flushed_at"] = _now_iso()
+    state["last_flush_reason"] = reason
+    state["updated_at"] = _now_iso()
+    all_state[session_id] = state
+    _save_all(all_state)
+    return {
+        "ok": True,
+        "checkpoint_written": True,
+        "session_id": session_id,
+        "milestone_count": 0,
+        "last_flush_reason": reason,
+        "compaction_count": save_result.get("compaction_count", 0),
+    }
+
+
+def record_milestone(
+    session_id: str,
+    *,
+    reason: str,
+    task: str = "",
+    task_status: str = "active",
+    active_files: Any = None,
+    current_goal: str = "",
+    decisions_summary: str = "",
+    blockers: str = "",
+    reasoning_thread: str = "",
+    next_step: str = "",
+    interval: int = DEFAULT_MILESTONE_INTERVAL,
+    force_flush: bool = False,
+) -> dict[str, Any]:
+    clean_sid = str(session_id or "").strip()
+    if not clean_sid:
+        return {"ok": False, "error": "session_id is required"}
+
+    all_state = _load_all()
+    state = _session_state(all_state, clean_sid)
+
+    state["last_reason"] = str(reason or "").strip()
+    state["updated_at"] = _now_iso()
+    state["task"] = _coalesce_text(task, state.get("task", ""))
+    state["task_status"] = _coalesce_text(task_status, state.get("task_status", "active"))
+    state["current_goal"] = _coalesce_text(current_goal, state.get("current_goal", ""))
+    state["decisions_summary"] = _coalesce_text(decisions_summary, state.get("decisions_summary", ""))
+    state["blockers"] = _coalesce_text(blockers, state.get("blockers", ""))
+    state["reasoning_thread"] = _coalesce_text(reasoning_thread, state.get("reasoning_thread", ""))
+    state["next_step"] = _coalesce_text(next_step, state.get("next_step", ""))
+
+    files = _normalize_active_files(active_files)
+    if files:
+        state["active_files"] = files
+
+    state["milestone_count"] = max(0, int(state.get("milestone_count", 0))) + 1
+    all_state[clean_sid] = state
+
+    flush_every = max(1, int(interval or DEFAULT_MILESTONE_INTERVAL))
+    if force_flush or state["milestone_count"] >= flush_every:
+        return _flush_state(all_state, clean_sid, state, reason=str(reason or "").strip())
+
+    _save_all(all_state)
+    return {
+        "ok": True,
+        "checkpoint_written": False,
+        "session_id": clean_sid,
+        "milestone_count": state["milestone_count"],
+        "flush_interval": flush_every,
+        "pending_reason": state["last_reason"],
+    }
+
+
+def force_runtime_checkpoint(session_id: str, *, reason: str = "pre-compact") -> dict[str, Any]:
+    clean_sid = str(session_id or "").strip()
+    if not clean_sid:
+        return {"ok": False, "error": "session_id is required"}
+
+    from db import get_db, read_checkpoint
+
+    all_state = _load_all()
+    state = _session_state(all_state, clean_sid)
+    conn = get_db()
+
+    session_row = conn.execute(
+        "SELECT task FROM sessions WHERE sid = ? LIMIT 1",
+        (clean_sid,),
+    ).fetchone()
+    existing_checkpoint = read_checkpoint(clean_sid) or {}
+    workflow_row = conn.execute(
+        """SELECT goal, status, current_step_key, next_action, shared_state
+           FROM workflow_runs
+           WHERE session_id = ?
+           ORDER BY updated_at DESC LIMIT 1""",
+        (clean_sid,),
+    ).fetchone()
+
+    workflow_state: dict[str, Any] = {}
+    if workflow_row and workflow_row["shared_state"]:
+        try:
+            parsed = json.loads(workflow_row["shared_state"])
+            if isinstance(parsed, dict):
+                workflow_state = parsed
+        except json.JSONDecodeError:
+            workflow_state = {}
+
+    workflow_blocker = ""
+    if workflow_row and workflow_row["status"] in {"blocked", "waiting_approval"}:
+        workflow_blocker = (
+            f"Workflow {workflow_row['status']} at "
+            f"{workflow_row['current_step_key'] or 'current-step'}"
+        )
+
+    merged_files = (
+        _normalize_active_files(state.get("active_files"))
+        or _extract_active_files_from_payload(workflow_state)
+        or _normalize_active_files(existing_checkpoint.get("active_files"))
+    )
+
+    state["task"] = _coalesce_text(
+        state.get("task", ""),
+        (session_row["task"] if session_row else "") or existing_checkpoint.get("task", ""),
+    )
+    state["current_goal"] = _coalesce_text(
+        state.get("current_goal", ""),
+        (workflow_row["goal"] if workflow_row else "") or existing_checkpoint.get("current_goal", "") or state.get("task", ""),
+    )
+    state["decisions_summary"] = _coalesce_text(
+        state.get("decisions_summary", ""),
+        existing_checkpoint.get("decisions_summary", "") or f"Forced durable checkpoint before {reason}.",
+    )
+    current_blockers = _coalesce_text(
+        state.get("blockers", ""),
+        existing_checkpoint.get("errors_found", ""),
+    )
+    if workflow_blocker:
+        if workflow_blocker not in current_blockers:
+            current_blockers = f"{workflow_blocker} | {current_blockers}".strip(" |")
+    state["blockers"] = current_blockers
+    state["reasoning_thread"] = _coalesce_text(
+        state.get("reasoning_thread", ""),
+        existing_checkpoint.get("reasoning_thread", "") or f"Auto-flushed by checkpoint_policy ({reason}).",
+    )
+    state["next_step"] = _coalesce_text(
+        state.get("next_step", ""),
+        (workflow_row["next_action"] if workflow_row else "") or existing_checkpoint.get("next_step", ""),
+    )
+    state["task_status"] = _coalesce_text(
+        state.get("task_status", ""),
+        (workflow_row["status"] if workflow_row else "") or existing_checkpoint.get("task_status", "") or "active",
+    )
+    state["active_files"] = merged_files
+    state["updated_at"] = _now_iso()
+    state["last_reason"] = reason
+    all_state[clean_sid] = state
+    return _flush_state(all_state, clean_sid, state, reason=reason)

--- a/src/hooks/post-compact.sh
+++ b/src/hooks/post-compact.sh
@@ -91,6 +91,36 @@ if [ -f "$NEXO_DB" ]; then
             LAST_HINT=$(echo "$DRAFT" | cut -d'|' -f2)
         fi
 
+        EXECUTION_LATCH=""
+        AUTONOMY_STATE_FILE="$DATA_DIR/autonomy_mandate.json"
+        if [ -f "$AUTONOMY_STATE_FILE" ]; then
+            EXECUTION_LATCH=$(
+                TARGET_SID="$SID" AUTONOMY_STATE_FILE="$AUTONOMY_STATE_FILE" python3 -c "
+import json, os, time
+try:
+    raw = json.loads(open(os.environ['AUTONOMY_STATE_FILE']).read())
+except Exception:
+    raise SystemExit(0)
+session_id = str(raw.get('session_id', '') or '').strip()
+target_sid = str(os.environ.get('TARGET_SID', '') or '').strip()
+if not raw.get('active'):
+    raise SystemExit(0)
+try:
+    expires_at = float(raw.get('expires_at', 0))
+except Exception:
+    expires_at = 0.0
+if expires_at <= time.time():
+    raise SystemExit(0)
+if session_id and target_sid and session_id != target_sid:
+    raise SystemExit(0)
+if not bool(raw.get('execute_until_blocker', True)):
+    raise SystemExit(0)
+print('**Execution mode:** execute-until-blocker still active after compaction.')
+print('**Guardrail:** skip option menus, reprioritization, summaries, and audits unless a real blocker or approval gate appears.')
+" 2>/dev/null || true
+            )
+        fi
+
         # Build Core Memory Block
         BLOCK="## SESSION CONTINUITY [auto-injected post-compaction #$((COMPACT_COUNT + 1))]"
         BLOCK="$BLOCK\n**Session:** $SID"
@@ -126,6 +156,10 @@ if [ -f "$NEXO_DB" ]; then
 
         if [ -n "$TASKS_SEEN" ] && [ "$TASKS_SEEN" != "[]" ]; then
             BLOCK="$BLOCK\n**Session tasks so far:** $TASKS_SEEN"
+        fi
+
+        if [ -n "$EXECUTION_LATCH" ]; then
+            BLOCK="$BLOCK\n$EXECUTION_LATCH"
         fi
 
         BLOCK="$BLOCK\n**Tool logs:** ${OPERATIONS_DIR}/tool-logs/${TODAY}.jsonl ($LOG_LINES entries)"

--- a/src/hooks/pre-compact.sh
+++ b/src/hooks/pre-compact.sh
@@ -49,6 +49,20 @@ if [ -f "$NEXO_DB" ]; then
                 END,
                 updated_at = datetime('now')
         " 2>/dev/null || true
+
+        # Flush the richer durable checkpoint state if milestone data exists.
+        NEXO_PRECOMPACT_SID="$LATEST_SID" HOOK_DIR="$HOOK_DIR" python3 -c "
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.environ['HOOK_DIR'], '..')))
+try:
+    import checkpoint_policy
+    checkpoint_policy.force_runtime_checkpoint(
+        os.environ['NEXO_PRECOMPACT_SID'],
+        reason='pre-compact-hook',
+    )
+except Exception:
+    pass
+" 2>/dev/null || true
     fi
 fi
 

--- a/src/plugins/protocol.py
+++ b/src/plugins/protocol.py
@@ -1648,6 +1648,28 @@ def handle_task_close(
             status = "debt-open"
             next_action = "Resolve the open protocol debt next."
 
+    durable_checkpoint = None
+    try:
+        from checkpoint_policy import record_milestone
+
+        checkpoint_blockers = ""
+        if clean_outcome in {"partial", "failed"}:
+            checkpoint_blockers = (outcome_notes or clean_evidence or next_action).strip()
+        durable_checkpoint = record_milestone(
+            task.get("session_id") or sid,
+            reason=f"task_close:{clean_outcome}",
+            task=task.get("goal", ""),
+            task_status=("blocked" if clean_outcome in {"partial", "failed"} else "active"),
+            active_files=effective_files,
+            current_goal=task.get("goal", ""),
+            decisions_summary=(clean_change_summary or clean_outcome),
+            blockers=checkpoint_blockers,
+            reasoning_thread=(clean_evidence or outcome_notes or "")[:800],
+            next_step=(next_action if clean_outcome != "done" else ""),
+        )
+    except Exception:
+        durable_checkpoint = None
+
     response = {
         "ok": True,
         "task_id": task_id,
@@ -1668,6 +1690,8 @@ def handle_task_close(
         "status": status,
         "next_action": next_action,
     }
+    if durable_checkpoint:
+        response["durable_checkpoint"] = durable_checkpoint
     return json.dumps(response, ensure_ascii=False, indent=2)
 
 

--- a/src/plugins/workflow.py
+++ b/src/plugins/workflow.py
@@ -71,6 +71,43 @@ def _parse_json_object(value: str) -> dict | None:
     return parsed if isinstance(parsed, dict) else None
 
 
+def _checkpoint_active_files(*payloads: dict | None) -> list[str]:
+    seen: list[str] = []
+    for payload in payloads:
+        if not isinstance(payload, dict):
+            continue
+        for key in ("active_files", "files", "tracked_files"):
+            raw = payload.get(key)
+            if raw is None:
+                continue
+            if isinstance(raw, str):
+                items = [item.strip() for item in raw.split(",") if item.strip()]
+            elif isinstance(raw, (list, tuple, set)):
+                items = [str(item).strip() for item in raw if str(item).strip()]
+            else:
+                items = [str(raw).strip()] if str(raw).strip() else []
+            for item in items:
+                if item and item not in seen:
+                    seen.append(item)
+    return seen
+
+
+def _workflow_blocker_text(
+    *,
+    step_status: str,
+    run_status: str,
+    summary: str,
+    next_action: str,
+    requires_approval: bool,
+) -> str:
+    status_tokens = {str(step_status or "").strip().lower(), str(run_status or "").strip().lower()}
+    if "blocked" in status_tokens:
+        return summary or next_action or "Workflow blocked."
+    if requires_approval or "waiting_approval" in status_tokens:
+        return summary or next_action or "Workflow waiting for approval."
+    return ""
+
+
 def handle_workflow_open(
     sid: str,
     goal: str,
@@ -387,6 +424,34 @@ def handle_workflow_update(
             "attempt_count": resume["next_step"].get("attempt_count", 0),
             "max_retries": resume["next_step"].get("max_retries", 0),
         }
+    try:
+        from checkpoint_policy import record_milestone
+
+        durable_checkpoint = record_milestone(
+            run.get("session_id", ""),
+            reason=f"workflow:{(step_key or run.get('current_step_key') or 'update')}",
+            task=run.get("goal", ""),
+            task_status=("blocked" if run["status"] in {"blocked", "waiting_approval"} else "active"),
+            active_files=_checkpoint_active_files(
+                _parse_json_object(shared_state) if str(shared_state).strip() else None,
+                _parse_json_object(state_patch) if str(state_patch).strip() else None,
+                run.get("shared_state") if isinstance(run.get("shared_state"), dict) else None,
+            ),
+            current_goal=run.get("goal", ""),
+            decisions_summary=(summary or checkpoint_label or step_title or step_key or run.get("last_checkpoint_label", "")),
+            blockers=_workflow_blocker_text(
+                step_status=step_status,
+                run_status=run["status"],
+                summary=summary,
+                next_action=next_action or run.get("next_action", ""),
+                requires_approval=requires_approval,
+            ),
+            reasoning_thread=(evidence or compensation or "").strip(),
+            next_step=(next_action or run.get("next_action", "")),
+        )
+        response["durable_checkpoint"] = durable_checkpoint
+    except Exception:
+        pass
     return json.dumps(response, ensure_ascii=False, indent=2)
 
 

--- a/src/tools_sessions.py
+++ b/src/tools_sessions.py
@@ -556,6 +556,27 @@ def handle_heartbeat(sid: str, task: str, context_hint: str = '') -> str:
 def _handle_heartbeat_inner(sid: str, task: str, context_hint: str = '') -> str:
     """Inner body of handle_heartbeat — wrapped by tool_span above."""
     from db import get_db, update_last_heartbeat_ts
+
+    mandate_state = None
+    if context_hint:
+        try:
+            from autonomy_mandate import maybe_ingest_from_text
+
+            mandate_state = maybe_ingest_from_text(
+                context_hint,
+                session_id=sid,
+                source="heartbeat",
+            )
+        except Exception:
+            mandate_state = None
+    if mandate_state is None:
+        try:
+            from autonomy_mandate import load_state
+
+            mandate_state = load_state()
+        except Exception:
+            mandate_state = None
+
     update_session(sid, task)
     # v6.0.1 — stamp last_heartbeat_ts so the PostToolUse hook can
     # decide whether to surface a pending-inbox reminder on autopilot
@@ -601,6 +622,16 @@ def _handle_heartbeat_inner(sid: str, task: str, context_hint: str = '') -> str:
                 parts.append(format_pre_action_context_bundle(bundle, compact=True))
         except Exception:
             pass
+
+    try:
+        from autonomy_mandate import format_execution_latch_notice
+
+        latch_notice = format_execution_latch_notice(sid, state=mandate_state)
+        if latch_notice:
+            parts.append("")
+            parts.append(latch_notice)
+    except Exception:
+        pass
 
     # Incremental diary draft — accumulate every heartbeat, full UPSERT every 5
     _hb_count = 0  # Hoisted for Layer 3 DIARY_OVERDUE signal

--- a/tests/test_autonomy_mandate.py
+++ b/tests/test_autonomy_mandate.py
@@ -36,6 +36,23 @@ def test_marker_detection_ingests_and_activates(mandate_module):
     assert st.session_id == "sid-1"
     loaded = am.load_state()
     assert loaded is not None and loaded.active
+    assert loaded.execute_until_blocker is True
+    assert loaded.suppress_mid_task_menus is True
+
+
+def test_new_explicit_markers_enable_execute_until_blocker(mandate_module):
+    am = mandate_module
+    st = am.maybe_ingest_from_text(
+        "Hazlo todo, no pares, estás al mando hasta que haya blocker real.",
+        session_id="sid-latch",
+    )
+    assert st is not None
+    assert st.marker in {"hazlo todo", "no pares", "estás al mando"}
+    assert am.is_execute_until_blocker_active("sid-latch") is True
+    notice = am.format_execution_latch_notice("sid-latch")
+    assert "execute-until-blocker" in notice
+    assert "option menus" in notice
+    assert "compaction" in notice
 
 
 def test_marker_detection_ingests_semantic_mandate(mandate_module):
@@ -59,6 +76,13 @@ def test_marker_detection_ignores_unrelated_text(mandate_module):
         classifier=lambda **_: False,
     ) is None
     assert am.load_state() is None
+
+
+def test_execution_latch_notice_is_session_scoped(mandate_module):
+    am = mandate_module
+    am.set_mandate(session_id="sid-owner", marker="hazlo todo")
+    assert am.format_execution_latch_notice("sid-owner")
+    assert am.format_execution_latch_notice("sid-other") == ""
 
 
 def test_expired_mandate_does_not_block(mandate_module):

--- a/tests/test_checkpoint_policy.py
+++ b/tests/test_checkpoint_policy.py
@@ -1,0 +1,182 @@
+import importlib
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+
+@pytest.fixture
+def checkpoint_runtime(isolated_db, tmp_path, monkeypatch):
+    monkeypatch.setenv("NEXO_HOME", str(tmp_path))
+
+    import checkpoint_policy
+    import db._core as db_core
+    import db._protocol as db_protocol
+    import db._workflow as db_workflow
+    import db
+    import plugins.protocol as protocol
+    import plugins.workflow as workflow
+    import tools_sessions
+
+    importlib.reload(checkpoint_policy)
+    importlib.reload(db_core)
+    importlib.reload(db_protocol)
+    importlib.reload(db_workflow)
+    importlib.reload(db)
+    importlib.reload(protocol)
+    importlib.reload(workflow)
+    importlib.reload(tools_sessions)
+    monkeypatch.setattr("plugins.workflow.get_protocol_strictness", lambda: "lenient")
+    yield checkpoint_policy
+
+
+def _register_session(sid: str):
+    from db import register_session
+
+    register_session(sid, "checkpoint policy test")
+    return sid
+
+
+def test_record_milestone_flushes_every_third_milestone(checkpoint_runtime):
+    import db
+
+    cp = checkpoint_runtime
+    sid = _register_session("nexo-1301-2301")
+
+    first = cp.record_milestone(
+        sid,
+        reason="task-close:inspect",
+        task="Ship continuity fix",
+        active_files=["/tmp/a.py"],
+        current_goal="Keep durable continuity",
+        next_step="Patch heartbeat",
+    )
+    second = cp.record_milestone(
+        sid,
+        reason="workflow:patch",
+        task="Ship continuity fix",
+        active_files=["/tmp/b.py"],
+        current_goal="Keep durable continuity",
+        next_step="Run tests",
+    )
+    third = cp.record_milestone(
+        sid,
+        reason="workflow:test",
+        task="Ship continuity fix",
+        active_files=["/tmp/c.py"],
+        current_goal="Keep durable continuity",
+        decisions_summary="Patched heartbeat + hooks",
+        blockers="",
+        next_step="Prepare release notes",
+    )
+
+    assert first["checkpoint_written"] is False
+    assert second["checkpoint_written"] is False
+    assert third["checkpoint_written"] is True
+
+    checkpoint = db.read_checkpoint(sid)
+    assert checkpoint is not None
+    assert checkpoint["current_goal"] == "Keep durable continuity"
+    assert "/tmp/c.py" in checkpoint["active_files"]
+    assert "checkpoint_reason=workflow:test" in checkpoint["decisions_summary"]
+    assert checkpoint["next_step"] == "Prepare release notes"
+
+
+def test_force_runtime_checkpoint_enriches_from_latest_workflow(checkpoint_runtime):
+    import db
+    from plugins.workflow import handle_workflow_open, handle_workflow_update
+
+    cp = checkpoint_runtime
+    sid = _register_session("nexo-1302-2302")
+
+    opened = json.loads(
+        handle_workflow_open(
+            sid=sid,
+            goal="Fix compaction continuity",
+            steps=json.dumps([{"step_key": "inspect", "title": "Inspect"}]),
+            next_action="Inspect current state",
+        )
+    )
+    json.loads(
+        handle_workflow_update(
+            run_id=opened["run_id"],
+            step_key="inspect",
+            step_status="blocked",
+            checkpoint_label="inspect-blocked",
+            summary="Waiting for next action after partial inspection",
+            next_action="Read the latest checkpoint after compaction",
+        )
+    )
+
+    flushed = cp.force_runtime_checkpoint(sid, reason="pre-compact-hook")
+    checkpoint = db.read_checkpoint(sid)
+
+    assert flushed["ok"] is True
+    assert flushed["checkpoint_written"] is True
+    assert checkpoint is not None
+    assert checkpoint["current_goal"] == "Fix compaction continuity"
+    assert "Workflow blocked" in checkpoint["errors_found"]
+    assert checkpoint["next_step"] == "Read the latest checkpoint after compaction"
+
+
+def test_task_close_response_includes_durable_checkpoint(checkpoint_runtime):
+    from plugins.protocol import handle_task_close, handle_task_open
+
+    sid = _register_session("nexo-1303-2303")
+    opened = json.loads(
+        handle_task_open(
+            sid=sid,
+            goal="Ship protocol fix",
+            task_type="edit",
+            area="nexo",
+            files="/tmp/protocol.py",
+            verification_step="run focused tests",
+        )
+    )
+
+    closed = json.loads(
+        handle_task_close(
+            sid=sid,
+            task_id=opened["task_id"],
+            outcome="done",
+            evidence="Focused protocol tests passed and checkpoint wiring was verified.",
+            files_changed='["/tmp/protocol.py"]',
+            change_summary="Added durable checkpoint wiring on task_close",
+        )
+    )
+
+    assert closed["ok"] is True
+    assert "durable_checkpoint" in closed
+    assert closed["durable_checkpoint"]["checkpoint_written"] is False
+
+
+def test_workflow_update_response_includes_durable_checkpoint(checkpoint_runtime):
+    from plugins.workflow import handle_workflow_open, handle_workflow_update
+
+    sid = _register_session("nexo-1304-2304")
+    opened = json.loads(
+        handle_workflow_open(
+            sid=sid,
+            goal="Keep execute-until-blocker through compaction",
+            steps=json.dumps([{"step_key": "patch", "title": "Patch"}]),
+        )
+    )
+
+    updated = json.loads(
+        handle_workflow_update(
+            run_id=opened["run_id"],
+            step_key="patch",
+            step_status="running",
+            checkpoint_label="patch-started",
+            summary="Patching heartbeat and post-compact surfaces",
+            state_patch=json.dumps({"active_files": ["/tmp/heartbeat.py", "/tmp/post-compact.sh"]}),
+            next_action="Finish the patch and run tests",
+        )
+    )
+
+    assert updated["ok"] is True
+    assert "durable_checkpoint" in updated
+    assert updated["durable_checkpoint"]["pending_reason"] == "workflow:patch"

--- a/tests/test_hot_context.py
+++ b/tests/test_hot_context.py
@@ -60,6 +60,30 @@ def test_heartbeat_surfaces_recent_context_from_last_hours(isolated_db):
     assert "recambiosbmw" in second.lower()
 
 
+def test_heartbeat_latches_execute_until_blocker_on_explicit_go(
+    isolated_db,
+    tmp_path,
+    monkeypatch,
+):
+    import autonomy_mandate
+    import tools_sessions
+
+    monkeypatch.setenv("NEXO_HOME", str(tmp_path))
+    importlib.reload(autonomy_mandate)
+    importlib.reload(tools_sessions)
+
+    sid = _register_session("nexo-1003-3003")
+    output = tools_sessions.handle_heartbeat(
+        sid,
+        "seguir ejecucion",
+        "Hazlo todo, no pares, estás al mando hasta terminar o encontrar un blocker real.",
+    )
+
+    assert "EXECUTION MODE: execute-until-blocker active" in output
+    assert "option menus" in output
+    assert autonomy_mandate.is_execute_until_blocker_active(sid) is True
+
+
 def test_task_open_includes_recent_context_excerpt(isolated_db):
     import db
     from plugins.protocol import handle_task_open

--- a/tests/test_shell_runtime_path_contract.py
+++ b/tests/test_shell_runtime_path_contract.py
@@ -65,12 +65,14 @@ def test_compaction_and_tool_log_hooks_use_runtime_layout() -> None:
     assert 'OPERATIONS_DIR="$NEXO_HOME/runtime/operations"' in pre_compact
     assert 'NEXO_DB="$DATA_DIR/nexo.db"' in pre_compact
     assert 'LOG_FILE="$OPERATIONS_DIR/tool-logs/${TODAY}.jsonl"' in pre_compact
+    assert "import checkpoint_policy" in pre_compact
 
     post_compact = _read("src/hooks/post-compact.sh")
     assert 'DATA_DIR="$NEXO_HOME/runtime/data"' in post_compact
     assert 'OPERATIONS_DIR="$NEXO_HOME/runtime/operations"' in post_compact
     assert 'NEXO_DB="$DATA_DIR/nexo.db"' in post_compact
     assert 'LOG_FILE="$OPERATIONS_DIR/tool-logs/${TODAY}.jsonl"' in post_compact
+    assert 'AUTONOMY_STATE_FILE="$DATA_DIR/autonomy_mandate.json"' in post_compact
 
 
 def test_auxiliary_hooks_use_runtime_or_core_locations_first() -> None:


### PR DESCRIPTION
## Summary
- Rescue of legitimate WIP that was stashed during the release session so the release commit could land clean.
- Extends autonomy_mandate markers + session-state flags; adds post/pre-compact hooks wiring; introduces `checkpoint_policy.py` with tests.

## Test plan
- [x] `pytest tests/test_autonomy_mandate.py tests/test_shell_runtime_path_contract.py tests/test_checkpoint_policy.py tests/test_hot_context.py -q` → 38 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)