### PR TITLE
brain: B10 path constants lazy-eval (3 clean files)

### DIFF
--- a/src/plugins/recover.py
+++ b/src/plugins/recover.py
@@ -46,10 +46,41 @@ from db_guard import (
     validate_backup_matches_source,
 )
 
-NEXO_HOME = export_resolved_nexo_home()
-DATA_DIR = paths.data_dir()
-BACKUP_BASE = paths.backups_dir()
-PRIMARY_DB = DATA_DIR / "nexo.db"
+# Path resolution moved to lazy helpers (AUDITOR-V700-PASS2 §11, B10 item 3)
+# to keep monkeypatched NEXO_HOME / paths.* fixtures honoured. PEP 562
+# ``__getattr__`` below preserves the legacy constant names for any caller
+# that imports them as module attributes.
+
+
+def _nexo_home() -> Path:
+    return export_resolved_nexo_home()
+
+
+def _data_dir() -> Path:
+    return paths.data_dir()
+
+
+def _backup_base() -> Path:
+    return paths.backups_dir()
+
+
+def _primary_db() -> Path:
+    return _data_dir() / "nexo.db"
+
+
+_LAZY_PATHS = {
+    "NEXO_HOME": _nexo_home,
+    "DATA_DIR": _data_dir,
+    "BACKUP_BASE": _backup_base,
+    "PRIMARY_DB": _primary_db,
+}
+
+
+def __getattr__(name: str):
+    resolver = _LAZY_PATHS.get(name)
+    if resolver is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    return resolver()
 
 
 # ── Backup discovery ────────────────────────────────────────────────────
@@ -64,24 +95,25 @@ def list_available_backups() -> list[dict]:
     critical_rows, is_usable. Sorted newest-first.
     """
     entries: list[dict] = []
-    if not BACKUP_BASE.is_dir():
+    backup_base = _backup_base()
+    if not backup_base.is_dir():
         return entries
 
     # Hourly backups from nexo-backup.sh
-    for entry in BACKUP_BASE.glob(HOURLY_BACKUP_GLOB):
+    for entry in backup_base.glob(HOURLY_BACKUP_GLOB):
         if not entry.is_file():
             continue
         entries.append(_describe_backup(entry, kind="hourly"))
 
     # Weekly backups
-    weekly_dir = BACKUP_BASE / "weekly"
+    weekly_dir = backup_base / "weekly"
     if weekly_dir.is_dir():
         for entry in weekly_dir.glob("weekly-*.db"):
             if entry.is_file():
                 entries.append(_describe_backup(entry, kind="weekly"))
 
     # pre-update / pre-autoupdate / pre-recover / pre-heal snapshot dirs
-    for subdir in BACKUP_BASE.iterdir():
+    for subdir in backup_base.iterdir():
         if not subdir.is_dir():
             continue
         name = subdir.name
@@ -162,7 +194,7 @@ def recover(
         dry_run: Report what would happen without touching disk.
         target: Override the target DB path (defaults to ~/.nexo/data/nexo.db).
     """
-    target_path = Path(target).expanduser() if target else PRIMARY_DB
+    target_path = Path(target).expanduser() if target else _primary_db()
     target_path.parent.mkdir(parents=True, exist_ok=True)
 
     result: dict = {
@@ -236,7 +268,7 @@ def recover(
             time.sleep(0.5)
 
     # Step 4: snapshot current state to pre-recover/
-    pre_recover_dir = BACKUP_BASE / f"pre-recover-{time.strftime('%Y-%m-%d-%H%M%S')}"
+    pre_recover_dir = _backup_base() / f"pre-recover-{time.strftime('%Y-%m-%d-%H%M%S')}"
     if target_path.is_file():
         pre_recover_dir.mkdir(parents=True, exist_ok=True)
         # Copy the main DB plus any sidecar files (-wal, -shm) with shutil so

--- a/src/public_contribution.py
+++ b/src/public_contribution.py
@@ -42,17 +42,57 @@ VALID_STATUSES = {
     STATUS_OFF,
 }
 
-NEXO_HOME = Path(os.environ.get("NEXO_HOME", str(Path.home() / ".nexo")))
+# Path resolution moved to lazy functions (AUDITOR-V700-PASS2 §11, B10 item
+# 3). The previous module-level constants were evaluated at import time, so
+# any caller that monkeypatched NEXO_HOME or ``paths.operations_dir()`` after
+# import kept seeing the stale values. PEP 562 ``__getattr__`` below still
+# exposes ``public_contribution.NEXO_HOME`` / ``CONTRIB_ROOT`` / etc. for
+# legacy callers that access them as module attributes — re-evaluated on
+# every access. A call like ``from public_contribution import CONTRIB_ROOT``
+# still snapshots at import, which is the intended behaviour for scripts
+# whose NEXO_HOME is fixed before they start.
+
+
+def _nexo_home() -> Path:
+    return Path(os.environ.get("NEXO_HOME", str(Path.home() / ".nexo")))
+
+
 # Public-contribution staging lives under ``NEXO_HOME / contrib`` (the mirror
 # clone of the public repo plus per-proposal worktrees). It is intentionally
 # outside ``paths.operations_dir()`` because it holds an actual git clone, not
-# operational artifacts. Artifacts (logs, proposal payloads) live at
-# ``CONTRIB_ARTIFACTS_DIR`` below. If this ever relocates, migrate the existing
-# clone + open worktrees — do NOT delete and reclone blindly.
-CONTRIB_ROOT = NEXO_HOME / "contrib" / "public-core"
-CONTRIB_REPO_DIR = CONTRIB_ROOT / "repo"
-CONTRIB_WORKTREES_DIR = CONTRIB_ROOT / "worktrees"
-CONTRIB_ARTIFACTS_DIR = paths.operations_dir() / "public-contrib"
+# operational artifacts. Artifacts (logs, proposal payloads) live under
+# ``_contrib_artifacts_dir()`` below. If this ever relocates, migrate the
+# existing clone + open worktrees — do NOT delete and reclone blindly.
+def _contrib_root() -> Path:
+    return _nexo_home() / "contrib" / "public-core"
+
+
+def _contrib_repo_dir() -> Path:
+    return _contrib_root() / "repo"
+
+
+def _contrib_worktrees_dir() -> Path:
+    return _contrib_root() / "worktrees"
+
+
+def _contrib_artifacts_dir() -> Path:
+    return paths.operations_dir() / "public-contrib"
+
+
+_LAZY_PATHS = {
+    "NEXO_HOME": _nexo_home,
+    "CONTRIB_ROOT": _contrib_root,
+    "CONTRIB_REPO_DIR": _contrib_repo_dir,
+    "CONTRIB_WORKTREES_DIR": _contrib_worktrees_dir,
+    "CONTRIB_ARTIFACTS_DIR": _contrib_artifacts_dir,
+}
+
+
+def __getattr__(name: str):
+    resolver = _LAZY_PATHS.get(name)
+    if resolver is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    return resolver()
 
 
 def _utcnow() -> datetime:

--- a/src/tools_sessions.py
+++ b/src/tools_sessions.py
@@ -32,8 +32,38 @@ except Exception:  # pragma: no cover - optional runtime dependency
 # Threads are daemon=True so they die when the MCP server process exits.
 
 KEEPALIVE_INTERVAL = 600  # 10 min — well inside the 15-min TTL
-NEXO_HOME = Path(os.environ.get("NEXO_HOME", str(Path.home() / ".nexo")))
-SESSION_PORTABILITY_DIR = paths.operations_dir() / "session-portability"
+
+
+# Path resolution moved to lazy functions (AUDITOR-V700-PASS2 §11, B10 item
+# 3). The prior module-level NEXO_HOME / SESSION_PORTABILITY_DIR constants
+# were evaluated at import time, so tests that monkeypatched NEXO_HOME or
+# paths.operations_dir() after import saw stale values. The ``__getattr__``
+# hook below keeps ``tools_sessions.SESSION_PORTABILITY_DIR`` / ``.NEXO_HOME``
+# working for attribute-style access (re-evaluated on every read). The
+# existing ``monkeypatch.setattr(tools_sessions, "SESSION_PORTABILITY_DIR",
+# ...)`` pattern in tests keeps working because setattr inserts into the
+# module __dict__ and shadows __getattr__.
+
+
+def _nexo_home() -> Path:
+    return Path(os.environ.get("NEXO_HOME", str(Path.home() / ".nexo")))
+
+
+def _session_portability_dir() -> Path:
+    return paths.operations_dir() / "session-portability"
+
+
+_LAZY_PATHS = {
+    "NEXO_HOME": _nexo_home,
+    "SESSION_PORTABILITY_DIR": _session_portability_dir,
+}
+
+
+def __getattr__(name: str):
+    resolver = _LAZY_PATHS.get(name)
+    if resolver is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    return resolver()
 
 _keepalive_threads: dict[str, threading.Event] = {}  # sid → stop_event
 
@@ -264,7 +294,7 @@ def handle_session_export_bundle(sid: str = "", path: str = "") -> str:
         return json.dumps(bundle, ensure_ascii=False)
 
     session_id = bundle["session"]["sid"]
-    export_path = Path(path).expanduser() if path else (SESSION_PORTABILITY_DIR / f"{session_id}.json")
+    export_path = Path(path).expanduser() if path else (_session_portability_dir() / f"{session_id}.json")
     export_path.parent.mkdir(parents=True, exist_ok=True)
     export_path.write_text(json.dumps(bundle, indent=2, ensure_ascii=False) + "\n")
     return json.dumps(

--- a/tests/test_session_portability.py
+++ b/tests/test_session_portability.py
@@ -20,7 +20,11 @@ def portability_runtime(isolated_db, monkeypatch):
     importlib.reload(db_episodic)
     importlib.reload(db)
     importlib.reload(tools_sessions)
-    monkeypatch.setattr(tools_sessions, "SESSION_PORTABILITY_DIR", Path(isolated_db["nexo_db"]).parent / "portability")
+    portability_dir = Path(isolated_db["nexo_db"]).parent / "portability"
+    # Override the lazy path helper so internal callers resolve to the
+    # isolated sandbox. The former ``SESSION_PORTABILITY_DIR`` constant is
+    # still exposed via PEP 562 __getattr__ for external callers.
+    monkeypatch.setattr(tools_sessions, "_session_portability_dir", lambda: portability_dir)
     yield
 
 


### PR DESCRIPTION
## Scope

Path constants lazy-eval (B10 item 3, AUDITOR-V700-PASS2 §11) for the 3 "clean" files — `public_contribution.py`, `tools_sessions.py`, `plugins/recover.py`. `plugins/update.py` is deliberately out of scope: its 3 blocking learning rules (#186 auto-restart, #325 TestRuntimeUpdate isolated dirs, #323 NPM canonical) get their own PR + task_open so the review reflects the extra caution that file needs.

Base: `refactor/brain-b7-b11` (stacked on top of PR #258).

### Pattern applied

Each module now has private helpers (`_nexo_home`, `_contrib_root`, `_session_portability_dir`, `_backup_base`, etc.) and a PEP 562 `__getattr__` that re-resolves the legacy UPPERCASE constants on every attribute access. That keeps three distinct call styles working:

1. `module.CONSTANT` — re-evaluated every read, honours any monkeypatch / env change.
2. `from module import CONSTANT` — still snapshots at the importer's import time, which is the intended behaviour for shipped scripts where `NEXO_HOME` is fixed before start.
3. `monkeypatch.setattr(module, "CONSTANT", ...)` — inserts into `module.__dict__` and shadows `__getattr__`. Keeps working.

Internal call sites inside each module switch to the helper function directly (bare-name lookups inside a module do NOT trigger PEP 562 `__getattr__`).

### Commits

1. **a47ef5f — public_contribution** NEXO_HOME + CONTRIB_ROOT + CONTRIB_REPO_DIR + CONTRIB_WORKTREES_DIR + CONTRIB_ARTIFACTS_DIR. Preserved the Fase 1 rationale docstring above `_contrib_root()`. No caller update needed — `from ... import` usage in `src/scripts/nexo-evolution-run.py` is intentional snapshot-at-start.
2. **cae7cfd — tools_sessions** NEXO_HOME + SESSION_PORTABILITY_DIR. The `tests/test_session_portability.py` fixture now monkey-patches the helper function so internal callers honour the isolated sandbox while external attribute access still works via `__getattr__`.
3. **6f8d25f — plugins/recover** NEXO_HOME + DATA_DIR + BACKUP_BASE + PRIMARY_DB. Internal callsites in `list_available_backups` and `restore_from_backup` use the helpers directly.

### Tests

```
pytest tests/test_public_contribution.py tests/test_session_portability.py \
       tests/test_recover.py tests/test_r34_identity_coherence.py \
       tests/test_script_registry.py tests/test_check_no_personal_data.py
→ 107 passed, 3 xpassed
```

Pre-existing `tests/test_cli_scripts.py::TestChatCommand` failures (4) are unrelated — they fail identically on the base branch before these commits.

### Follow-up

A second PR will tackle `src/plugins/update.py` (module-level `_THIS_DIR`, `CODE_ROOT`, `_REPO_CANDIDATE`, `NEXO_HOME`, `DATA_DIR`, `BACKUP_BASE`, `REPO_DIR`, `SRC_DIR`, `PACKAGE_JSON`, `_PACKAGED_INSTALL`). That file has three file-conditioned learning rules demanding deliberate review:

- #186 (nexo update must auto-restart processes/crons on version bump)
- #325 (TestRuntimeUpdate isolated dirs must include ALL top-level imports of copied modules)
- #323 (Claude Code auto-install must use the canonical npm package)

Pulling it out into its own PR keeps the review surface crisp.
