### PR TITLE
brain: G1 enforcer + G3 SSH wrapper + persist hard + G5 adaptive empirical

### DIFF
--- a/src/auto_update.py
+++ b/src/auto_update.py
@@ -4648,6 +4648,16 @@ def _run_runtime_post_sync(dest: Path = NEXO_HOME, progress_fn=None) -> tuple[bo
     except Exception as exc:
         actions.append(f"classifier-install-warning:{exc.__class__.__name__}")
 
+    try:
+        _emit_progress(progress_fn, "Persisting Guardian enforcement defaults...")
+        persisted, persist_message = _persist_guardian_hard_defaults(dest)
+        if persisted:
+            actions.append("guardian-hard-persisted")
+        if persist_message:
+            actions.append(persist_message)
+    except Exception as exc:
+        actions.append(f"guardian-hard-persist-warning:{exc.__class__.__name__}")
+
     _emit_progress(progress_fn, "Verifying runtime imports...")
     verify = subprocess.run(
         [sys.executable, "-c", "import server"],
@@ -4693,6 +4703,76 @@ def _emit_progress(progress_fn, message: str) -> None:
             progress_fn(message)
         except Exception:
             pass
+
+
+_GUARDIAN_PERSIST_HARD_DEFAULTS = {
+    "G1_ENFORCER_ACTIVE": "hard",
+    "G3_ENFORCE_DESTRUCTIVE": "hard",
+    "G3_SSH_ENFORCE_REMOTE_WRITE": "hard",
+    "G4_ENFORCE_GUARD_CHECK": "hard",
+}
+
+
+def _persist_guardian_hard_defaults(dest: Path) -> tuple[bool, str | None]:
+    """Write ``~/.nexo/config/guardian-runtime-overrides.json`` with the
+    v7.2.0 "Guardian-on by default" matrix so operators get the active
+    enforcer experience without setting env vars every shell.
+
+    Returns (persisted, message). ``persisted`` is True when the file was
+    written or updated during this call; False when we left it alone
+    (operator opt-out, or file already matches the defaults).
+
+    Contract:
+        - Operator opt-out with ``NEXO_GUARDIAN_PERSIST_HARD=off`` in env
+          at update time: leave the file untouched.
+        - Ephemeral runtimes: skip.
+        - Never overwrite a key the operator already customized to a
+          non-default value (``shadow`` / ``off`` / anything else). Only
+          fills missing keys or upgrades explicit defaults.
+    """
+    if _is_ephemeral_runtime_install(dest):
+        return False, "guardian-hard-persist-skipped:ephemeral"
+    if os.environ.get("NEXO_GUARDIAN_PERSIST_HARD", "").strip().lower() == "off":
+        return False, "guardian-hard-persist-skipped:operator-opt-out"
+
+    config_path = dest / "personal" / "config" / "guardian-runtime-overrides.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+
+    current: dict[str, str] = {}
+    if config_path.is_file():
+        try:
+            raw = json.loads(config_path.read_text())
+            if isinstance(raw, dict):
+                current = {str(k): str(v) for k, v in raw.items()}
+        except Exception:
+            # Malformed file — treat as empty. We write the fresh defaults
+            # and keep the malformed copy for the operator to inspect.
+            try:
+                config_path.rename(
+                    config_path.with_suffix(
+                        config_path.suffix + f".broken-{int(time.time())}"
+                    )
+                )
+            except Exception:
+                pass
+            current = {}
+
+    original = dict(current)
+    for key, default in _GUARDIAN_PERSIST_HARD_DEFAULTS.items():
+        if key not in current:
+            current[key] = default
+
+    if current == original and config_path.is_file():
+        return False, None
+
+    try:
+        tmp_path = config_path.with_suffix(config_path.suffix + ".tmp")
+        tmp_path.write_text(json.dumps(current, indent=2, ensure_ascii=False) + "\n")
+        tmp_path.replace(config_path)
+    except Exception as exc:  # pragma: no cover - filesystem failures
+        return False, f"guardian-hard-persist-error:{exc.__class__.__name__}"
+
+    return True, None
 
 
 def _parse_runtime_init_payload(stdout: str) -> dict:

--- a/src/auto_update.py
+++ b/src/auto_update.py
@@ -4658,6 +4658,16 @@ def _run_runtime_post_sync(dest: Path = NEXO_HOME, progress_fn=None) -> tuple[bo
     except Exception as exc:
         actions.append(f"guardian-hard-persist-warning:{exc.__class__.__name__}")
 
+    try:
+        _emit_progress(progress_fn, "Promoting adaptive weights if enough data...")
+        promoted, promote_message = _maybe_promote_adaptive_weights_empirically(dest)
+        if promoted:
+            actions.append("adaptive-weights-promoted")
+        if promote_message:
+            actions.append(promote_message)
+    except Exception as exc:
+        actions.append(f"adaptive-weights-promote-warning:{exc.__class__.__name__}")
+
     _emit_progress(progress_fn, "Verifying runtime imports...")
     verify = subprocess.run(
         [sys.executable, "-c", "import server"],
@@ -4771,6 +4781,107 @@ def _persist_guardian_hard_defaults(dest: Path) -> tuple[bool, str | None]:
         tmp_path.replace(config_path)
     except Exception as exc:  # pragma: no cover - filesystem failures
         return False, f"guardian-hard-persist-error:{exc.__class__.__name__}"
+
+    return True, None
+
+
+from datetime import datetime as _adaptive_datetime  # isolated alias; other modules use ``time.time()``
+
+_ADAPTIVE_PROMOTE_MIN_SAMPLES = 200
+_ADAPTIVE_PROMOTE_MIN_DAYS = 2
+
+
+def _maybe_promote_adaptive_weights_empirically(dest: Path) -> tuple[bool, str | None]:
+    """Promote ``shadow_weights`` to ``learned_weights`` during ``nexo update``
+    when the install already has enough empirical signal.
+
+    Mirrors the empirical path in ``adaptive_mode.learn_weights`` (the
+    background learner cron). Without this, operators upgrading to v7.2.0
+    with a mature shadow dataset would still have to wait for the next
+    learner tick to feel the calibration — which can be hours or days.
+
+    Conditions to promote:
+        - adaptive_state.json exists and parses.
+        - ``shadow_weights`` dict is present.
+        - ``shadow_weights_samples >= 200`` AND the learner has been
+          running for at least 2 calendar days
+          (``learned_weights_first_date`` ≥ 2 days ago).
+        - ``learned_weights`` is absent or empty (never overwrite an
+          already-active set of weights).
+        - Operator opt-out flag ``NEXO_ADAPTIVE_EMPIRICAL_PROMOTION=off``
+          is NOT set. Same flag the learner already honours, so
+          operators who opted out stay opted out everywhere.
+
+    Returns ``(promoted, message)``:
+        - ``(True, None)``: weights were promoted, audit trail written.
+        - ``(False, None)``: no-op (no shadow data, not enough samples,
+          already promoted, or ephemeral install).
+        - ``(False, "adaptive-promote-skipped:<reason>")``: explicit skip
+          for the install log.
+    """
+    if _is_ephemeral_runtime_install(dest):
+        return False, "adaptive-promote-skipped:ephemeral"
+    if os.environ.get("NEXO_ADAPTIVE_EMPIRICAL_PROMOTION", "").strip().lower() == "off":
+        return False, "adaptive-promote-skipped:operator-opt-out"
+
+    state_path = dest / "personal" / "brain" / "adaptive_state.json"
+    if not state_path.is_file():
+        # Fall back to the legacy pre-F0.6 location for half-migrated
+        # installs; the migrator will eventually move it.
+        legacy = dest / "brain" / "adaptive_state.json"
+        if legacy.is_file():
+            state_path = legacy
+        else:
+            return False, None  # no data yet — nothing to promote
+
+    try:
+        raw = json.loads(state_path.read_text())
+    except Exception:
+        return False, "adaptive-promote-skipped:state-parse-error"
+    if not isinstance(raw, dict):
+        return False, "adaptive-promote-skipped:state-not-dict"
+
+    learned = raw.get("learned_weights")
+    if isinstance(learned, dict) and learned:
+        return False, None  # already active — nothing to do
+
+    shadow = raw.get("shadow_weights")
+    if not isinstance(shadow, dict) or not shadow:
+        return False, None  # no shadow data yet
+
+    samples = 0
+    try:
+        samples = int(raw.get("shadow_weights_samples", 0) or 0)
+    except (TypeError, ValueError):
+        samples = 0
+    if samples < _ADAPTIVE_PROMOTE_MIN_SAMPLES:
+        return False, None
+
+    first_date_raw = str(raw.get("learned_weights_first_date") or "").strip()
+    if not first_date_raw:
+        return False, None
+    try:
+        first_dt = _adaptive_datetime.strptime(first_date_raw[:19], "%Y-%m-%dT%H:%M:%S")
+    except ValueError:
+        return False, "adaptive-promote-skipped:first-date-parse-error"
+    days_since_first = (_adaptive_datetime.utcnow() - first_dt).days
+    if days_since_first < _ADAPTIVE_PROMOTE_MIN_DAYS:
+        return False, None
+
+    # Promote — deep-copy so callers holding references to the original
+    # dict don't see phantom mutations mid-update.
+    raw["learned_weights"] = {str(k): v for k, v in shadow.items()}
+    raw["learned_weights_date"] = _adaptive_datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S")
+    raw["learned_weights_samples"] = samples
+    raw["learned_weights_promoted_by"] = "nexo_update_empirical_v7_2_0"
+    raw["learned_weights_promoted_at"] = _adaptive_datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S")
+
+    try:
+        tmp_path = state_path.with_suffix(state_path.suffix + ".tmp")
+        tmp_path.write_text(json.dumps(raw, indent=2, ensure_ascii=False) + "\n")
+        tmp_path.replace(state_path)
+    except Exception as exc:  # pragma: no cover - filesystem failures
+        return False, f"adaptive-promote-error:{exc.__class__.__name__}"
 
     return True, None
 

--- a/src/guardian_runtime_config.py
+++ b/src/guardian_runtime_config.py
@@ -1,0 +1,98 @@
+"""Guardian runtime config resolver — single source of truth for enforcer flags.
+
+v7.2.0 introduces ``~/.nexo/personal/config/guardian-runtime-overrides.json``
+as the persistent operator-owned default for Guardian gate modes:
+
+    {
+      "G1_ENFORCER_ACTIVE": "hard",
+      "G3_ENFORCE_DESTRUCTIVE": "hard",
+      "G3_SSH_ENFORCE_REMOTE_WRITE": "hard",
+      "G4_ENFORCE_GUARD_CHECK": "hard"
+    }
+
+The JSON values match the ``NEXO_<FLAG>`` env-var semantics exactly
+(``off`` / ``shadow`` / ``hard``). Env vars always win over the file so
+an ad-hoc ``NEXO_G4_ENFORCE_GUARD_CHECK=shadow`` during debugging still
+takes effect. The file is loaded lazily and cached per-process; callers
+should not rely on edits to take effect without a restart.
+
+Public API:
+    ``resolve_guardian_flag(name, default='shadow')`` -> normalized value.
+
+``name`` is the short key (``G1_ENFORCER_ACTIVE``) without the ``NEXO_``
+prefix. Resolution order:
+    1. Environment variable ``NEXO_<name>`` if set and non-empty.
+    2. Override file entry.
+    3. ``default``.
+
+All returned values are lowercased and whitespace-stripped.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+
+_CACHE: dict[str, str] | None = None
+
+
+def _overrides_path() -> Path:
+    home = Path(os.environ.get("NEXO_HOME", str(Path.home() / ".nexo")))
+    return home / "personal" / "config" / "guardian-runtime-overrides.json"
+
+
+def _load_overrides() -> dict[str, str]:
+    global _CACHE
+    if _CACHE is not None:
+        return _CACHE
+    path = _overrides_path()
+    if not path.is_file():
+        _CACHE = {}
+        return _CACHE
+    try:
+        raw = json.loads(path.read_text())
+    except Exception:
+        _CACHE = {}
+        return _CACHE
+    if not isinstance(raw, dict):
+        _CACHE = {}
+        return _CACHE
+    normalized: dict[str, str] = {}
+    for key, value in raw.items():
+        if not isinstance(value, str):
+            continue
+        normalized[str(key).strip().upper()] = value.strip().lower()
+    _CACHE = normalized
+    return _CACHE
+
+
+def invalidate_cache() -> None:
+    """Drop the cached override file so the next call re-reads from disk.
+
+    Intended for tests and for the updater right after it writes a new
+    version of the file. Production code should not need to call this.
+    """
+    global _CACHE
+    _CACHE = None
+
+
+def resolve_guardian_flag(name: str, default: str = "shadow") -> str:
+    """Resolve a Guardian gate mode (``off`` / ``shadow`` / ``hard``).
+
+    Env var ``NEXO_<name>`` has priority; falls back to the overrides
+    file; falls back to ``default`` last.
+    """
+    clean = str(name or "").strip().upper()
+    if not clean:
+        return str(default or "shadow").strip().lower()
+
+    env_value = os.environ.get(f"NEXO_{clean}", "").strip()
+    if env_value:
+        return env_value.lower()
+
+    file_value = _load_overrides().get(clean, "")
+    if file_value:
+        return file_value
+
+    return str(default or "shadow").strip().lower()

--- a/src/hook_guardrails.py
+++ b/src/hook_guardrails.py
@@ -156,6 +156,82 @@ def _classify_destructive_intent(command: str) -> str | None:
     return None
 
 
+# Block K G3 (SSH wrapper): remote-write patterns the local destructive
+# gate never sees because they run inside ``ssh host '...'`` / rsync /
+# scp / sftp. Matched against the raw Bash command string.
+# Each regex aims to catch a well-known write primitive *inside* a remote
+# invocation. ``ssh host 'ls'`` must not match — only write-verbs do.
+_SSH_REMOTE_SHELL_RE = re.compile(
+    r"\bssh\b[^'\"`]*?(?:['\"`])(?P<remote>[^'\"`]+)(?:['\"`])",
+    re.IGNORECASE,
+)
+_SSH_REMOTE_WRITE_VERBS = (
+    re.compile(r"^\s*cat\s*>\s*\S", re.IGNORECASE),                  # cat > file
+    re.compile(r"^\s*cat\s*>>\s*\S", re.IGNORECASE),                 # cat >> file
+    re.compile(r"\btee\s+(?:-\S+\s+)*[^\s|&;]+", re.IGNORECASE),      # tee [-a] file
+    re.compile(r"^\s*(?:echo|printf)\s+.*\s+>>?\s*\S", re.IGNORECASE),  # echo ... > file
+    re.compile(r"\bsed\s+-i\b", re.IGNORECASE),                      # sed -i ...
+    re.compile(r"(?:^|\s)>\s*\S", re.IGNORECASE),                    # bare > file
+    re.compile(r"(?:^|\s)>>\s*\S", re.IGNORECASE),                   # bare >> file
+    re.compile(r"\brm\s+-\S*[rRfF]", re.IGNORECASE),                 # remote rm -rf
+    re.compile(r"\bmv\s+\S+\s+\S+", re.IGNORECASE),                  # remote mv
+    re.compile(r"\bcp\s+\S+\s+\S+", re.IGNORECASE),                  # remote cp
+)
+_SCP_WRITE_RE = re.compile(
+    r"\bscp\b[^|&;]*?\s\S+\s+[^:\s]+:[^\s]+",
+    re.IGNORECASE,
+)
+_RSYNC_WRITE_RE = re.compile(
+    r"\brsync\b[^|&;]*?\s\S+\s+[^:\s]+:[^\s]+",
+    re.IGNORECASE,
+)
+_SFTP_BATCH_RE = re.compile(
+    r"\bsftp\b(?:[^|&;]*\s)?-b\s+\S+",
+    re.IGNORECASE,
+)
+
+
+def _classify_ssh_remote_write(command: str) -> str | None:
+    """Return the matching pattern name when ``command`` writes to a remote host.
+
+    Covers four shapes:
+        1. ``ssh host '<remote-shell-that-writes>'`` with or without
+           ``-o`` flags, using single/double/backtick quoting.
+        2. ``scp LOCAL_PATH host:REMOTE_PATH`` (upload direction).
+        3. ``rsync [opts] LOCAL_PATH host:REMOTE_PATH`` (upload direction).
+        4. ``sftp -b batchfile host`` (any -b invocation is considered a
+           write candidate because the batch may mutate).
+
+    Ignores read-only invocations such as ``ssh host 'ls /etc'`` or
+    ``scp host:REMOTE /local/`` (download), which is the common case.
+    """
+    cmd = str(command or "")
+
+    if _SCP_WRITE_RE.search(cmd):
+        # Disambiguate download (host:remote local) vs upload (local host:remote).
+        # Simple rule: if the FIRST ``host:path`` argument is preceded by a
+        # local-looking arg, treat as upload.
+        download = re.search(r"\bscp\b[^|&;]*?\s[^:\s]+:\S+\s+\S+", cmd)
+        if not download:
+            return "scp_remote_write"
+    if _RSYNC_WRITE_RE.search(cmd):
+        download = re.search(r"\brsync\b[^|&;]*?\s[^:\s]+:\S+\s+\S+", cmd)
+        if not download:
+            return "rsync_remote_write"
+    if _SFTP_BATCH_RE.search(cmd):
+        return "sftp_batch_remote_write"
+
+    for match in _SSH_REMOTE_SHELL_RE.finditer(cmd):
+        remote = match.group("remote") or ""
+        # Strip leading "sudo ", "env VAR=x ", "cd dir &&" — they never mean
+        # a write by themselves, and may hide real writes behind them.
+        trimmed = re.sub(r"^\s*(?:sudo\s+|env\s+\S+=\S+\s+|cd\s+\S+\s*&&\s*)+", "", remote)
+        for pattern in _SSH_REMOTE_WRITE_VERBS:
+            if pattern.search(trimmed):
+                return "ssh_remote_shell_write"
+    return None
+
+
 def _operation_kind(tool_name: str) -> str:
     if tool_name in READ_LIKE_TOOLS:
         return "read"
@@ -1011,7 +1087,11 @@ def process_pre_tool_event(payload: dict) -> dict:
     # NEXO_G3_ENFORCE_DESTRUCTIVE (default "shadow"): shadow records a
     # warn-severity debt for observability; hard blocks the operation
     # with error severity; off disables the gate entirely.
-    g3_mode = os.environ.get("NEXO_G3_ENFORCE_DESTRUCTIVE", "shadow").strip().lower()
+    try:
+        from guardian_runtime_config import resolve_guardian_flag
+        g3_mode = resolve_guardian_flag("G3_ENFORCE_DESTRUCTIVE", default="shadow")
+    except Exception:
+        g3_mode = os.environ.get("NEXO_G3_ENFORCE_DESTRUCTIVE", "shadow").strip().lower()
     if g3_mode in {"shadow", "hard"} and tool_name == "Bash":
         shell_command = _extract_bash_command(tool_input)
         destructive_pattern = _classify_destructive_intent(shell_command)
@@ -1053,6 +1133,62 @@ def process_pre_tool_event(payload: dict) -> dict:
                     "g3_mode": g3_mode,
                 }
 
+    # Block K G3 SSH wrapper (Francisco 2026-04-22 v7.2.0): remote-write
+    # commands routed through ssh/rsync/scp/sftp never reach the local
+    # destructive gate. Gated by NEXO_G3_SSH_ENFORCE_REMOTE_WRITE (default
+    # "shadow") mirroring the destructive-local flag shape. Shadow logs a
+    # warn debt row; hard blocks with error severity; off disables.
+    try:
+        from guardian_runtime_config import resolve_guardian_flag
+        g3_ssh_mode = resolve_guardian_flag(
+            "G3_SSH_ENFORCE_REMOTE_WRITE", default="shadow"
+        )
+    except Exception:
+        g3_ssh_mode = os.environ.get(
+            "NEXO_G3_SSH_ENFORCE_REMOTE_WRITE", "shadow"
+        ).strip().lower()
+    if g3_ssh_mode in {"shadow", "hard"} and tool_name == "Bash":
+        shell_command = _extract_bash_command(tool_input)
+        ssh_pattern = _classify_ssh_remote_write(shell_command)
+        if ssh_pattern:
+            severity = "error" if g3_ssh_mode == "hard" else "warn"
+            debt = _ensure_protocol_debt(
+                conn,
+                session_id=sid,
+                task_id="",
+                debt_type="g3_ssh_remote_write_requires_cortex",
+                severity=severity,
+                evidence=(
+                    f"Bash command matched SSH remote-write pattern '{ssh_pattern}'. "
+                    f"Command head: {shell_command[:160]}. "
+                    "Run nexo_cortex_decide (or nexo_task_open for the session) "
+                    "and record evidence before retrying."
+                ),
+                file_token=ssh_pattern,
+            )
+            if g3_ssh_mode == "hard":
+                return {
+                    "ok": True,
+                    "session_id": sid,
+                    "tool_name": tool_name,
+                    "operation": op,
+                    "strictness": strictness,
+                    "blocks": [
+                        {
+                            "file": "",
+                            "task_id": "",
+                            "debt_id": debt.get("id"),
+                            "debt_type": "g3_ssh_remote_write_requires_cortex",
+                            "reason_code": "g3_ssh_remote_write_blocked",
+                            "severity": "error",
+                            "pattern": ssh_pattern,
+                            "g3_ssh_mode": g3_ssh_mode,
+                        }
+                    ],
+                    "status": "blocked",
+                    "g3_ssh_mode": g3_ssh_mode,
+                }
+
     # Block K G4 (Francisco 2026-04-22): require nexo_guard_check to have
     # run within the session for every file about to be written. Opt-in
     # via NEXO_G4_ENFORCE_GUARD_CHECK (default "shadow"): ``shadow``
@@ -1061,7 +1197,11 @@ def process_pre_tool_event(payload: dict) -> dict:
     # so the operator must run guard_check explicitly. Skipped entirely
     # in lenient mode or when there are no files, since the existing
     # strict-mode path already covers those cases with its own gating.
-    g4_mode = os.environ.get("NEXO_G4_ENFORCE_GUARD_CHECK", "shadow").strip().lower()
+    try:
+        from guardian_runtime_config import resolve_guardian_flag
+        g4_mode = resolve_guardian_flag("G4_ENFORCE_GUARD_CHECK", default="shadow")
+    except Exception:
+        g4_mode = os.environ.get("NEXO_G4_ENFORCE_GUARD_CHECK", "shadow").strip().lower()
     if g4_mode in {"shadow", "hard"} and files and sid:
         g4_blocks: list[dict] = []
         g4_warnings: list[dict] = []

--- a/src/hooks/g1_enforcer.py
+++ b/src/hooks/g1_enforcer.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""G1 enforcer — response_contract.mode as a physical gate (master Block K).
+
+When ``nexo_task_open`` returns a ``response_contract`` with
+``mode ∈ {defer, ask, verify}`` the agent is expected to execute the
+paired ``next_action`` (``nexo_cortex_decide`` for defer/ask,
+``nexo_confidence_check`` with populated ``evidence_refs`` for verify, or
+user turn) *before* emitting a user-visible answer. Until the G1 enforcer
+landed, nothing physical blocked the agent from ignoring the contract —
+the disciplined behaviour was self-imposed.
+
+This module runs from PostToolUse. It inspects the session's latest open
+task and, if the next_action still looks un-fulfilled after a grace
+window, returns a ``systemMessage`` nudging the agent back onto protocol.
+
+Modes (env ``NEXO_G1_ENFORCER_ACTIVE``, default ``shadow``):
+    off     — never inject; never log.
+    shadow  — log a warn-level protocol_debt row; no user-visible message.
+    hard    — inject a ``<system-reminder>``-style nudge into
+              PostToolUse output so the agent reads it before the next
+              response cycle.
+
+Fulfillment heuristic (conservative): after ``G1_GRACE_SECONDS`` the hook
+considers the contract NOT fulfilled if:
+    - the task is still ``status='open'``, AND
+    - no ``cortex_evaluations`` row exists for this session created after
+      ``task.opened_at`` (covers defer/ask — cortex_decide writes there),
+      AND
+    - no ``confidence_checks`` row exists for this session created after
+      ``task.opened_at`` (covers verify).
+
+To avoid storm on tight tool loops the hook rate-limits to one nudge per
+``G1_RATE_LIMIT_SECONDS`` per ``(session_id, task_id)``.
+
+Public entrypoint: ``check_response_contract_gate(sid) -> str | None``.
+The caller passes the NEXO sid (already resolved from the payload by
+``post_tool_use.py``). Returns the rendered message when the nudge
+should fire, ``None`` otherwise.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import time
+from pathlib import Path
+
+
+G1_GRACE_SECONDS = int(os.environ.get("NEXO_G1_GRACE_SECONDS", "120"))
+G1_RATE_LIMIT_SECONDS = int(os.environ.get("NEXO_G1_RATE_LIMIT_SECONDS", "180"))
+G1_REQUIRING_MODES = frozenset({"defer", "ask", "verify"})
+
+
+def _mode() -> str:
+    try:
+        import sys
+        from pathlib import Path as _Path
+        _src = _Path(__file__).resolve().parents[1]
+        if str(_src) not in sys.path:
+            sys.path.insert(0, str(_src))
+        from guardian_runtime_config import resolve_guardian_flag  # type: ignore
+        value = resolve_guardian_flag("G1_ENFORCER_ACTIVE", default="shadow")
+    except Exception:
+        value = os.environ.get("NEXO_G1_ENFORCER_ACTIVE", "shadow").strip().lower()
+    return value if value in {"off", "shadow", "hard"} else "shadow"
+
+
+def _db_path() -> Path:
+    try:
+        import paths  # type: ignore
+        return paths.db_path()
+    except Exception:
+        home = Path(os.environ.get("NEXO_HOME", str(Path.home() / ".nexo")))
+        new = home / "runtime" / "data" / "nexo.db"
+        if new.is_file():
+            return new
+        legacy = home / "data" / "nexo.db"
+        return legacy if legacy.is_file() else new
+
+
+def _table_exists(conn: sqlite3.Connection, name: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+        (name,),
+    ).fetchone()
+    return row is not None
+
+
+def _has_followup_event_since(
+    conn: sqlite3.Connection,
+    table: str,
+    session_id: str,
+    since_iso: str,
+    session_column: str = "session_id",
+    time_column: str = "created_at",
+) -> bool:
+    """Return True if any row in ``table`` for this session post-dates ``since_iso``."""
+    if not _table_exists(conn, table):
+        return False
+    try:
+        row = conn.execute(
+            f"SELECT 1 FROM {table} "
+            f"WHERE {session_column} = ? AND {time_column} > ? "
+            "LIMIT 1",
+            (session_id, since_iso),
+        ).fetchone()
+    except sqlite3.OperationalError:
+        # Schema drift: the column may not be called session_id in older tables.
+        return False
+    return row is not None
+
+
+def _fetch_latest_open_task(conn: sqlite3.Connection, session_id: str) -> dict | None:
+    if not _table_exists(conn, "protocol_tasks"):
+        return None
+    cols = conn.execute("PRAGMA table_info(protocol_tasks)").fetchall()
+    names = {c[1] for c in cols}
+    if "response_mode" not in names:
+        return None
+    row = conn.execute(
+        "SELECT task_id, goal, response_mode, opened_at, status "
+        "FROM protocol_tasks "
+        "WHERE session_id = ? AND status = 'open' "
+        "ORDER BY opened_at DESC LIMIT 1",
+        (session_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    return {
+        "task_id": row[0],
+        "goal": row[1] or "",
+        "response_mode": (row[2] or "").strip().lower(),
+        "opened_at": row[3] or "",
+        "status": row[4] or "",
+    }
+
+
+def _parse_db_time(value: str) -> float | None:
+    """``protocol_tasks.opened_at`` uses ``datetime('now')`` → ISO-8601 UTC without timezone."""
+    if not value:
+        return None
+    try:
+        import datetime as _dt
+        # ``datetime('now')`` format: 'YYYY-MM-DD HH:MM:SS'
+        for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%dT%H:%M:%SZ"):
+            try:
+                dt = _dt.datetime.strptime(value[:19], fmt)
+                return dt.replace(tzinfo=_dt.timezone.utc).timestamp()
+            except ValueError:
+                continue
+    except Exception:
+        pass
+    return None
+
+
+def _rate_limited(conn: sqlite3.Connection, session_id: str, task_id: str) -> bool:
+    """Return True if a nudge has already been emitted for (sid,task) within the window."""
+    if not _table_exists(conn, "hook_rate_limits"):
+        try:
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS hook_rate_limits ("
+                " hook TEXT NOT NULL,"
+                " session_id TEXT NOT NULL,"
+                " key TEXT NOT NULL,"
+                " last_fired_at REAL NOT NULL,"
+                " PRIMARY KEY (hook, session_id, key)"
+                ")"
+            )
+            conn.commit()
+        except sqlite3.OperationalError:
+            return False
+    row = conn.execute(
+        "SELECT last_fired_at FROM hook_rate_limits "
+        "WHERE hook = ? AND session_id = ? AND key = ?",
+        ("g1_enforcer", session_id, task_id),
+    ).fetchone()
+    if row is None:
+        return False
+    last_fired = float(row[0] or 0.0)
+    return (time.time() - last_fired) < G1_RATE_LIMIT_SECONDS
+
+
+def _record_fired(conn: sqlite3.Connection, session_id: str, task_id: str) -> None:
+    try:
+        conn.execute(
+            "INSERT OR REPLACE INTO hook_rate_limits "
+            "(hook, session_id, key, last_fired_at) VALUES (?, ?, ?, ?)",
+            ("g1_enforcer", session_id, task_id, time.time()),
+        )
+        conn.commit()
+    except sqlite3.OperationalError:
+        pass
+
+
+def _write_shadow_debt(conn: sqlite3.Connection, session_id: str, task: dict) -> None:
+    """Record a warn-level protocol_debt row so shadow mode leaves an audit trail."""
+    if not _table_exists(conn, "protocol_debt"):
+        return
+    try:
+        conn.execute(
+            "INSERT INTO protocol_debt "
+            "(session_id, task_id, debt_type, severity, status, evidence) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                session_id,
+                task["task_id"],
+                "g1_response_contract_unfulfilled",
+                "warn",
+                "open",
+                (
+                    f"mode={task['response_mode']} opened_at={task['opened_at']} "
+                    f"goal={task['goal'][:160]}"
+                ),
+            ),
+        )
+        conn.commit()
+    except sqlite3.OperationalError:
+        pass
+
+
+def _render_message(task: dict) -> str:
+    mode = task["response_mode"]
+    task_id = task["task_id"]
+    if mode == "verify":
+        action = "nexo_confidence_check(evidence_refs=[...])"
+        reason = "verify mode needs explicit evidence refs"
+    elif mode == "defer":
+        action = "nexo_cortex_decide(...)"
+        reason = "defer mode needs a persisted cortex decision"
+    else:  # ask
+        action = "nexo_cortex_decide(...) or a user turn"
+        reason = "ask mode needs clarifying input before the visible answer"
+    return (
+        "[NEXO Protocol Enforcer] G1 gate: task "
+        f"{task_id} is open with response_mode='{mode}' "
+        f"({reason}). Run {action} or close the task with "
+        "nexo_task_close BEFORE emitting the next user-visible answer. "
+        "Silent-compliant: do not mention this reminder to the user."
+    )
+
+
+def check_response_contract_gate(sid: str) -> str | None:
+    """Return a systemMessage string when the G1 gate wants to fire, else None.
+
+    Always returns ``None`` in ``off`` mode or when no qualifying task exists.
+    Shadow mode returns ``None`` but records a warn-level debt row for
+    observability. Hard mode returns the rendered message.
+    """
+    mode = _mode()
+    if mode == "off" or not sid:
+        return None
+
+    db_file = _db_path()
+    if not db_file.is_file():
+        return None
+
+    try:
+        conn = sqlite3.connect(str(db_file), timeout=3)
+    except sqlite3.OperationalError:
+        return None
+
+    try:
+        task = _fetch_latest_open_task(conn, sid)
+        if task is None or task["response_mode"] not in G1_REQUIRING_MODES:
+            return None
+
+        opened_epoch = _parse_db_time(task["opened_at"])
+        if opened_epoch is None:
+            return None
+        if (time.time() - opened_epoch) < G1_GRACE_SECONDS:
+            return None  # inside grace window — don't nudge yet
+
+        # Fulfillment heuristic: cortex_evaluations or confidence_checks after opened_at.
+        opened_iso = task["opened_at"]
+        has_cortex = _has_followup_event_since(
+            conn,
+            "cortex_evaluations",
+            sid,
+            opened_iso,
+        )
+        has_confidence = _has_followup_event_since(
+            conn,
+            "confidence_checks",
+            sid,
+            opened_iso,
+        )
+        if has_cortex or has_confidence:
+            return None  # contract fulfilled
+
+        if _rate_limited(conn, sid, task["task_id"]):
+            return None
+
+        if mode == "shadow":
+            _write_shadow_debt(conn, sid, task)
+            _record_fired(conn, sid, task["task_id"])
+            return None
+
+        # hard
+        _record_fired(conn, sid, task["task_id"])
+        _write_shadow_debt(conn, sid, task)  # keep the audit trail in hard too
+        return _render_message(task)
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass

--- a/src/hooks/post_tool_use.py
+++ b/src/hooks/post_tool_use.py
@@ -233,10 +233,19 @@ def main() -> int:
     # (including any writes the previous steps may have done). Emits a
     # single-line JSON systemMessage so Claude Code surfaces it to the
     # agent without breaking the tool pipeline.
+    # v7.2.0 — G1 enforcer (response_contract.mode physical gate) plugs in
+    # alongside the inbox reminder. Shadow mode only records a debt row;
+    # hard mode appends a nudge to the systemMessage.
     try:
         sid = _resolve_sid_from_payload(payload)
         reminder = check_inbox_and_emit_reminder(sid)
-        combined = _combine_system_messages(protocol_message, reminder)
+        g1_message: str | None = None
+        try:
+            from g1_enforcer import check_response_contract_gate  # type: ignore
+            g1_message = check_response_contract_gate(sid)
+        except Exception:
+            g1_message = None
+        combined = _combine_system_messages(protocol_message, reminder, g1_message)
         if combined:
             print(json.dumps({"systemMessage": combined}))
     except Exception:

--- a/src/plugins/adaptive_mode.py
+++ b/src/plugins/adaptive_mode.py
@@ -540,7 +540,22 @@ def learn_weights(min_samples: int = 30, lookback_days: int = 30) -> dict:
         drift = {name: round(learned[name] - WEIGHTS[name], 4) for name in signal_names}
         max_drift = max(abs(d) for d in drift.values())
 
-        # Shadow mode: first 2 weeks, only LOG without activating
+        # Shadow → active promotion (v7.2.0, master Block K G5):
+        #
+        # Historical rule was "shadow for the first 14 days after the first
+        # learned-weights compute, regardless of sample volume". That was
+        # safe but biased: on an active install the learner already has
+        # hundreds of samples by day 2, yet the promotion waited two full
+        # weeks. The inhibition rate stays above the 30-60% target the
+        # whole time, and any real drift is painfully slow to react to.
+        #
+        # New rule: promote to active when EITHER
+        #   (a) the classic 14-day window has elapsed, OR
+        #   (b) the learner has ≥200 samples AND ≥2 calendar days of data.
+        #
+        # Operator opt-out: set NEXO_ADAPTIVE_EMPIRICAL_PROMOTION=off to
+        # fall back to the 14-day-only rule. Env override is checked on
+        # every call so a flipped install can be reverted without restart.
         first_learned_date = state.get("learned_weights_first_date")
         if not first_learned_date:
             first_learned_date = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S")
@@ -548,7 +563,16 @@ def learn_weights(min_samples: int = 30, lookback_days: int = 30) -> dict:
 
         first_dt = datetime.strptime(first_learned_date, "%Y-%m-%dT%H:%M:%S")
         days_since_first = (datetime.utcnow() - first_dt).days
-        is_shadow = days_since_first < 14
+        empirical_opt_out = (
+            os.environ.get("NEXO_ADAPTIVE_EMPIRICAL_PROMOTION", "").strip().lower() == "off"
+        )
+        calendar_ready = days_since_first >= 14
+        empirical_ready = (
+            (not empirical_opt_out)
+            and len(rows) >= 200
+            and days_since_first >= 2
+        )
+        is_shadow = not (calendar_ready or empirical_ready)
 
         state["shadow_weights"] = learned
         state["shadow_weights_date"] = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S")

--- a/tests/test_adaptive_weights_rollback.py
+++ b/tests/test_adaptive_weights_rollback.py
@@ -166,6 +166,67 @@ class TestLearnWeightsShadowAndGraduation:
         assert state.get("learned_weights")
         assert len(state["learned_weights"]) == 6
 
+    def test_empirical_promotion_activates_after_200_samples_and_2_days(
+        self, adaptive_env, monkeypatch
+    ):
+        """v7.2.0 G5: promote to active when data is solid, not only on the calendar."""
+        db, adaptive_mode = _reload_adaptive_stack(monkeypatch, adaptive_env)
+        db.init_db()
+
+        # 210 samples over the last few days — well above the 200 empirical bar.
+        _seed_adaptive_log_with_feedback(db, rows=210)
+
+        # Learning started 3 days ago. Still short of the 14-day calendar rule
+        # but the empirical rule should kick in because 210 ≥ 200 AND 3 ≥ 2.
+        state = adaptive_mode._load_state()
+        state["learned_weights_first_date"] = (
+            datetime.utcnow() - timedelta(days=3)
+        ).strftime("%Y-%m-%dT%H:%M:%S")
+        adaptive_mode._save_state(state)
+
+        result = adaptive_mode.learn_weights(min_samples=30)
+        assert result["status"] == "active"
+        assert result["mode"] == "active"
+        state = adaptive_mode._load_state()
+        assert state.get("learned_weights")
+
+    def test_empirical_promotion_suppressed_with_opt_out_env(
+        self, adaptive_env, monkeypatch
+    ):
+        """Operator opt-out falls back to the 14-day calendar rule."""
+        db, adaptive_mode = _reload_adaptive_stack(monkeypatch, adaptive_env)
+        db.init_db()
+
+        _seed_adaptive_log_with_feedback(db, rows=210)
+        state = adaptive_mode._load_state()
+        state["learned_weights_first_date"] = (
+            datetime.utcnow() - timedelta(days=3)
+        ).strftime("%Y-%m-%dT%H:%M:%S")
+        adaptive_mode._save_state(state)
+
+        monkeypatch.setenv("NEXO_ADAPTIVE_EMPIRICAL_PROMOTION", "off")
+        result = adaptive_mode.learn_weights(min_samples=30)
+        assert result["status"] == "shadow"
+        state = adaptive_mode._load_state()
+        assert state.get("learned_weights") is None or "learned_weights" not in state
+
+    def test_empirical_promotion_needs_at_least_two_days(
+        self, adaptive_env, monkeypatch
+    ):
+        """Plenty of samples but only 1 calendar day → stay in shadow."""
+        db, adaptive_mode = _reload_adaptive_stack(monkeypatch, adaptive_env)
+        db.init_db()
+
+        _seed_adaptive_log_with_feedback(db, rows=210)
+        state = adaptive_mode._load_state()
+        state["learned_weights_first_date"] = (
+            datetime.utcnow() - timedelta(days=1)
+        ).strftime("%Y-%m-%dT%H:%M:%S")
+        adaptive_mode._save_state(state)
+
+        result = adaptive_mode.learn_weights(min_samples=30)
+        assert result["status"] == "shadow"
+
 
 # ── Rollback safety ────────────────────────────────────────────────────────
 

--- a/tests/test_g1_g3_enforcer_active.py
+++ b/tests/test_g1_g3_enforcer_active.py
@@ -1,0 +1,393 @@
+"""Tests for v7.2.0 Guardian activation: G1 enforcer + G3 SSH wrapper + persist.
+
+Coverage goals:
+- G1: off / shadow / hard return paths, grace window, rate limit,
+  fulfillment heuristic (cortex_evaluations / confidence_checks).
+- G3 SSH: classifier positive/negative cases, gate shadow vs hard on Bash
+  tool use.
+- Guardian runtime config resolver: env > file > default priority.
+- Auto-update persist: creates file with hard defaults, preserves
+  operator customization, respects opt-out env, ephemeral skip.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+
+SRC = Path(__file__).resolve().parents[1] / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+# ---------------------------------------------------------------------------
+# guardian_runtime_config resolver
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def overrides_home(tmp_path, monkeypatch):
+    home = tmp_path / "nexo"
+    (home / "personal" / "config").mkdir(parents=True)
+    monkeypatch.setenv("NEXO_HOME", str(home))
+    import importlib
+    import guardian_runtime_config
+    importlib.reload(guardian_runtime_config)
+    return home, guardian_runtime_config
+
+
+def test_resolver_default_when_no_env_and_no_file(overrides_home):
+    _, cfg = overrides_home
+    cfg.invalidate_cache()
+    assert cfg.resolve_guardian_flag("G1_ENFORCER_ACTIVE") == "shadow"
+    assert cfg.resolve_guardian_flag("SOMETHING_ELSE", default="off") == "off"
+
+
+def test_resolver_file_used_when_present(overrides_home, monkeypatch):
+    home, cfg = overrides_home
+    (home / "personal" / "config" / "guardian-runtime-overrides.json").write_text(
+        json.dumps({"G1_ENFORCER_ACTIVE": "hard", "G4_ENFORCE_GUARD_CHECK": "off"})
+    )
+    cfg.invalidate_cache()
+    monkeypatch.delenv("NEXO_G1_ENFORCER_ACTIVE", raising=False)
+    monkeypatch.delenv("NEXO_G4_ENFORCE_GUARD_CHECK", raising=False)
+    assert cfg.resolve_guardian_flag("G1_ENFORCER_ACTIVE") == "hard"
+    assert cfg.resolve_guardian_flag("G4_ENFORCE_GUARD_CHECK") == "off"
+
+
+def test_resolver_env_wins_over_file(overrides_home, monkeypatch):
+    home, cfg = overrides_home
+    (home / "personal" / "config" / "guardian-runtime-overrides.json").write_text(
+        json.dumps({"G1_ENFORCER_ACTIVE": "hard"})
+    )
+    cfg.invalidate_cache()
+    monkeypatch.setenv("NEXO_G1_ENFORCER_ACTIVE", "off")
+    assert cfg.resolve_guardian_flag("G1_ENFORCER_ACTIVE") == "off"
+
+
+def test_resolver_tolerates_malformed_file(overrides_home, monkeypatch):
+    home, cfg = overrides_home
+    (home / "personal" / "config" / "guardian-runtime-overrides.json").write_text("{not valid json")
+    cfg.invalidate_cache()
+    monkeypatch.delenv("NEXO_G1_ENFORCER_ACTIVE", raising=False)
+    assert cfg.resolve_guardian_flag("G1_ENFORCER_ACTIVE", default="shadow") == "shadow"
+
+
+# ---------------------------------------------------------------------------
+# G3 SSH remote-write classifier
+# ---------------------------------------------------------------------------
+
+
+SSH_POSITIVE_CASES = [
+    ('ssh host "cat > /tmp/x"', "ssh_remote_shell_write"),
+    ('ssh -o Foo=bar host "tee /etc/hosts"', "ssh_remote_shell_write"),
+    ('ssh host "sed -i s/a/b/ file"', "ssh_remote_shell_write"),
+    ('ssh host "echo hi > /tmp/y"', "ssh_remote_shell_write"),
+    ('ssh host "rm -rf /tmp/z"', "ssh_remote_shell_write"),
+    ('ssh host "cd /tmp && tee bar"', "ssh_remote_shell_write"),
+    ("scp /local/file host:/remote/path", "scp_remote_write"),
+    ("rsync -a /local host:/remote", "rsync_remote_write"),
+    ("sftp -b /tmp/batch host", "sftp_batch_remote_write"),
+]
+
+SSH_NEGATIVE_CASES = [
+    "ssh host ls /etc",
+    'ssh host "ls -la /home"',
+    "scp host:/remote/file /local/path",
+    "rsync -a host:/remote /local",
+    "sftp host",
+    "ls -la",
+    "git status",
+]
+
+
+@pytest.mark.parametrize("cmd,expected", SSH_POSITIVE_CASES)
+def test_ssh_classifier_positive(cmd, expected):
+    from hook_guardrails import _classify_ssh_remote_write
+    assert _classify_ssh_remote_write(cmd) == expected
+
+
+@pytest.mark.parametrize("cmd", SSH_NEGATIVE_CASES)
+def test_ssh_classifier_negative(cmd):
+    from hook_guardrails import _classify_ssh_remote_write
+    assert _classify_ssh_remote_write(cmd) is None
+
+
+# ---------------------------------------------------------------------------
+# G1 enforcer — integration over a test sqlite DB
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def g1_env(tmp_path, monkeypatch):
+    home = tmp_path / "nexo"
+    (home / "runtime" / "data").mkdir(parents=True)
+    db = home / "runtime" / "data" / "nexo.db"
+    conn = sqlite3.connect(str(db))
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS protocol_tasks (
+            task_id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL,
+            goal TEXT DEFAULT '',
+            response_mode TEXT DEFAULT '',
+            opened_at TEXT DEFAULT '',
+            status TEXT DEFAULT 'open'
+        );
+        CREATE TABLE IF NOT EXISTS protocol_debt (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT DEFAULT '',
+            task_id TEXT DEFAULT '',
+            debt_type TEXT NOT NULL,
+            severity TEXT DEFAULT 'warn',
+            status TEXT DEFAULT 'open',
+            evidence TEXT DEFAULT '',
+            resolution TEXT DEFAULT '',
+            created_at TEXT DEFAULT (datetime('now')),
+            resolved_at TEXT DEFAULT NULL
+        );
+        CREATE TABLE IF NOT EXISTS cortex_evaluations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT DEFAULT '',
+            created_at TEXT DEFAULT (datetime('now'))
+        );
+        CREATE TABLE IF NOT EXISTS confidence_checks (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT DEFAULT '',
+            created_at TEXT DEFAULT (datetime('now'))
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+    monkeypatch.setenv("NEXO_HOME", str(home))
+
+    # Reload modules so their cached ``NEXO_HOME`` and overrides match.
+    import importlib
+    import guardian_runtime_config
+    importlib.reload(guardian_runtime_config)
+    import sys as _sys
+    _sys.path.insert(0, str(SRC / "hooks"))
+    import g1_enforcer
+    importlib.reload(g1_enforcer)
+    return home, db, g1_enforcer
+
+
+def _iso_ago(seconds: int) -> str:
+    """Format a naive UTC ISO string (protocol_tasks.opened_at style) N seconds ago."""
+    import datetime as _dt
+    moment = _dt.datetime.now(tz=_dt.timezone.utc) - _dt.timedelta(seconds=seconds)
+    return moment.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _insert_task(db: Path, *, task_id: str, sid: str, mode: str, opened_at: str, status: str = "open") -> None:
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "INSERT INTO protocol_tasks (task_id, session_id, goal, response_mode, opened_at, status) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (task_id, sid, "test task", mode, opened_at, status),
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_g1_off_returns_none(g1_env, monkeypatch):
+    home, db, g1 = g1_env
+    _insert_task(db, task_id="T1", sid="sid-1", mode="defer", opened_at=_iso_ago(600))
+    monkeypatch.setenv("NEXO_G1_ENFORCER_ACTIVE", "off")
+    assert g1.check_response_contract_gate("sid-1") is None
+
+
+def test_g1_grace_window_suppresses(g1_env, monkeypatch):
+    home, db, g1 = g1_env
+    _insert_task(db, task_id="T1", sid="sid-1", mode="defer", opened_at=_iso_ago(10))
+    monkeypatch.setenv("NEXO_G1_ENFORCER_ACTIVE", "hard")
+    assert g1.check_response_contract_gate("sid-1") is None
+
+
+def test_g1_hard_fires_when_contract_unfulfilled(g1_env, monkeypatch):
+    home, db, g1 = g1_env
+    _insert_task(db, task_id="T1", sid="sid-1", mode="defer", opened_at=_iso_ago(600))
+    monkeypatch.setenv("NEXO_G1_ENFORCER_ACTIVE", "hard")
+    msg = g1.check_response_contract_gate("sid-1")
+    assert msg is not None
+    assert "G1 gate" in msg
+    assert "defer" in msg
+    # debt row written
+    conn = sqlite3.connect(str(db))
+    rows = conn.execute(
+        "SELECT debt_type, severity FROM protocol_debt WHERE session_id=?",
+        ("sid-1",),
+    ).fetchall()
+    conn.close()
+    assert ("g1_response_contract_unfulfilled", "warn") in rows
+
+
+def test_g1_shadow_logs_debt_but_no_message(g1_env, monkeypatch):
+    home, db, g1 = g1_env
+    _insert_task(db, task_id="T1", sid="sid-1", mode="verify", opened_at=_iso_ago(600))
+    monkeypatch.setenv("NEXO_G1_ENFORCER_ACTIVE", "shadow")
+    msg = g1.check_response_contract_gate("sid-1")
+    assert msg is None
+    conn = sqlite3.connect(str(db))
+    count = conn.execute(
+        "SELECT COUNT(*) FROM protocol_debt WHERE session_id=? AND debt_type=?",
+        ("sid-1", "g1_response_contract_unfulfilled"),
+    ).fetchone()[0]
+    conn.close()
+    assert count == 1
+
+
+def test_g1_fulfilled_via_cortex_evaluation_suppresses_fire(g1_env, monkeypatch):
+    home, db, g1 = g1_env
+    opened = _iso_ago(600)
+    _insert_task(db, task_id="T1", sid="sid-1", mode="defer", opened_at=opened)
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "INSERT INTO cortex_evaluations (session_id, created_at) VALUES (?, datetime('now'))",
+        ("sid-1",),
+    )
+    conn.commit()
+    conn.close()
+    monkeypatch.setenv("NEXO_G1_ENFORCER_ACTIVE", "hard")
+    assert g1.check_response_contract_gate("sid-1") is None
+
+
+def test_g1_fulfilled_via_confidence_check_suppresses_fire(g1_env, monkeypatch):
+    home, db, g1 = g1_env
+    opened = _iso_ago(600)
+    _insert_task(db, task_id="T1", sid="sid-1", mode="verify", opened_at=opened)
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "INSERT INTO confidence_checks (session_id, created_at) VALUES (?, datetime('now'))",
+        ("sid-1",),
+    )
+    conn.commit()
+    conn.close()
+    monkeypatch.setenv("NEXO_G1_ENFORCER_ACTIVE", "hard")
+    assert g1.check_response_contract_gate("sid-1") is None
+
+
+def test_g1_answer_mode_never_fires(g1_env, monkeypatch):
+    home, db, g1 = g1_env
+    _insert_task(db, task_id="T1", sid="sid-1", mode="answer", opened_at=_iso_ago(600))
+    monkeypatch.setenv("NEXO_G1_ENFORCER_ACTIVE", "hard")
+    assert g1.check_response_contract_gate("sid-1") is None
+
+
+def test_g1_rate_limit_suppresses_second_fire(g1_env, monkeypatch):
+    home, db, g1 = g1_env
+    _insert_task(db, task_id="T1", sid="sid-1", mode="ask", opened_at=_iso_ago(600))
+    monkeypatch.setenv("NEXO_G1_ENFORCER_ACTIVE", "hard")
+    first = g1.check_response_contract_gate("sid-1")
+    assert first is not None
+    second = g1.check_response_contract_gate("sid-1")
+    assert second is None  # rate limited
+
+
+def test_g1_closed_task_does_not_fire(g1_env, monkeypatch):
+    home, db, g1 = g1_env
+    _insert_task(db, task_id="T1", sid="sid-1", mode="defer", opened_at=_iso_ago(600), status="closed")
+    monkeypatch.setenv("NEXO_G1_ENFORCER_ACTIVE", "hard")
+    assert g1.check_response_contract_gate("sid-1") is None
+
+
+# ---------------------------------------------------------------------------
+# Auto-update persist Guardian hard defaults
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def persist_env(tmp_path, monkeypatch):
+    home = tmp_path / "nexo"
+    (home / "personal" / "config").mkdir(parents=True)
+    monkeypatch.setenv("NEXO_HOME", str(home))
+    import importlib
+    import auto_update
+    importlib.reload(auto_update)
+    return home, auto_update
+
+
+def test_persist_creates_file_with_hard_defaults(persist_env, monkeypatch):
+    home, au = persist_env
+    monkeypatch.delenv("NEXO_GUARDIAN_PERSIST_HARD", raising=False)
+    # Force non-ephemeral path
+    monkeypatch.setattr(au, "_is_ephemeral_runtime_install", lambda _dest: False)
+
+    persisted, msg = au._persist_guardian_hard_defaults(home)
+    assert persisted is True
+    assert msg is None
+    config_path = home / "personal" / "config" / "guardian-runtime-overrides.json"
+    assert config_path.is_file()
+    payload = json.loads(config_path.read_text())
+    assert payload["G1_ENFORCER_ACTIVE"] == "hard"
+    assert payload["G3_ENFORCE_DESTRUCTIVE"] == "hard"
+    assert payload["G3_SSH_ENFORCE_REMOTE_WRITE"] == "hard"
+    assert payload["G4_ENFORCE_GUARD_CHECK"] == "hard"
+
+
+def test_persist_preserves_operator_customization(persist_env, monkeypatch):
+    home, au = persist_env
+    config_path = home / "personal" / "config" / "guardian-runtime-overrides.json"
+    config_path.write_text(json.dumps({
+        "G1_ENFORCER_ACTIVE": "shadow",         # operator kept this intentionally soft
+        "G3_ENFORCE_DESTRUCTIVE": "hard",
+        # Missing keys should still be filled in with defaults.
+    }))
+    monkeypatch.delenv("NEXO_GUARDIAN_PERSIST_HARD", raising=False)
+    monkeypatch.setattr(au, "_is_ephemeral_runtime_install", lambda _dest: False)
+
+    persisted, msg = au._persist_guardian_hard_defaults(home)
+    assert persisted is True  # at least one key added
+    payload = json.loads(config_path.read_text())
+    assert payload["G1_ENFORCER_ACTIVE"] == "shadow"  # NOT overwritten
+    assert payload["G3_ENFORCE_DESTRUCTIVE"] == "hard"
+    assert payload["G3_SSH_ENFORCE_REMOTE_WRITE"] == "hard"  # added
+    assert payload["G4_ENFORCE_GUARD_CHECK"] == "hard"       # added
+
+
+def test_persist_idempotent_when_already_at_defaults(persist_env, monkeypatch):
+    home, au = persist_env
+    config_path = home / "personal" / "config" / "guardian-runtime-overrides.json"
+    config_path.write_text(json.dumps({
+        "G1_ENFORCER_ACTIVE": "hard",
+        "G3_ENFORCE_DESTRUCTIVE": "hard",
+        "G3_SSH_ENFORCE_REMOTE_WRITE": "hard",
+        "G4_ENFORCE_GUARD_CHECK": "hard",
+    }))
+    monkeypatch.delenv("NEXO_GUARDIAN_PERSIST_HARD", raising=False)
+    monkeypatch.setattr(au, "_is_ephemeral_runtime_install", lambda _dest: False)
+
+    mtime_before = config_path.stat().st_mtime_ns
+    time.sleep(0.01)
+    persisted, _msg = au._persist_guardian_hard_defaults(home)
+    assert persisted is False
+    # File untouched.
+    assert config_path.stat().st_mtime_ns == mtime_before
+
+
+def test_persist_respects_operator_opt_out_env(persist_env, monkeypatch):
+    home, au = persist_env
+    monkeypatch.setenv("NEXO_GUARDIAN_PERSIST_HARD", "off")
+    monkeypatch.setattr(au, "_is_ephemeral_runtime_install", lambda _dest: False)
+
+    persisted, msg = au._persist_guardian_hard_defaults(home)
+    assert persisted is False
+    assert msg is not None and "operator-opt-out" in msg
+    config_path = home / "personal" / "config" / "guardian-runtime-overrides.json"
+    assert not config_path.is_file()
+
+
+def test_persist_skips_ephemeral_runtime(persist_env, monkeypatch):
+    home, au = persist_env
+    monkeypatch.setattr(au, "_is_ephemeral_runtime_install", lambda _dest: True)
+    monkeypatch.delenv("NEXO_GUARDIAN_PERSIST_HARD", raising=False)
+    persisted, msg = au._persist_guardian_hard_defaults(home)
+    assert persisted is False
+    assert msg is not None and "ephemeral" in msg

--- a/tests/test_g1_g3_enforcer_active.py
+++ b/tests/test_g1_g3_enforcer_active.py
@@ -391,3 +391,129 @@ def test_persist_skips_ephemeral_runtime(persist_env, monkeypatch):
     persisted, msg = au._persist_guardian_hard_defaults(home)
     assert persisted is False
     assert msg is not None and "ephemeral" in msg
+
+
+# ---------------------------------------------------------------------------
+# Auto-update empirical adaptive-weights promotion during `nexo update`
+# ---------------------------------------------------------------------------
+
+
+def _write_adaptive_state(home: Path, payload: dict) -> Path:
+    state_path = home / "personal" / "brain" / "adaptive_state.json"
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
+    return state_path
+
+
+def _iso_utc(days_ago: int = 0) -> str:
+    import datetime as _dt
+    moment = _dt.datetime.utcnow() - _dt.timedelta(days=days_ago)
+    return moment.strftime("%Y-%m-%dT%H:%M:%S")
+
+
+_SAMPLE_SHADOW = {
+    "vibe": 0.2402,
+    "corrections": 0.262,
+    "brevity": 0.1345,
+    "topic": 0.0962,
+    "tool_errors": 0.1345,
+    "git_diff": 0.1326,
+}
+
+
+def test_adaptive_promote_happy_path_activates_weights(persist_env, monkeypatch):
+    home, au = persist_env
+    monkeypatch.delenv("NEXO_ADAPTIVE_EMPIRICAL_PROMOTION", raising=False)
+    monkeypatch.setattr(au, "_is_ephemeral_runtime_install", lambda _dest: False)
+
+    _write_adaptive_state(home, {
+        "shadow_weights": _SAMPLE_SHADOW,
+        "shadow_weights_samples": 245,
+        "learned_weights_first_date": _iso_utc(days_ago=3),
+    })
+
+    promoted, msg = au._maybe_promote_adaptive_weights_empirically(home)
+    assert promoted is True
+    assert msg is None
+
+    state_path = home / "personal" / "brain" / "adaptive_state.json"
+    data = json.loads(state_path.read_text())
+    assert data["learned_weights"] == _SAMPLE_SHADOW
+    assert data["learned_weights_samples"] == 245
+    assert data["learned_weights_promoted_by"] == "nexo_update_empirical_v7_2_0"
+    assert data["learned_weights_promoted_at"]
+
+
+def test_adaptive_promote_noop_when_already_active(persist_env, monkeypatch):
+    home, au = persist_env
+    monkeypatch.delenv("NEXO_ADAPTIVE_EMPIRICAL_PROMOTION", raising=False)
+    monkeypatch.setattr(au, "_is_ephemeral_runtime_install", lambda _dest: False)
+
+    _write_adaptive_state(home, {
+        "shadow_weights": _SAMPLE_SHADOW,
+        "shadow_weights_samples": 245,
+        "learned_weights": _SAMPLE_SHADOW,
+        "learned_weights_first_date": _iso_utc(days_ago=30),
+    })
+
+    promoted, msg = au._maybe_promote_adaptive_weights_empirically(home)
+    assert promoted is False
+    assert msg is None
+
+
+def test_adaptive_promote_skips_when_samples_below_threshold(persist_env, monkeypatch):
+    home, au = persist_env
+    monkeypatch.delenv("NEXO_ADAPTIVE_EMPIRICAL_PROMOTION", raising=False)
+    monkeypatch.setattr(au, "_is_ephemeral_runtime_install", lambda _dest: False)
+
+    _write_adaptive_state(home, {
+        "shadow_weights": _SAMPLE_SHADOW,
+        "shadow_weights_samples": 50,  # below the 200 bar
+        "learned_weights_first_date": _iso_utc(days_ago=5),
+    })
+
+    promoted, msg = au._maybe_promote_adaptive_weights_empirically(home)
+    assert promoted is False
+    assert msg is None  # quiet no-op, not a "skipped:" message
+
+
+def test_adaptive_promote_skips_when_days_below_threshold(persist_env, monkeypatch):
+    home, au = persist_env
+    monkeypatch.delenv("NEXO_ADAPTIVE_EMPIRICAL_PROMOTION", raising=False)
+    monkeypatch.setattr(au, "_is_ephemeral_runtime_install", lambda _dest: False)
+
+    _write_adaptive_state(home, {
+        "shadow_weights": _SAMPLE_SHADOW,
+        "shadow_weights_samples": 500,
+        "learned_weights_first_date": _iso_utc(days_ago=1),
+    })
+
+    promoted, msg = au._maybe_promote_adaptive_weights_empirically(home)
+    assert promoted is False
+    assert msg is None
+
+
+def test_adaptive_promote_respects_operator_opt_out(persist_env, monkeypatch):
+    home, au = persist_env
+    monkeypatch.setenv("NEXO_ADAPTIVE_EMPIRICAL_PROMOTION", "off")
+    monkeypatch.setattr(au, "_is_ephemeral_runtime_install", lambda _dest: False)
+
+    _write_adaptive_state(home, {
+        "shadow_weights": _SAMPLE_SHADOW,
+        "shadow_weights_samples": 245,
+        "learned_weights_first_date": _iso_utc(days_ago=3),
+    })
+
+    promoted, msg = au._maybe_promote_adaptive_weights_empirically(home)
+    assert promoted is False
+    assert msg is not None and "operator-opt-out" in msg
+
+
+def test_adaptive_promote_handles_missing_state_file_quietly(persist_env, monkeypatch):
+    home, au = persist_env
+    monkeypatch.delenv("NEXO_ADAPTIVE_EMPIRICAL_PROMOTION", raising=False)
+    monkeypatch.setattr(au, "_is_ephemeral_runtime_install", lambda _dest: False)
+    # No adaptive_state.json at all — fresh install.
+    promoted, msg = au._maybe_promote_adaptive_weights_empirically(home)
+    assert promoted is False
+    assert msg is None


### PR DESCRIPTION
## Summary

Block K Guardian activation wave — G1 enforcer + G3 SSH wrapper + persist hard defaults + G5 adaptive empirical promotion.

Shadow-by-default on the branch so the merge never breaks an install. `_persist_guardian_hard_defaults` flips the defaults to `hard` at the next `nexo update` on every non-ephemeral install; operators who want 7.1.x passive behaviour set `NEXO_GUARDIAN_PERSIST_HARD=off`.

## Commits

- `b03fdc5` — G1 enforcer active + G3 SSH wrapper + `guardian_runtime_config.py` resolver unified + `_persist_guardian_hard_defaults` post-update.
- `fca8691` — G5 adaptive weights empirical promotion (shadow→active on ≥200 samples AND ≥2 days, not 14-day calendar wait).
- `9a0e1b9` — G5 auto-promote during `nexo update` so operators with mature shadow data activate immediately post-update (doesn't wait for next learner cron).

## Verification

- `pytest tests/test_g1_g3_enforcer_active.py -q` → 40 passed.
- `pytest tests/test_g1_g3_enforcer_active.py tests/test_hook_guardrails.py tests/test_auto_update_*.py -q` → 90+ passed on regression smoke.
- SSH classifier smoke: 13 positive/negative cases all OK.
- Rebase clean over `origin/main` (post #261 + #258 + #259 + #260).

## Roadmap closure

Closes Block K G1 (enforcer activo `response_contract.mode` bloqueo físico) + G3 SSH wrapper + G5 cortex calibration empirical path. G2/G3-destructive-Bash/G4/G7/G8 already shipped. G5/G6/G10 still open for v7.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
