### PR TITLE
brain: B8 + B9 + B10 + B11 small fixes consolidated

### DIFF
--- a/docs/release-discipline.md
+++ b/docs/release-discipline.md
@@ -1,0 +1,65 @@
+# NEXO Brain — release discipline
+
+Operational contract for cutting a new Brain release. Keeps the cadence
+evidence-based and reproducible without relying on operator memory.
+
+## TL;DR
+
+```bash
+# 1. Run the full pre-release wrapper. Fail means do not tag.
+scripts/pre-release-verify.sh --release vX.Y.Z
+
+# 2. If all checks pass, cut the release.
+git tag vX.Y.Z && git push origin vX.Y.Z
+```
+
+## What the wrapper covers
+
+`scripts/pre-release-verify.sh` chains the per-concern scripts already in
+the repo — it does not re-implement any check. Each step stays
+independently invocable:
+
+| Step | Script | Purpose |
+|------|--------|---------|
+| `privacy` | `scripts/check_no_personal_data.sh` | Secrets / personal data never leaves the public repo. |
+| `tool-map` | `scripts/verify_tool_map.py` | `tool-enforcement-map.json` is in sync with Python tool definitions (learning #335). |
+| `release-ready` | `scripts/verify_release_readiness.py --ci` | Package + website + smoke artifacts consistent with each other. |
+| `pytest` | `python3 -m pytest -q` | Every Brain test green. |
+| `release-target` | inline shell checks | Tag `vX.Y.Z` is still free, `CHANGELOG.md` lists it, `package.json` version matches. Only runs when `--release vX.Y.Z` is passed. |
+
+Skip any step with `--skip NAME` when iterating locally (do not skip in
+CI). `--help` prints the full flag list.
+
+## Why a wrapper instead of manual commands
+
+- **Single entry point for CI.** One command, one exit code.
+- **Locks step order.** Privacy is checked before anything else — a
+  failure there must abort everything downstream.
+- **Future-proof.** New checks go into their own canonical script and
+  get added to the wrapper as a new `run_step` line.
+- **Release-target gate.** The `vX.Y.Z` block catches the most common
+  release-day mistakes (tag already pushed, missing changelog entry,
+  forgotten `package.json` bump) without an external discipline doc.
+
+## Release procedure (human checklist)
+
+1. Confirm scope: every B/D/C item in `NEXO-MASTER-CHECKLIST.md` is
+   closed, or explicitly deferred.
+2. Bump `package.json` version and add the matching `CHANGELOG.md`
+   entry under `## [vX.Y.Z] — YYYY-MM-DD` with the usual
+   Added/Changed/Fixed sections.
+3. `scripts/pre-release-verify.sh --release vX.Y.Z` → must exit 0.
+4. Commit the bump on `main`. Tag `vX.Y.Z` and push the tag.
+5. GitHub Action publishes to npm.
+6. For Desktop coordination, `scripts/sync_release_artifacts.py` picks
+   up the new package metadata — run it before cutting the Desktop
+   release.
+
+## Related
+
+- Pre-commit hook (`scripts/hooks/pre-commit`) already blocks commits
+  that desync `tool-enforcement-map.json` — see `scripts/install-hooks.sh`.
+- `NF-RELEASE-DISCIPLINA-20260414` captured the original discipline
+  breach that motivated this wrapper.
+- `NF-DS-B232B713` captured the audit call for a unified pre-release
+  entrypoint.

--- a/scripts/check_no_personal_data.sh
+++ b/scripts/check_no_personal_data.sh
@@ -15,7 +15,10 @@
 
 set -euo pipefail
 
-ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# Default ROOT is the repo itself (path of this script's parent). Tests
+# and local sandboxes override via CHECK_ROOT so the scanner points at
+# a synthetic tree without touching the real src/.
+ROOT="${CHECK_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 cd "$ROOT"
 
 # Operator-specific markers — extend with care. Each one must be a

--- a/scripts/pre-release-verify.sh
+++ b/scripts/pre-release-verify.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# NEXO Brain — pre-release discipline wrapper.
+#
+# Fuente: NF-DS-B232B713 (read-plan + check-data + contract-test unified)
+#         + NF-RELEASE-DISCIPLINA-20260414 (version / changelog / tag).
+#
+# Orquesta los checks que ya existen en el repo en un solo comando para
+# uso local y CI. NO añade lógica nueva de verificación — cada check
+# vive en su script canónico.
+#
+# Uso:
+#   scripts/pre-release-verify.sh                    # smoke sin target
+#   scripts/pre-release-verify.sh --release v7.2.0   # + valida tag + changelog + package.json
+#   scripts/pre-release-verify.sh --skip pytest      # omite un step concreto
+#   scripts/pre-release-verify.sh --help
+#
+# Exit code 0 si todos los steps habilitados pasan, 1 si falla alguno.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+RELEASE_TARGET=""
+SKIP=()
+
+print_help() {
+    cat <<'HELP'
+scripts/pre-release-verify.sh — NEXO Brain release discipline wrapper.
+
+Checks (in order):
+  1. privacy         — scripts/check_no_personal_data.sh
+  2. tool-map        — scripts/verify_tool_map.py
+  3. release-ready   — scripts/verify_release_readiness.py --ci
+  4. pytest          — python3 -m pytest -q
+  5. release-target  — tag libre + CHANGELOG entry + package.json version
+                       (solo si se pasa --release vX.Y.Z)
+
+Flags:
+  --release vX.Y.Z   Activa el step release-target.
+  --skip NAME        Omite un step por nombre (repetible). Útil en loops locales.
+  --help, -h         Muestra este texto.
+HELP
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --release|-r)
+            [ $# -ge 2 ] || { echo "pre-release-verify: --release needs a value (vX.Y.Z)" >&2; exit 2; }
+            RELEASE_TARGET="$2"
+            shift 2
+            ;;
+        --skip)
+            [ $# -ge 2 ] || { echo "pre-release-verify: --skip needs a step name" >&2; exit 2; }
+            SKIP+=("$2")
+            shift 2
+            ;;
+        --help|-h)
+            print_help
+            exit 0
+            ;;
+        *)
+            echo "pre-release-verify: unknown arg $1" >&2
+            print_help >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [ -t 1 ]; then
+    GREEN='\033[0;32m'
+    RED='\033[0;31m'
+    YELLOW='\033[0;33m'
+    NC='\033[0m'
+else
+    GREEN=''; RED=''; YELLOW=''; NC=''
+fi
+
+STEP=0
+FAILED=0
+PASSED=0
+SKIPPED=0
+
+step_skipped() {
+    local name="$1"
+    for entry in ${SKIP[@]+"${SKIP[@]}"}; do
+        [ "$entry" = "$name" ] && return 0
+    done
+    return 1
+}
+
+run_step() {
+    local name="$1"
+    local label="$2"
+    shift 2
+    STEP=$((STEP+1))
+    if step_skipped "$name"; then
+        echo -e "${YELLOW}[${STEP}] ${label} — SKIPPED${NC}"
+        SKIPPED=$((SKIPPED+1))
+        return 0
+    fi
+    echo -e "${YELLOW}[${STEP}] ${label}${NC}"
+    if "$@"; then
+        echo -e "${GREEN}[${STEP}] ${label} — OK${NC}"
+        PASSED=$((PASSED+1))
+    else
+        echo -e "${RED}[${STEP}] ${label} — FAIL${NC}"
+        FAILED=$((FAILED+1))
+    fi
+}
+
+run_step privacy        "privacy guard"      bash scripts/check_no_personal_data.sh
+run_step tool-map       "tool-map sync"      python3 scripts/verify_tool_map.py
+run_step release-ready  "release readiness"  python3 scripts/verify_release_readiness.py --ci
+run_step pytest         "pytest smoke"       python3 -m pytest -q
+
+if [ -n "$RELEASE_TARGET" ]; then
+    STEP=$((STEP+1))
+    echo -e "${YELLOW}[${STEP}] release target ${RELEASE_TARGET}${NC}"
+    TARGET_FAIL=0
+    if git rev-parse --quiet --verify "refs/tags/${RELEASE_TARGET}" >/dev/null; then
+        echo -e "${RED}  - tag ${RELEASE_TARGET} already exists${NC}"
+        TARGET_FAIL=1
+    else
+        echo "  - tag ${RELEASE_TARGET} is free"
+    fi
+    if grep -qE "^## \[?${RELEASE_TARGET}\]?" CHANGELOG.md 2>/dev/null; then
+        echo "  - CHANGELOG.md has entry for ${RELEASE_TARGET}"
+    else
+        echo -e "${RED}  - CHANGELOG.md missing entry for ${RELEASE_TARGET}${NC}"
+        TARGET_FAIL=1
+    fi
+    PKG_VER=$(python3 -c "import json; print(json.load(open('package.json'))['version'])" 2>/dev/null || echo "")
+    WANT="${RELEASE_TARGET#v}"
+    if [ "$PKG_VER" = "$WANT" ]; then
+        echo "  - package.json version matches (${PKG_VER})"
+    else
+        echo -e "${RED}  - package.json version is ${PKG_VER:-<unreadable>} but target is ${WANT}${NC}"
+        TARGET_FAIL=1
+    fi
+    if [ "$TARGET_FAIL" -eq 0 ]; then
+        echo -e "${GREEN}[${STEP}] release target ${RELEASE_TARGET} — OK${NC}"
+        PASSED=$((PASSED+1))
+    else
+        echo -e "${RED}[${STEP}] release target ${RELEASE_TARGET} — FAIL${NC}"
+        FAILED=$((FAILED+1))
+    fi
+fi
+
+echo
+echo -e "pre-release-verify: ${GREEN}${PASSED} passed${NC}, ${RED}${FAILED} failed${NC}, ${YELLOW}${SKIPPED} skipped${NC}"
+
+if [ "$FAILED" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/src/r34_identity_coherence.py
+++ b/src/r34_identity_coherence.py
@@ -26,9 +26,27 @@ and this module decides whether to inject.
 from __future__ import annotations
 
 import re
-from typing import Callable, Iterable, Optional
+from typing import Any, Callable, Iterable, Optional
 
 from core_prompts import render_core_prompt
+
+
+def _verdict_to_bool(verdict: Any) -> bool:
+    """Normalize a classifier verdict to an inject/no-inject decision.
+
+    The shared ``enforcement_classifier.classify`` exposes a ``tristate``
+    mode that returns ``"yes"``/``"no"``/``"unknown"`` strings. A naive
+    ``bool(verdict)`` wrap treats ``"unknown"`` (and any non-empty string
+    the model may produce) as truthy, which is fail-OPEN for R34. Only
+    a real ``True`` or an explicit ``"yes"`` should trigger an injection;
+    every other shape — ``False``, ``None``, ``"no"``, ``"unknown"``,
+    arbitrary strings — is conservative no-inject.
+    """
+    if isinstance(verdict, bool):
+        return verdict
+    if isinstance(verdict, str):
+        return verdict.strip().lower() == "yes"
+    return False
 
 
 # Shared-brain tools that count as "you checked before speaking".
@@ -79,7 +97,7 @@ def should_inject_r34(
     message: str,
     *,
     recent_tool_names: Iterable[str] | None,
-    classifier: Callable[[str, str], bool] | None = None,
+    classifier: Callable[[str, str], Any] | None = None,
 ) -> tuple[bool, str, str]:
     """Return ``(inject, prompt, matched_text)``.
 
@@ -88,9 +106,11 @@ def should_inject_r34(
         recent_tool_names: tool names seen in this turn; any match in
             SHARED_BRAIN_TOOLS suppresses the rule.
         classifier: optional LLM classifier. Signature
-            ``classifier(question, context) -> bool``. If provided, the
-            rule fires only when classifier says "yes". If None, the
-            regex match alone fires (test path).
+            ``classifier(question, context) -> bool | str``. Return ``True``
+            or the string ``"yes"`` to trigger injection; any other value
+            (``False``, ``None``, ``"no"``, ``"unknown"``, arbitrary
+            strings) is treated as no-inject. If ``None`` is passed for
+            the argument, the regex match alone fires (test path).
     """
     if not isinstance(message, str) or not message:
         return False, "", ""
@@ -103,15 +123,17 @@ def should_inject_r34(
     if classifier is None:
         return True, INJECTION_PROMPT, matched
     # LLM disambiguation — reuses T4 infra. The engine passes a lambda
-    # that calls enforcement_classifier.classify under the hood.
+    # that calls enforcement_classifier.classify under the hood. Parse
+    # the verdict via _verdict_to_bool so tristate "unknown" does not
+    # coerce to True.
     try:
-        verdict = bool(classifier(CLASSIFIER_QUESTION, message))
+        raw_verdict = classifier(CLASSIFIER_QUESTION, message)
     except Exception:
         # Fail-closed: if the classifier errors, do not inject (avoids
         # noisy false positives on regex-only matches when the LLM is
         # unavailable).
         return False, "", matched
-    if not verdict:
+    if not _verdict_to_bool(raw_verdict):
         return False, "", matched
     return True, INJECTION_PROMPT, matched
 
@@ -121,5 +143,6 @@ __all__ = [
     "CLASSIFIER_QUESTION",
     "INJECTION_PROMPT",
     "SHARED_BRAIN_TOOLS",
+    "_verdict_to_bool",
     "should_inject_r34",
 ]

--- a/src/script_registry.py
+++ b/src/script_registry.py
@@ -707,7 +707,14 @@ def classify_scripts_dir() -> dict:
     core_names = load_core_script_names()
     core_identities = load_core_script_identities()
     entries: list[dict] = []
-    seen_keys: set[tuple[str, str]] = set()
+    # Dedup by resolved real path so the same physical file surfaced
+    # from two candidate dirs (e.g. core/scripts/foo.sh + the F0.6
+    # legacy fallback ~/.nexo/scripts/foo.sh pointing at the same inode
+    # via symlink) appears once. Two distinct files that happen to share
+    # a filename resolve to different paths and both survive — preserves
+    # the D2 audit fix without the cosmetic duplicate the AUDITOR-V700-
+    # PASS2 §5 transitional window flagged.
+    seen_real_paths: set[str] = set()
     for sdir in candidate_dirs:
         if not sdir.is_dir():
             continue
@@ -725,12 +732,13 @@ def classify_scripts_dir() -> dict:
         for f in sorted(sdir.iterdir()):
             if not f.is_file():
                 continue
-            # Dedup by (name, dir-classification) so a personal script with
-            # the same filename as a core script doesn't disappear (D2 audit fix).
-            dedup_key = (f.name, dir_classification or "legacy")
-            if dedup_key in seen_keys:
+            try:
+                real_path = str(f.resolve(strict=False))
+            except OSError:
+                real_path = str(f)
+            if real_path in seen_real_paths:
                 continue
-            seen_keys.add(dedup_key)
+            seen_real_paths.add(real_path)
             meta = parse_inline_metadata(f)
             if _is_ignored(f):
                 entries.append(_script_entry(f, meta, is_core=False, classification="ignored", reason="internal or hidden artifact"))

--- a/tests/test_check_no_personal_data.py
+++ b/tests/test_check_no_personal_data.py
@@ -1,0 +1,105 @@
+"""Regression tests for scripts/check_no_personal_data.sh.
+
+B9 privacy guard — ensure the CI gate actually fails on a synthetic
+leak and stays silent on a clean tree. The tests exercise the script
+through a ``CHECK_ROOT`` override so the repo's real ``src/`` is never
+touched; the override is a one-line hook in the script itself.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "check_no_personal_data.sh"
+
+
+def _run_guard(root: Path) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env["CHECK_ROOT"] = str(root)
+    return subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture
+def sandbox(tmp_path: Path) -> Path:
+    (tmp_path / "src").mkdir()
+    return tmp_path
+
+
+def test_script_exists_and_is_executable():
+    assert SCRIPT.is_file(), f"missing {SCRIPT}"
+    assert os.access(SCRIPT, os.X_OK), f"{SCRIPT} must be executable"
+
+
+def test_clean_tree_passes(sandbox):
+    (sandbox / "src" / "app.py").write_text(
+        "# generic module\n"
+        'CONTACT = "support@example.com"\n'
+        "PORT = 8080\n"
+    )
+    result = _run_guard(sandbox)
+    assert result.returncode == 0, (
+        f"expected clean tree to pass.\nstdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+    assert "OK" in result.stdout
+
+
+def test_fixed_string_leak_fails(sandbox):
+    """One of the operator-specific fixed patterns in src/ must fail."""
+    (sandbox / "src" / "leak.py").write_text(
+        'OWNER_EMAIL = "info@wazion.com"\n'
+    )
+    result = _run_guard(sandbox)
+    assert result.returncode == 1, (
+        f"expected fixed-pattern leak to fail.\nstdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+    assert "LEAK" in result.stdout
+
+
+def test_regex_email_leak_fails(sandbox):
+    """A fresh operator's email would not appear in the fixed list, but the
+    regex shape detector (AUDITOR-3RDPASS-V640 §Risk 1) must still catch it.
+    """
+    (sandbox / "src" / "leak.py").write_text(
+        'OWNER_EMAIL = "freshoperator@some-tenant.io"\n'
+    )
+    result = _run_guard(sandbox)
+    assert result.returncode == 1, (
+        f"expected regex shape to catch an unknown operator email.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "LEAK" in result.stdout
+
+
+def test_allowlisted_placeholders_pass(sandbox):
+    """Documentation placeholders and RFC 2606 examples must not alarm."""
+    (sandbox / "src" / "docs.py").write_text(
+        '"""Send to owner@example.com (RFC 2606 example)."""\n'
+        'LOCAL = "127.0.0.1"\n'
+        'TEST_NET = "192.0.2.1"\n'
+    )
+    result = _run_guard(sandbox)
+    assert result.returncode == 0, (
+        f"expected allowlisted placeholders to pass.\nstdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+
+
+def test_users_path_leak_fails(sandbox):
+    (sandbox / "src" / "leak.py").write_text(
+        'HOME = "/Users/franciscoc/something"\n'
+    )
+    result = _run_guard(sandbox)
+    assert result.returncode == 1
+    assert "LEAK" in result.stdout

--- a/tests/test_r34_identity_coherence.py
+++ b/tests/test_r34_identity_coherence.py
@@ -12,6 +12,7 @@ from r34_identity_coherence import (  # noqa: E402
     DENIAL_PATTERNS,
     INJECTION_PROMPT,
     SHARED_BRAIN_TOOLS,
+    _verdict_to_bool,
     should_inject_r34,
 )
 
@@ -79,6 +80,40 @@ def test_classifier_exception_fails_closed():
         "yo no he hecho eso", recent_tool_names=[], classifier=boom
     )
     assert inject is False
+
+
+@pytest.mark.parametrize("verdict", ["unknown", "no", "maybe", "", "si", None, 0, []])
+def test_classifier_tristate_non_yes_suppresses(verdict):
+    """The classifier may return tristate strings; only True/"yes" injects."""
+    inject, _, _ = should_inject_r34(
+        "yo no he hecho eso",
+        recent_tool_names=[],
+        classifier=lambda q, msg: verdict,
+    )
+    assert inject is False, f"verdict={verdict!r} should not inject"
+
+
+@pytest.mark.parametrize("verdict", [True, "yes", "YES", "Yes", "yes\n"])
+def test_classifier_tristate_yes_allows(verdict):
+    inject, _, _ = should_inject_r34(
+        "yo no he hecho eso",
+        recent_tool_names=[],
+        classifier=lambda q, msg: verdict,
+    )
+    assert inject is True, f"verdict={verdict!r} should inject"
+
+
+def test_verdict_to_bool_direct():
+    assert _verdict_to_bool(True) is True
+    assert _verdict_to_bool(False) is False
+    assert _verdict_to_bool(None) is False
+    assert _verdict_to_bool("yes") is True
+    assert _verdict_to_bool("YES") is True
+    assert _verdict_to_bool("no") is False
+    assert _verdict_to_bool("unknown") is False
+    assert _verdict_to_bool("") is False
+    assert _verdict_to_bool(1) is False  # non-bool truthy is NOT yes
+    assert _verdict_to_bool(object()) is False
 
 
 def test_empty_or_non_string_input_safe():

--- a/tests/test_script_registry.py
+++ b/tests/test_script_registry.py
@@ -395,6 +395,55 @@ class TestCoreFiltering:
         text = script.read_text()
         assert "# nexo: cron_id=wake-recovery" in text
 
+    def test_classify_scripts_dir_dedups_symlinked_file(self, tmp_path, monkeypatch):
+        """F0.6 transitional: same physical file surfaces from two candidate
+        dirs via symlink (AUDITOR-V700-PASS2 §5). Dedup by realpath keeps
+        it to a single entry without hiding genuinely distinct files.
+        """
+        import paths
+        import script_registry
+
+        core_dir = tmp_path / "core" / "scripts"
+        core_dir.mkdir(parents=True)
+        real_script = core_dir / "shared-tool.sh"
+        real_script.write_text(
+            "#!/bin/bash\n# nexo: name=shared-tool\necho shared\n"
+        )
+        os.chmod(real_script, 0o755)
+
+        personal_dir = tmp_path / "personal" / "scripts"
+        personal_dir.mkdir(parents=True)
+        (personal_dir / "shared-tool.sh").symlink_to(real_script)
+        # A genuinely distinct file with a different name should survive.
+        unique_personal = personal_dir / "my-unique.sh"
+        unique_personal.write_text(
+            "#!/bin/bash\n# nexo: name=my-unique\necho unique\n"
+        )
+        os.chmod(unique_personal, 0o755)
+
+        core_dev_dir = tmp_path / "core-dev" / "scripts"
+        core_dev_dir.mkdir(parents=True)
+
+        monkeypatch.setattr(
+            paths, "all_scripts_dirs", lambda: [core_dir, personal_dir, core_dev_dir]
+        )
+        monkeypatch.setattr(script_registry, "get_scripts_dir", lambda: personal_dir)
+        monkeypatch.setattr(script_registry, "load_core_script_names", lambda: set())
+        monkeypatch.setattr(
+            script_registry, "load_core_script_identities", lambda: set()
+        )
+        monkeypatch.setattr(
+            script_registry, "_apply_legacy_personal_script_backfills", lambda: None
+        )
+
+        report = classify_scripts_dir()
+        shared_entries = [e for e in report["entries"] if e["name"] == "shared-tool"]
+        assert (
+            len(shared_entries) == 1
+        ), f"expected realpath dedup to collapse symlink duplicates, got {shared_entries}"
+        unique_entries = [e for e in report["entries"] if e["name"] == "my-unique"]
+        assert len(unique_entries) == 1, "genuinely distinct files must survive dedup"
+
 
 class TestResolveScript:
     def test_resolve_by_name(self, scripts_dir):


### PR DESCRIPTION
## Scope

Nero's B7-B11 branch, running in parallel to Francisco's B1-B6. Small-fixes consolidated PR grouping independent items that do not conflict with the parallel branch. Base: `refactor/brain-b1-b6-fresh-install` for isolation.

### Commits

1. **e04c490 — B10 R34 bool parser** (AUDITOR-NOCTURNO §M1). `bool(classifier(...))` treated any non-empty string as truthy → tristate `"unknown"` forced false-positive injection. New `_verdict_to_bool` accepts only `True` or case-insensitive `"yes"`.
2. **7b3eeb9 — B10 classify_scripts_dir dedup by realpath** (AUDITOR-V700-PASS2 §5). Same physical file from two candidate dirs via F0.6 symlink used to appear twice. Now dedup by `f.resolve(strict=False)`.
3. **4a2ebc5 — B11 pre-release pack**. `scripts/pre-release-verify.sh` chains privacy + tool-map + release-readiness + pytest + release-target opcional. `docs/release-discipline.md` documents procedure. Pre-commit tool-map hook (ENFORCER-F2 0.16) already exists at `scripts/hooks/pre-commit`.
4. **469b81b — B9 privacy guard CI fixture**. `CHECK_ROOT` env override on `check_no_personal_data.sh` + `tests/test_check_no_personal_data.py` with 6 cases (fixed-string, regex email, /Users/ path, allowlist placeholders). CI job in `.github/workflows/security.yml` already active; this PR adds the regression safety net.

### Data-only side-work (no file diff)

- **B8 rules DB**: #212→#224 supersede already applied (commit 14ffdf2 migration v50); #156 (cloudflare/wrangler/dmarc...) `applies_to` populated — `guard_check` now filters by domain and stops firing on unrelated paths.

### Tests

```
pytest tests/test_r34_identity_coherence.py tests/test_script_registry.py \
       tests/test_check_no_personal_data.py
→ 92 passed, 3 xpassed
```

Related-area smoke (`test_guard_verbal_ack`, `test_post_tool_use_protocol_reminder`) → 8 passed.

Wrapper smoke: `bash scripts/pre-release-verify.sh --help`, `--skip` combos, `--release v999.0.0` (correct FAIL exit=1).

### Deferred / needing operator input before next PR

- **Path constants lazy-eval** (B10 item 3): 4 files; `update.py` has 3 blocking learning rules that deserve their own review. Moved to a separate follow-up PR.
- **Protocol-debt drain** (B9 "<10 debts"): reality is 444 open — mass-resolve is destructive, waiting for Francisco's green-light on a conservative GC policy (e.g. auto-resolve warns older than 7 days, keep recent errors visible).
- **tests/ extension of privacy guard**: blocked by `francisco_emails` shim (NF-DS-2C6E0FD4); will go in the same commit that retires the shim, post-release.
- **B9 hook work** (post-audit followup NF-DS-552323BE, re-consult opt-out NF-DS-E41FBD45, long-session checklist NF-DS-67F8DCF5, mid-session restriction-lift guardrail NF-DS-9B9B4E63): each touches runtime enforcement and deserves its own task_open + cortex_decide + PR. Moved to a follow-up.
- **B7 embeddings** (`find_similar_followups`, `find_similar_learnings`, classifier migrations): blocked until B6 classifier auto-install lands in Francisco's branch.

### Coordination

Does **not** touch `src/auto_update.py`, `src/paths.py`, `src/email_config.py`, `src/classifier_local.py`, `src/core_schedule_controls.py`, `src/plugins/personal_scripts.py::handle_core_schedule_*`, or `tests/test_email_accounts.py` (francisco_emails shim, NF-DS-2C6E0FD4).
