### PR TITLE
fix(tests): stop test_core_prompts polluting NEXO_CODE for the whole suite

### DIFF
--- a/tests/test_core_prompts.py
+++ b/tests/test_core_prompts.py
@@ -9,8 +9,8 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-os.environ["NEXO_CODE"] = str(ROOT)
 SRC = ROOT / "src"
+os.environ["NEXO_CODE"] = str(SRC)
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 


### PR DESCRIPTION
## Summary
v7.1.10 rescued `test_core_prompts.py` ships a module-level `os.environ["NEXO_CODE"] = str(ROOT)` (ROOT = repo root, not `src/`). Because it is a direct env mutation (not `monkeypatch`), it runs at pytest collection time and persists for every subsequent test in the same process. Any module that captures `NEXO_CODE` at import time (e.g. `src/crons/sync.py::SOURCE_ROOT`, `src/doctor/providers/runtime.py::NEXO_CODE`, `src/runtime_power.py::NEXO_CODE`) ends up pointing to the repo root and derives paths without `src/`.

This caused 4 CI failures downstream of `test_core_prompts` in the v7.1.10 publish.yml run:
- `tests/test_doctor.py::TestRuntimeChecks::test_launchagent_integrity_fix_bootstraps_real_plist`
- `tests/test_doctor.py::TestRuntimeChecks::test_launchagent_integrity_fix_normalizes_special_launchagent_env`
- `tests/test_runtime_power.py::test_sync_core_crons_for_power_policy_is_noop_when_sync_surface_missing`
- `tests/test_user_data_portability.py::test_import_user_bundle_bypasses_export_rate_limit_for_safety_backup`

Fix: swap `os.environ["NEXO_CODE"] = str(ROOT)` to `str(SRC)` (and reorder so SRC is declared first). `core_prompts._resolve_repo_root()` normalizes `candidate.name == "src"` back to repo root, so test_core_prompts still passes.

## Test plan
- [x] Reproduced failure locally: `PYTHONPATH=src pytest tests/ -x` → same 4 tests fail after test_core_prompts.
- [x] With fix applied: `PYTHONPATH=src pytest $(ls tests/test_[a-c]*.py) tests/test_doctor.py::TestRuntimeChecks::test_launchagent_integrity_fix_bootstraps_real_plist tests/test_runtime_power.py::test_sync_core_crons_for_power_policy_is_noop_when_sync_surface_missing tests/test_user_data_portability.py::test_import_user_bundle_bypasses_export_rate_limit_for_safety_backup` → 457 passed.
- [x] Isolated repro: `pytest test_core_prompts.py test_doctor.py::...bootstraps_real_plist` → 11 passed.

No runtime behavior change. npm `nexo-brain@7.1.10` code is unaffected (tests-only fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)