### PR TITLE
fix(bootstrap): preload deferred mcp__nexo__* schemas in enforcement map

### DIFF
--- a/tool-enforcement-map.json
+++ b/tool-enforcement-map.json
@@ -3214,7 +3214,7 @@
             "threshold": 1
           }
         ],
-        "inject_prompt": "You must start by calling nexo_startup to register this session. Execute it now with a brief task description. Do not produce visible text.",
+        "inject_prompt": "You must start by calling nexo_startup to register this session. If mcp__nexo__* tools appear as deferred in the tool list (names visible but JSONSchemas not loaded), first call ToolSearch with query \"select:mcp__nexo__nexo_startup,mcp__nexo__nexo_heartbeat,mcp__nexo__nexo_session_diary_read,mcp__nexo__nexo_reminders,mcp__nexo__nexo_smart_startup\" to load the schemas — deferred is not absent. Then execute nexo_startup with a brief task description. Do not produce visible text.",
         "triggers_after": [
           "nexo_smart_startup",
           "nexo_session_diary_read",


### PR DESCRIPTION
## Summary

Amend `nexo_startup.enforcement.inject_prompt` in `tool-enforcement-map.json` so that when the MCP host defers tool schemas (Claude Code with many MCPs), the model is explicitly instructed to preload `mcp__nexo__*` via `ToolSearch` before calling `nexo_startup`.

Companion to nexo-desktop PR #18 which adds the same preload instruction to the Desktop renderer bootstrap. Belt-and-suspenders: both layers covered.

## Root cause

Claude Code exposes many-MCP tools as "deferred": names visible in system-reminder blocks, JSONSchemas not loaded until `ToolSearch select:<name>`. The old `inject_prompt` assumed tools were immediately callable; when schemas were deferred the model skipped the protocol entirely because it believed NEXO was unavailable.

## Change

```diff
-"inject_prompt": "You must start by calling nexo_startup to register this session. Execute it now with a brief task description. Do not produce visible text."
+"inject_prompt": "You must start by calling nexo_startup to register this session. If mcp__nexo__* tools appear as deferred in the tool list (names visible but JSONSchemas not loaded), first call ToolSearch with query \"select:mcp__nexo__nexo_startup,mcp__nexo__nexo_heartbeat,mcp__nexo__nexo_session_diary_read,mcp__nexo__nexo_reminders,mcp__nexo__nexo_smart_startup\" to load the schemas — deferred is not absent. Then execute nexo_startup with a brief task description. Do not produce visible text."
```

## Verification

- [x] JSON parses cleanly (`python3 -c "import json; json.load(open(...))"`)
- [x] Pre-commit hook: `tool-enforcement-map.json is in sync with code (263 tools)`
- [x] Diff is a single-line inject_prompt amendment; nothing structural changed

## Context

- Learning #554 (nexo-brain, critical): "Deferred MCP tool schemas rompen bootstrap NEXO silenciosamente"
- Followup `NF-BRAIN-BOOTSTRAP-DEFERRED-SCHEMAS` (critical)
- Observed live in session `nexo-1776899231-34499` 2026-04-23
- Documented as Bug 3 in `~/Desktop/NEXO-ONEPASS-LLM-COVERAGE-RELEASE-PLAN.md`
- Companion: https://github.com/wazionapps/nexo-desktop/pull/18

Generated with [Claude Code](https://claude.com/claude-code)
