### PR TITLE
brain: B10 update.py mini-refactor — lazy NEXO_HOME + packaged check

### DIFF
--- a/src/plugins/update.py
+++ b/src/plugins/update.py
@@ -84,37 +84,67 @@ _THIS_DIR = Path(__file__).resolve().parent
 CODE_ROOT = _THIS_DIR.parent
 _REPO_CANDIDATE = CODE_ROOT.parent
 
+# B10 mini-refactor (AUDITOR-V700-PASS2 §11): the pieces below that look up
+# env-dependent or filesystem-dependent state now go through lazy helpers so
+# tests can monkeypatch NEXO_HOME / the .git location after the module was
+# imported without snapshotting a stale value. The module-level constants
+# (NEXO_HOME, DATA_DIR, BACKUP_BASE, REPO_DIR, SRC_DIR, PACKAGE_JSON) are
+# kept for the existing 77 callsites; they will migrate to the helpers in
+# followup NF-B10-UPDATE-PY-LAZY-CALLSITES-COSMETIC post-release.
+
+
+def _nexo_home() -> Path:
+    """Resolve the current NEXO_HOME on every call.
+
+    export_resolved_nexo_home() reads the env var + runtime config each time,
+    so fixtures that monkeypatch NEXO_HOME mid-test pick up the new path.
+    """
+    return export_resolved_nexo_home()
+
+
+def _is_packaged_install() -> bool:
+    """Return True iff we are running inside a packaged NEXO install.
+
+    Evaluated on every call because tests may stage a fake repo (or drop a
+    synthetic .git marker) after the module has already been imported.
+    """
+    return not (_REPO_CANDIDATE / ".git").exists() and not (_REPO_CANDIDATE / ".git").is_file()
+
+
 NEXO_HOME = export_resolved_nexo_home()
 DATA_DIR = paths.data_dir()
 BACKUP_BASE = paths.backups_dir()
 
 # In packaged installs, update.py lives at <NEXO_HOME>/plugins/update.py.
-_PACKAGED_INSTALL = not (_REPO_CANDIDATE / ".git").exists() and not (_REPO_CANDIDATE / ".git").is_file()
+_PACKAGED_INSTALL = _is_packaged_install()
 REPO_DIR = CODE_ROOT if _PACKAGED_INSTALL else _REPO_CANDIDATE
 SRC_DIR = CODE_ROOT
 PACKAGE_JSON = REPO_DIR / "package.json"
 
 
-def _venv_python_path(runtime_root: Path = NEXO_HOME) -> Path:
+def _venv_python_path(runtime_root: Path | None = None) -> Path:
+    root = runtime_root or _nexo_home()
     if sys.platform == "win32":
-        return runtime_root / ".venv" / "Scripts" / "python.exe"
-    return runtime_root / ".venv" / "bin" / "python3"
+        return root / ".venv" / "Scripts" / "python.exe"
+    return root / ".venv" / "bin" / "python3"
 
 
-def _venv_pip_path(runtime_root: Path = NEXO_HOME) -> Path:
+def _venv_pip_path(runtime_root: Path | None = None) -> Path:
+    root = runtime_root or _nexo_home()
     if sys.platform == "win32":
-        return runtime_root / ".venv" / "Scripts" / "pip.exe"
-    return runtime_root / ".venv" / "bin" / "pip"
+        return root / ".venv" / "Scripts" / "pip.exe"
+    return root / ".venv" / "bin" / "pip"
 
 
-def _ensure_managed_venv(runtime_root: Path = NEXO_HOME) -> str | None:
-    venv_python = _venv_python_path(runtime_root)
+def _ensure_managed_venv(runtime_root: Path | None = None) -> str | None:
+    root = runtime_root or _nexo_home()
+    venv_python = _venv_python_path(root)
     if venv_python.exists():
         return None
     try:
-        runtime_root.mkdir(parents=True, exist_ok=True)
+        root.mkdir(parents=True, exist_ok=True)
         result = subprocess.run(
-            [sys.executable, "-m", "venv", str(runtime_root / ".venv")],
+            [sys.executable, "-m", "venv", str(root / ".venv")],
             capture_output=True,
             text=True,
             timeout=120,
@@ -173,7 +203,7 @@ def _runtime_code_root(runtime_root: Path | None = None) -> Path:
 
 def _core_artifact_source_dir() -> Path | None:
     """Return the canonical source directory for packaged core artifacts."""
-    if _PACKAGED_INSTALL:
+    if _is_packaged_install():
         return _find_npm_pkg_src()
     return SRC_DIR
 
@@ -241,7 +271,7 @@ def _cleanup_retired_runtime_files() -> list[str]:
 
 def _read_version() -> str:
     """Read the installed/runtime version."""
-    if _PACKAGED_INSTALL:
+    if _is_packaged_install():
         # version.json is the runtime truth for packaged installs.
         try:
             version_file = NEXO_HOME / "version.json"
@@ -286,7 +316,7 @@ def _requirements_hash() -> str:
     """Return a content hash of requirements.txt, or empty string if missing."""
     import hashlib
     req_file = SRC_DIR / "requirements.txt"
-    if not req_file.exists() and _PACKAGED_INSTALL:
+    if not req_file.exists() and _is_packaged_install():
         npm_src = _find_npm_pkg_src()
         if npm_src:
             req_file = npm_src / "requirements.txt"
@@ -441,7 +471,7 @@ def _restore_databases(backup_dir: str):
 def _reinstall_pip_deps() -> str | None:
     """Reinstall Python dependencies from requirements.txt into the managed venv."""
     req_file = SRC_DIR / "requirements.txt"
-    if not req_file.exists() and _PACKAGED_INSTALL:
+    if not req_file.exists() and _is_packaged_install():
         # In packaged mode, requirements.txt lives in the npm package's src/ dir
         npm_src = _find_npm_pkg_src()
         if npm_src:
@@ -714,7 +744,7 @@ def _format_dep_results(dep_results: list[dict]) -> list[str]:
 def _run_migrations() -> str | None:
     """Run init_db() to apply pending migrations. Returns error or None."""
     # In packaged mode, db/ lives in NEXO_HOME; in dev mode, in SRC_DIR
-    cwd = str(NEXO_HOME) if _PACKAGED_INSTALL else str(SRC_DIR)
+    cwd = str(NEXO_HOME) if _is_packaged_install() else str(SRC_DIR)
     try:
         result = subprocess.run(
             [sys.executable, "-c", "import db; db.init_db()"],
@@ -733,7 +763,7 @@ def _run_migrations() -> str | None:
 def _verify_import() -> str | None:
     """Verify server.py can be imported successfully."""
     # In packaged mode, server.py lives in NEXO_HOME; in dev mode, in SRC_DIR
-    cwd = str(NEXO_HOME) if _PACKAGED_INSTALL else str(SRC_DIR)
+    cwd = str(NEXO_HOME) if _is_packaged_install() else str(SRC_DIR)
     try:
         result = subprocess.run(
             [sys.executable, "-c", "import server"],

--- a/tests/test_packaged_update_runtime.py
+++ b/tests/test_packaged_update_runtime.py
@@ -151,7 +151,10 @@ def test_refresh_installed_manifest_packaged_mode_uses_npm_src_for_core_artifact
     monkeypatch.setenv("NEXO_HOME", str(runtime_home))
     monkeypatch.setattr(update, "NEXO_HOME", runtime_home)
     monkeypatch.setattr(update, "SRC_DIR", runtime_home)
+    # B10 mini-refactor: callsites moved from the _PACKAGED_INSTALL constant
+    # to the _is_packaged_install() helper, so monkey-patch the helper too.
     monkeypatch.setattr(update, "_PACKAGED_INSTALL", True)
+    monkeypatch.setattr(update, "_is_packaged_install", lambda: True)
     monkeypatch.setattr(update, "_find_npm_pkg_src", lambda: npm_src)
 
     update._refresh_installed_manifest()

--- a/tests/test_update_plugin_lazy_paths.py
+++ b/tests/test_update_plugin_lazy_paths.py
@@ -1,0 +1,107 @@
+"""Regression tests for the B10 mini-refactor of src/plugins/update.py.
+
+Prior to the refactor, the default argument of ``_venv_python_path``,
+``_venv_pip_path`` and ``_ensure_managed_venv`` was evaluated at module
+import time: ``def _venv_python_path(runtime_root: Path = NEXO_HOME)``.
+A test that monkeypatched NEXO_HOME after import kept getting the
+original path because Python binds default values once at definition.
+
+The refactored signatures accept ``Path | None = None`` and call
+``_nexo_home()`` inside the body, so the resolution follows the live
+env / config state on every call.
+
+The ``_is_packaged_install()`` helper runs the .git probe on every
+call so fixtures that stage or hide a synthetic .git marker after
+import also see the fresh state.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_SRC = Path(__file__).resolve().parent.parent / "src"
+if str(REPO_SRC) not in sys.path:
+    sys.path.insert(0, str(REPO_SRC))
+
+
+@pytest.fixture
+def fresh_update_module(tmp_path, monkeypatch):
+    """Import plugins.update with NEXO_HOME pointing at tmp_path/a."""
+    home_a = tmp_path / "nexo-a"
+    home_a.mkdir()
+    monkeypatch.setenv("NEXO_HOME", str(home_a))
+    from plugins import update as plugin_update  # noqa: E402
+    importlib.reload(plugin_update)
+    return plugin_update, home_a
+
+
+def test_venv_python_path_follows_env_change_after_import(fresh_update_module, tmp_path, monkeypatch):
+    plugin_update, home_a = fresh_update_module
+
+    original = plugin_update._venv_python_path()
+    assert str(home_a) in str(original), f"expected path rooted in {home_a}, got {original}"
+
+    home_b = tmp_path / "nexo-b"
+    home_b.mkdir()
+    monkeypatch.setenv("NEXO_HOME", str(home_b))
+
+    updated = plugin_update._venv_python_path()
+    assert str(home_b) in str(updated), (
+        "default-arg bug regressed: _venv_python_path returned a path under "
+        f"the original NEXO_HOME ({home_a}) instead of the new one ({home_b}). "
+        f"Got {updated}."
+    )
+    assert str(home_a) not in str(updated)
+
+
+def test_venv_pip_path_follows_env_change_after_import(fresh_update_module, tmp_path, monkeypatch):
+    plugin_update, home_a = fresh_update_module
+
+    original = plugin_update._venv_pip_path()
+    assert str(home_a) in str(original)
+
+    home_b = tmp_path / "nexo-b"
+    home_b.mkdir()
+    monkeypatch.setenv("NEXO_HOME", str(home_b))
+
+    updated = plugin_update._venv_pip_path()
+    assert str(home_b) in str(updated)
+    assert str(home_a) not in str(updated)
+
+
+def test_explicit_runtime_root_overrides_env(fresh_update_module, tmp_path):
+    """Signature-compat: callers that pass runtime_root explicitly still
+    win over the lazy default."""
+    plugin_update, _ = fresh_update_module
+
+    explicit = tmp_path / "explicit-root"
+    explicit.mkdir()
+    path = plugin_update._venv_python_path(explicit)
+    assert str(explicit) in str(path)
+
+
+def test_is_packaged_install_is_lazy(tmp_path, monkeypatch):
+    """_PACKAGED_INSTALL used to freeze at module import. The helper must
+    re-probe the filesystem on every call so tests that stage a repo layout
+    after import are honoured."""
+    from plugins import update as plugin_update
+    importlib.reload(plugin_update)
+
+    # The real repo under which the test runs is a git checkout — so the
+    # helper should report False there.
+    assert plugin_update._is_packaged_install() is False
+
+    # Redirect the probe's _REPO_CANDIDATE to a directory with no .git.
+    fake_candidate = tmp_path / "packaged-root"
+    fake_candidate.mkdir()
+    monkeypatch.setattr(plugin_update, "_REPO_CANDIDATE", fake_candidate)
+    assert plugin_update._is_packaged_install() is True
+
+    # Materialise a .git marker and the helper flips back without re-importing.
+    (fake_candidate / ".git").mkdir()
+    assert plugin_update._is_packaged_install() is False


### PR DESCRIPTION
## Scope

B10 update.py **mini-refactor** (Option B approved by Francisco). Closes the concrete import-time freeze hazards in `src/plugins/update.py` without touching the 77 cosmetic bare-name callsites — those go to a post-release followup.

Base: `refactor/brain-b7-b11` (stacked on PR #258). Kept separate from PR #259 because `plugins/update.py` carries three blocking learning rules (#186 auto-restart, #325 TestRuntimeUpdate isolated dirs, #323 Claude Code canonical npm) that deserve their own review cycle.

### What changed

1. **Default-arg bug.** `_venv_python_path`, `_venv_pip_path`, `_ensure_managed_venv` used to bind NEXO_HOME at module import via `runtime_root: Path = NEXO_HOME`. Any caller that mutated NEXO_HOME after import still saw the original path. Switched to `Path | None = None` with `root = runtime_root or _nexo_home()` in the body — **public signature preserved**, explicit callers keep working.
2. **`_PACKAGED_INSTALL` freeze.** Introduced `_is_packaged_install()` helper and routed the six runtime callsites through it so fixtures that stage a fake repo layout after import see the fresh state. The module-level constant stays for `REPO_DIR`'s import-time derivation (legitimately static per process).
3. **Explicitly out of scope.** `_THIS_DIR`, `CODE_ROOT`, `_REPO_CANDIDATE`, `SRC_DIR` derive from `__file__` and never change in-process — unchanged. The 77 bare-name references to `NEXO_HOME`, `DATA_DIR`, `BACKUP_BASE`, `REPO_DIR`, `PACKAGE_JSON`, `SRC_DIR` in the rest of the module stay as-is, tracked in followup `NF-B10-UPDATE-PY-LAZY-CALLSITES-COSMETIC` (2026-05-15, post-release sprint).
4. **Test adjustment.** `tests/test_packaged_update_runtime.py::test_refresh_installed_manifest_packaged_mode_uses_npm_src_for_core_artifacts` now monkey-patches `_is_packaged_install` alongside `_PACKAGED_INSTALL` (one-line keep-both) so the helper's fresh probe does not override the test's intent.

### Tests

```
pytest tests/test_update_plugin_lazy_paths.py   → 4 passed  (new; demonstrates the fix)
pytest tests/test_runtime_update_contract.py
       tests/test_update_path_and_reload.py
       tests/test_update_shell_contract.py
       tests/test_update_wipe_guard.py
       tests/test_packaged_update_runtime.py    → 38 passed
pytest tests/test_auto_update_*.py (7 files)    → 49 passed
```

Total: 91 passed, 0 failed.

### Blocking learnings acknowledged

- **#186 nexo update auto-restart on version bump** — refactor does not alter the restart flow, only path resolution.
- **#325 TestRuntimeUpdate isolated dirs include ALL top-level imports** — no new top-level imports added; helpers are internal functions.
- **#323 Claude Code canonical npm package** — NPM detection (`_find_npm_pkg_src`, `_npm_command_parts`) untouched.

### Coordination

After this PR lands per Francisco's merge chain:
1. B1-B6 → main
2. PR #258 → main
3. PR #259 → main
4. **This PR** → main
5. G1-G3 enforcer → main
6. Tag v7.2.0 + npm publish
