### PR TITLE
fix(upgrade): sync templates/ root in bin/nexo-brain.js migration path

### DIFF
--- a/bin/nexo-brain.js
+++ b/bin/nexo-brain.js
@@ -2127,6 +2127,14 @@ async function main() {
         writeRuntimeCoreArtifactsManifest(NEXO_HOME, srcDir);
         log("  Scripts updated.");
 
+        // Update templates/ root (core-prompts/, CLAUDE.md.template, etc.) — recursive
+        const migTemplatesSrc = path.join(__dirname, "..", "templates");
+        const migTemplatesDest = path.join(NEXO_HOME, "templates");
+        if (fs.existsSync(migTemplatesSrc)) {
+          copyDirRec(migTemplatesSrc, migTemplatesDest);
+          log("  Templates updated.");
+        }
+
         // Register ALL 8 core hooks in settings.json (additive — don't remove user's custom hooks)
         let settings = {};
         if (fs.existsSync(CLAUDE_SETTINGS)) {


### PR DESCRIPTION
## Summary

Fix upgrade path in bin/nexo-brain.js so the templates/ root (core-prompts/, CLAUDE.md.template, etc.) is propagated during client upgrades.

## Root cause

The upgrade flow (installedVersion !== currentVersion) in bin/nexo-brain.js copied hooks, plugins, dashboard, rules, crons and scripts via copyDirRec but never touched templates/ root. Fresh install (~line 3085) and same-version refresh (~line 2303) both synced templates; only the upgrade path missed it.

Consequence observed in the wild: Maria iMac upgrade 7.1.10 -> 7.8.1 left 27 core-prompts templates stale, and the post-update import verification failed because the new autonomy_mandate.py required autonomy-mandate-question.md which was never copied. Workaround was a manual rsync; this patch removes the need for any future client upgrading from earlier versions.

## Change

+ 8 lines in bin/nexo-brain.js after log("  Scripts updated."):

```javascript
const migTemplatesSrc = path.join(__dirname, "..", "templates");
const migTemplatesDest = path.join(NEXO_HOME, "templates");
if (fs.existsSync(migTemplatesSrc)) {
  copyDirRec(migTemplatesSrc, migTemplatesDest);
  log("  Templates updated.");
}
```

## Verification

- [x] npm pack --dry-run lists 82 entries under templates/core-prompts/ (tarball already carried them; only the migration consumer was dropping them)
- [x] git diff shows exactly +8 lines, placement immediately after Scripts updated.
- [x] Fresh install path (~3085) and same-version refresh path (~2303) untouched — they already synced templates

## Context

- Learning #553 (nexo-brain, high priority)
- Followup NF-BRAIN-781-TEMPLATES-PKG
- Diary entry 2026-04-22
- Documented as Bug 1 in ~/Desktop/NEXO-ONEPASS-LLM-COVERAGE-RELEASE-PLAN.md

Generated with [Claude Code](https://claude.com/claude-code)
