### PR TITLE
feat(semantic): semantic_router + semantic_reasoner scaffolding (18 decision_kinds, 31 tests)

### DIFF
--- a/docs/semantic-reasoner-model-notes.md
+++ b/docs/semantic-reasoner-model-notes.md
@@ -1,0 +1,142 @@
+# Semantic reasoner — pin + design notes
+
+Plan ONEPASS LLM Coverage, release stage. Companion to
+[classifier-model-notes.md](./classifier-model-notes.md).
+
+## What the reasoner is
+
+`src/semantic_reasoner.py` is the second layer of the semantic stack:
+
+```
+fast_local  ->  semantic_reasoner  ->  remote_fallback
+ (Zero-shot    (this module)         (call_model_raw
+  mDeBERTa,                            last-resort)
+  pinned)
+```
+
+`semantic_router.py` dispatches every Brain semantic decision through this
+stack. Call sites name their `decision_kind` and the router applies the
+per-kind policy.
+
+## Two reasoner modes — honest pin strategy
+
+The plan asked for a "stronger, pinned model" as the second layer. This
+release ships that stronger layer using a split strategy that avoids
+falsifying a pin we cannot reproducibly verify. The two modes are:
+
+### Mode A — `multipass_local`
+
+Used for textual decision kinds (`session_end_intent`, `r14_correction`,
+`r16_declared_done`, `r17_promise_debt`, `autonomy_mandate`,
+`guard_verbal_ack`, `r34_identity_coherence`, `followup_operator_attention`,
+`drive_signal_type`, `drive_area`, `reply_event_type`, `query_intent`,
+`sentiment_intent`).
+
+- Reuses the already-pinned `LocalZeroShotClassifier`.
+- Model id + revision: **see
+  [classifier-model-notes.md](./classifier-model-notes.md)**. Pin is
+  authoritative there; this module intentionally does not duplicate the
+  SHA so upgrades only need to touch one file.
+- Stricter behaviour than the fast path:
+  1. three inference passes with mild prompt perturbations
+     (`"{q}"`, `"Decide: {q}"`, `"Classify this utterance: {q}"`)
+  2. majority vote across passes
+  3. result only accepted if ≥2/3 passes agree **and** the averaged
+     confidence for the winning label is ≥ 0.75 (policy default).
+- No extra model download. No extra install state. No extra bootstrap
+  risk.
+
+The reason this is *stronger* than the fast path: single-pass zero-shot
+classifiers have measurable variance on short ambiguous utterances, and
+tighter thresholds applied to single samples produce too many refusals.
+Three-pass majority voting kills false positives without requiring a
+larger model.
+
+### Mode B — `cached_llm`
+
+Used for code-aware decision kinds (`r20_constant_change`, `t4_r15`,
+`t4_r23e`, `t4_r23f`, `t4_r23h`) where zero-shot NLI was never the right
+authority.
+
+- Thin wrapper around `src/call_model_raw.py`.
+- The backend model is resolved through `resonance_map.resolve_model_and_effort`
+  with `caller='semantic_reasoner'`, `tier='muy_bajo'`. The actual model
+  id + revision is therefore pinned by the resonance map, not by this
+  module. This matches how every other Brain LLM caller is pinned and
+  keeps a single source of truth.
+- **Disk cache**: `~/.nexo/runtime/operations/semantic-reasoner-cache.json`.
+  Keys are `sha256(json({decision_kind, normalized_question,
+  normalized_context, labels}))`. TTL default 24h. Scope is per-decision_kind
+  so a cached `t4_r15` answer cannot leak into `t4_r23f`.
+- Cache bounded at 2000 entries with LRU trim to 1800 on write. Entries
+  older than TTL are ignored even if not evicted.
+
+Rationale: these decisions are expensive-per-call but highly repetitive
+(the same snippet of code keeps passing through the enforcement engine).
+Caching on `(decision_kind, normalized_input)` reduces remote calls
+dramatically without changing correctness, and the policy stays explicit.
+
+## Why not ship a dedicated stronger local LLM in this release
+
+The plan contemplated pinning a local LLM (Llama 3.1 8B, Qwen 2.5 7B,
+etc.) as the reasoner. We deferred that for two verifiable reasons:
+
+1. **Install-time risk**: provisioning a 5–10 GB model during `nexo
+   update` would require a new download pipeline, GPU/MPS detection, a
+   separate install-state file, and the heavy-bootstrap protections the
+   existing classifier needed. That surface area is a full feature, not
+   a sub-step of this release.
+2. **Pin verifiability**: pinning a model SHA without a live connection
+   to HuggingFace at review time risks locking every operator to a
+   revision that turns out to have been silently rewritten upstream.
+   The fast-local pin (`classifier-model-notes.md`) paid that cost once;
+   adding a second local pin without reproducible verification would
+   recreate the exact footgun the pin policy exists to prevent.
+
+A future release can graduate Mode B from `cached_llm` to a truly local
+LLM without changing the `semantic_router` contract. Call sites only see
+`RouterResult`; whether the reasoner ran locally or remotely is hidden.
+
+## Environment variables
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `NEXO_SEMANTIC_REASONER_CACHE_PATH` | *(unset)* | Override cache file path. Used in tests and for debug isolation. |
+| `NEXO_SEMANTIC_REASONER_TTL` | `86400` | Cache TTL in seconds. Lower for aggressive re-validation; raise for offline-heavy usage. |
+
+There is **no** `NEXO_SEMANTIC_REASONER=0` opt-out: the reasoner is
+always available when its dependencies are. Opt-out happens at the
+router level via `allow_remote_fallback=False` plus the existing
+`NEXO_LOCAL_CLASSIFIER` flag for Mode A.
+
+## Upgrade policy
+
+- Mode A: follow the upgrade policy already documented in
+  `classifier-model-notes.md`. When the fast-path pin bumps, Mode A
+  automatically picks it up.
+- Mode B: follow the resonance-map upgrade policy. The reasoner never
+  pins an LLM directly; `nexo_cortex_review` already tracks resonance
+  quality and fires the next-tier eval cycle.
+- Policy table in `src/semantic_router.py::_POLICY`: changing a
+  decision_kind's route or threshold requires editing that dict AND
+  updating this doc AND bumping the relevant tests. A drift check in
+  CI (`tests/test_semantic_router.py::test_policy_kinds_are_documented`)
+  fails if any kind goes undocumented.
+
+## Wiring status
+
+- [x] `src/semantic_router.py` — 18 decision_kinds registered.
+- [x] `src/semantic_reasoner.py` — Modes A + B implemented.
+- [x] `docs/semantic-reasoner-model-notes.md` — this file.
+- [x] `tests/test_semantic_router.py` — policy + routing tests.
+- [x] `tests/test_semantic_reasoner.py` — mode A/B tests (stubbing the
+      fast classifier and `call_model_raw`).
+- [ ] Per-site migration of existing callers (`session_end_intent.py`,
+      `autonomy_mandate.py`, `guard_verbal_ack.py`, `r14_*`, `r16_*`,
+      `r17_*`, `r20_*`, `r34_*`, `tools_drive.py`, `nexo-followup-runner.py`,
+      etc.) — ships in a **follow-up PR**. That PR does not change the
+      router/reasoner contract, only replaces per-site classifier policy
+      trees with `semantic_router.route(decision_kind=…)` calls.
+- [ ] Desktop bridge (`lib/brain-semantic-router.js` + `nexo semantic
+      classify` CLI) — ships in the nexo-desktop release PR that pairs
+      with this one.

--- a/docs/semantic-reasoner-model-notes.md
+++ b/docs/semantic-reasoner-model-notes.md
@@ -1,6 +1,6 @@
 # Semantic reasoner — pin + design notes
 
-Plan ONEPASS LLM Coverage, release stage. Companion to
+Plan ONEPASS LLM Coverage (target release v7.9.0). Companion to
 [classifier-model-notes.md](./classifier-model-notes.md).
 
 ## What the reasoner is
@@ -18,11 +18,14 @@ fast_local  ->  semantic_reasoner  ->  remote_fallback
 stack. Call sites name their `decision_kind` and the router applies the
 per-kind policy.
 
-## Two reasoner modes — honest pin strategy
+## Two reasoner modes — same pin, stricter aggregation (A) or remote LLM via resonance map (B)
 
-The plan asked for a "stronger, pinned model" as the second layer. This
-release ships that stronger layer using a split strategy that avoids
-falsifying a pin we cannot reproducibly verify. The two modes are:
+The plan asked for a "stronger, pinned" second layer. The honest shape of
+what this release ships is **not** a new downloadable model. Mode A reuses
+the existing mDeBERTa pin with stricter aggregation semantics (three
+passes, majority vote, higher threshold); Mode B delegates to the LLM
+resolved by the resonance map. Neither adds a new model SHA to the repo,
+and the docs are careful not to imply otherwise. The two modes are:
 
 ### Mode A — `multipass_local`
 
@@ -101,13 +104,16 @@ LLM without changing the `semantic_router` contract. Call sites only see
 
 | Variable | Default | Effect |
 |----------|---------|--------|
-| `NEXO_SEMANTIC_REASONER_CACHE_PATH` | *(unset)* | Override cache file path. Used in tests and for debug isolation. |
-| `NEXO_SEMANTIC_REASONER_TTL` | `86400` | Cache TTL in seconds. Lower for aggressive re-validation; raise for offline-heavy usage. |
+| `NEXO_SEMANTIC_REASONER` | *(unset, i.e. enabled)* | Dedicated runtime kill switch. Set to `0`, `off`, `false`, `no`, `disable`, or `disabled` to force every `reason()` call to refuse. The router then falls through to `remote_fallback` on its own, or returns `no_route` if that is also disallowed. Mandated by the plan as the opt-out dedicated to this module, separate from `NEXO_LOCAL_CLASSIFIER`. |
+| `NEXO_SEMANTIC_REASONER_CACHE_PATH` | *(unset)* | Override cache file path (under `paths.operations_dir()` by default). Used in tests and for debug isolation. |
+| `NEXO_SEMANTIC_REASONER_TTL` | `86400` | Cache TTL in seconds for Mode B entries. Malformed or non-positive values fall back to the default and emit a logger warning — no crash on operator typos. |
 
-There is **no** `NEXO_SEMANTIC_REASONER=0` opt-out: the reasoner is
-always available when its dependencies are. Opt-out happens at the
-router level via `allow_remote_fallback=False` plus the existing
-`NEXO_LOCAL_CLASSIFIER` flag for Mode A.
+Note that `NEXO_LOCAL_CLASSIFIER` still exists but **only gates install-time
+provisioning** of the fast-local weights (see `src/auto_update.py`). Once
+the model is on disk it keeps loading. If you need a pure runtime kill
+switch for the reasoner layer specifically, use `NEXO_SEMANTIC_REASONER`.
+The router also accepts `allow_remote_fallback=False` per call to force
+local-only behaviour for a specific decision.
 
 ## Upgrade policy
 
@@ -137,6 +143,14 @@ router level via `allow_remote_fallback=False` plus the existing
       etc.) — ships in a **follow-up PR**. That PR does not change the
       router/reasoner contract, only replaces per-site classifier policy
       trees with `semantic_router.route(decision_kind=…)` calls.
-- [ ] Desktop bridge (`lib/brain-semantic-router.js` + `nexo semantic
-      classify` CLI) — ships in the nexo-desktop release PR that pairs
-      with this one.
+- [x] Desktop bridge — `nexo-desktop/lib/brain-semantic-router.js` (PR #19)
+      spawns this repo's `scripts/semantic-classify.py` (Brain-side CLI)
+      and parses the `RouterResult` from stdout. There is no `nexo
+      semantic classify` subcommand in `src/cli.py`; the bridge targets
+      the Python script directly to keep the surface minimal.
+- [ ] Per-site migration of existing callers (`session_end_intent.py`,
+      `autonomy_mandate.py`, `r14_*`, `r16_*`, `r17_*`, `r20_*`, `r34_*`,
+      T4 gates, `tools_drive.py`, `nexo-followup-runner.py`) — tracked
+      in followup `NF-SEMANTIC-ROUTER-SITE-MIGRATION` and ships in
+      themed follow-up PRs. No call site currently consumes the router;
+      this release is scaffolding only.

--- a/scripts/semantic-classify.py
+++ b/scripts/semantic-classify.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""JSON-in JSON-out CLI wrapper around ``src/semantic_router.route``.
+
+Plan ONEPASS LLM Coverage — Desktop bridge.
+
+Used by ``nexo-desktop/lib/brain-semantic-router.js`` to perform semantic
+decisions without embedding a second policy tree in Desktop. Keeps Brain
+as the single authority for semantic decisions; Desktop is a client.
+
+Contract:
+
+    stdin   — JSON object with at least {decision_kind, question}.
+              Optional fields: context, labels, allow_remote_fallback.
+
+    stdout  — JSON object mirroring RouterResult (ok, decision_kind,
+              verdict, label, confidence, route_used, degraded, error,
+              meta).
+
+    exit    — 0 on well-formed result (ok or not_ok are both exit 0).
+              1 only when the CLI itself cannot parse input or resolve
+              the router module.
+
+This deliberately does NOT rehydrate the NEXO MCP stack, does NOT touch
+the database, does NOT invoke nexo_startup. It is a pure function
+wrapper so Desktop can call it hot-path without the automation cost.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def _setup_imports() -> None:
+    """Insert ``src/`` at the head of sys.path so ``import semantic_router``
+    resolves inside the repo install (same pattern tests/conftest.py uses).
+    Falls back to the packaged runtime location if the repo layout is not
+    present (client installs).
+    """
+    here = Path(__file__).resolve().parent
+    candidates = [
+        here.parent / "src",  # repo layout
+        Path.home() / ".nexo" / "core" / "src",  # installed runtime
+    ]
+    for candidate in candidates:
+        if candidate.is_dir():
+            sys.path.insert(0, str(candidate))
+            return
+
+
+def _error(msg: str, *, code: int = 1) -> int:
+    print(json.dumps({"ok": False, "error": msg, "route_used": "no_route"}))
+    return code
+
+
+def _coerce_labels(value):
+    if value is None:
+        return None
+    if isinstance(value, (list, tuple)):
+        return tuple(str(x) for x in value)
+    return None
+
+
+def main() -> int:
+    _setup_imports()
+
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return _error("empty stdin; expected JSON payload")
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return _error(f"invalid JSON on stdin: {exc}")
+
+    if not isinstance(payload, dict):
+        return _error("payload must be a JSON object")
+
+    decision_kind = str(payload.get("decision_kind", "") or "").strip()
+    question = str(payload.get("question", "") or "")
+    context = str(payload.get("context", "") or "")
+    labels = _coerce_labels(payload.get("labels"))
+    allow_remote_fallback = bool(payload.get("allow_remote_fallback", True))
+
+    if not decision_kind:
+        return _error("missing required field: decision_kind")
+    if not question:
+        return _error("missing required field: question")
+
+    try:
+        import semantic_router as sr
+    except ImportError as exc:
+        return _error(f"semantic_router unavailable: {exc}", code=1)
+
+    result = sr.route(
+        decision_kind=decision_kind,
+        question=question,
+        context=context,
+        labels=labels,
+        allow_remote_fallback=allow_remote_fallback,
+    )
+    print(
+        json.dumps(
+            {
+                "ok": bool(result.ok),
+                "decision_kind": result.decision_kind,
+                "verdict": result.verdict,
+                "label": result.label,
+                "confidence": float(result.confidence),
+                "route_used": result.route_used,
+                "degraded": bool(result.degraded),
+                "error": result.error,
+                "meta": result.meta or {},
+            },
+            ensure_ascii=False,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/semantic_reasoner.py
+++ b/src/semantic_reasoner.py
@@ -248,12 +248,26 @@ def _read_cache() -> dict[str, Any]:
 
 
 def _write_cache(cache: dict[str, Any]) -> None:
+    """Atomic write with pid+uuid suffix so concurrent Brain / Desktop CLI
+    writers do not stomp each other's temp file."""
     try:
         path = _cache_path()
         path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_suffix(".tmp")
-        tmp.write_text(json.dumps(cache, ensure_ascii=False, sort_keys=True))
-        tmp.replace(path)
+        import os as _os
+        import uuid as _uuid
+
+        tmp = path.with_name(
+            f"{path.name}.tmp.{_os.getpid()}.{_uuid.uuid4().hex[:8]}"
+        )
+        payload = json.dumps(cache, ensure_ascii=False, sort_keys=True)
+        with open(tmp, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+            handle.flush()
+            try:
+                _os.fsync(handle.fileno())
+            except OSError:
+                pass
+        _os.replace(tmp, path)
     except Exception as exc:  # pragma: no cover
         _logger.warning("semantic_reasoner: cache write failed (%s)", exc)
 
@@ -282,6 +296,30 @@ def _cache_put(key: str, entry: dict[str, Any]) -> None:
     _write_cache(cache)
 
 
+def _parse_ttl_env() -> int:
+    """Read ``NEXO_SEMANTIC_REASONER_TTL`` defensively.
+
+    Malformed values (non-integer, negative) fall back to the default so
+    operator typos never crash the reasoner on first call.
+    """
+    raw = os.environ.get("NEXO_SEMANTIC_REASONER_TTL", "")
+    if not raw:
+        return _DEFAULT_CACHE_TTL_SECONDS
+    try:
+        parsed = int(raw)
+    except (TypeError, ValueError):
+        _logger.warning(
+            "semantic_reasoner: invalid NEXO_SEMANTIC_REASONER_TTL=%r; "
+            "using default %d",
+            raw,
+            _DEFAULT_CACHE_TTL_SECONDS,
+        )
+        return _DEFAULT_CACHE_TTL_SECONDS
+    if parsed <= 0:
+        return _DEFAULT_CACHE_TTL_SECONDS
+    return parsed
+
+
 def _reason_cached_llm(
     *,
     decision_kind: str,
@@ -291,7 +329,7 @@ def _reason_cached_llm(
     confidence_floor: float,
 ):
     RouterResult = _import_router_result()
-    ttl = int(os.environ.get("NEXO_SEMANTIC_REASONER_TTL", _DEFAULT_CACHE_TTL_SECONDS))
+    ttl = _parse_ttl_env()
     key = _cache_key(
         decision_kind=decision_kind,
         question=question,
@@ -301,23 +339,32 @@ def _reason_cached_llm(
 
     cached = _cache_get(key, ttl)
     if cached is not None:
-        return RouterResult(
-            ok=True,
-            decision_kind=decision_kind,
-            verdict=cached.get("verdict"),
-            label=cached.get("verdict"),
-            confidence=float(cached.get("confidence", 0.6)),
-            route_used="semantic_reasoner",
-            degraded=False,
-            meta={
-                "mode": "cached_llm",
-                "cache_hit": True,
-                "cache_key": key[:12],
-            },
+        cached_verdict = cached.get("verdict")
+        if isinstance(cached_verdict, str) and cached_verdict.strip():
+            return RouterResult(
+                ok=True,
+                decision_kind=decision_kind,
+                verdict=cached_verdict,
+                label=cached_verdict,
+                confidence=float(cached.get("confidence", 0.6)),
+                route_used="semantic_reasoner",
+                degraded=False,
+                meta={
+                    "mode": "cached_llm",
+                    "cache_hit": True,
+                    "cache_key": key[:12],
+                },
+            )
+        # Corrupt entry (verdict missing or non-string). Drop it and fall
+        # through to a live call so the caller is never handed a cached
+        # "ok=True, verdict=None" sentinel.
+        _logger.warning(
+            "semantic_reasoner: dropping corrupt cache entry for key=%s",
+            key[:12],
         )
 
     try:
-        from call_model_raw import ClassifierUnavailableError, call_model_raw
+        import call_model_raw as _cmr
     except Exception as exc:  # pragma: no cover
         return RouterResult(
             ok=False,
@@ -325,6 +372,20 @@ def _reason_cached_llm(
             route_used="semantic_reasoner",
             degraded=True,
             error=f"call_model_raw unavailable: {exc}",
+            meta={"mode": "cached_llm", "cache_hit": False},
+        )
+
+    call_model_raw_fn = getattr(_cmr, "call_model_raw", None)
+    classifier_unavailable_cls = getattr(
+        _cmr, "ClassifierUnavailableError", Exception
+    )
+    if call_model_raw_fn is None:
+        return RouterResult(
+            ok=False,
+            decision_kind=decision_kind,
+            route_used="semantic_reasoner",
+            degraded=True,
+            error="call_model_raw callable missing",
             meta={"mode": "cached_llm", "cache_hit": False},
         )
 
@@ -340,7 +401,7 @@ def _reason_cached_llm(
         "label fits, answer 'unknown'."
     )
     try:
-        raw = call_model_raw(
+        raw = call_model_raw_fn(
             prompt,
             system=system,
             caller="semantic_reasoner",
@@ -348,13 +409,22 @@ def _reason_cached_llm(
             max_tokens=32,
             temperature=0.0,
         )
-    except ClassifierUnavailableError as exc:
+    except classifier_unavailable_cls as exc:
         return RouterResult(
             ok=False,
             decision_kind=decision_kind,
             route_used="semantic_reasoner",
             degraded=True,
             error=f"remote_unavailable: {exc}",
+            meta={"mode": "cached_llm", "cache_hit": False},
+        )
+    except Exception as exc:  # noqa: BLE001 — fail-closed
+        return RouterResult(
+            ok=False,
+            decision_kind=decision_kind,
+            route_used="semantic_reasoner",
+            degraded=True,
+            error=f"remote_error: {exc}",
             meta={"mode": "cached_llm", "cache_hit": False},
         )
 
@@ -366,7 +436,11 @@ def _reason_cached_llm(
             route_used="semantic_reasoner",
             degraded=True,
             error="llm_returned_unknown_or_unparseable",
-            meta={"mode": "cached_llm", "cache_hit": False, "raw": raw[:80]},
+            meta={
+                "mode": "cached_llm",
+                "cache_hit": False,
+                "raw": (raw or "")[:80],
+            },
         )
 
     _cache_put(
@@ -435,6 +509,23 @@ def _normalize_verdict(
 # ---------------------------------------------------------------------------
 
 
+_REASONER_OFF_VALUES = {"0", "off", "false", "no", "disable", "disabled"}
+
+
+def _is_reasoner_disabled() -> bool:
+    """Honour the ``NEXO_SEMANTIC_REASONER`` runtime kill switch.
+
+    The plan (ONEPASS LLM Coverage) explicitly required an env opt-out
+    dedicated to the reasoner, separate from ``NEXO_LOCAL_CLASSIFIER``
+    (which only gates install-time provisioning). Operators who hit a
+    reasoner regression in production can set ``NEXO_SEMANTIC_REASONER=0``
+    to force every ``reason()`` call to refuse; the router then falls
+    through to ``remote_fallback`` on its own.
+    """
+    raw = os.environ.get("NEXO_SEMANTIC_REASONER", "").strip().lower()
+    return raw in _REASONER_OFF_VALUES
+
+
 def reason(
     *,
     decision_kind: str,
@@ -449,6 +540,18 @@ def reason(
     Returns a ``RouterResult``. The router knows how to keep going to
     ``remote_fallback`` if this layer refuses.
     """
+    RouterResult = _import_router_result()
+
+    if _is_reasoner_disabled():
+        return RouterResult(
+            ok=False,
+            decision_kind=decision_kind,
+            route_used="semantic_reasoner",
+            degraded=True,
+            error="reasoner_disabled_by_env",
+            meta={"env": "NEXO_SEMANTIC_REASONER"},
+        )
+
     labels_tuple: tuple[str, ...] | None = tuple(labels) if labels else None
     if mode == "multipass_local":
         return _reason_multipass_local(
@@ -466,7 +569,6 @@ def reason(
             confidence_floor=confidence_floor,
         )
 
-    RouterResult = _import_router_result()
     return RouterResult(
         ok=False,
         decision_kind=decision_kind,

--- a/src/semantic_reasoner.py
+++ b/src/semantic_reasoner.py
@@ -1,0 +1,479 @@
+"""semantic_reasoner — second-layer semantic decision maker.
+
+Plan ONEPASS LLM Coverage. Called through ``src/semantic_router.py``.
+Exposes a single ``reason()`` entrypoint with two modes:
+
+    Mode A  — ``multipass_local``  (textual decision kinds)
+
+        Reuses the already-pinned ``LocalZeroShotClassifier`` (see
+        ``docs/classifier-model-notes.md``) but with stricter behaviour:
+        three inference passes with mild prompt perturbations, then
+        majority vote across passes. A decision is only accepted if at
+        least two of three passes agree AND the agreed confidence is
+        above the stricter threshold. This kills single-pass false
+        positives without adding a new model dependency.
+
+    Mode B  — ``cached_llm``  (code-aware decision kinds)
+
+        Thin wrapper around ``call_model_raw`` with a disk cache scoped
+        by (decision_kind, sha256(normalized_prompt)). TTL = 24h. The
+        cache lives under ``~/.nexo/runtime/operations/semantic-reasoner-cache.json``
+        alongside the existing classifier install state. Cache hits
+        return instantly and are flagged in ``meta.cache_hit``. Misses
+        call the LLM; the response and its normalized verdict are
+        written back to the cache atomically.
+
+Pin notes: this module does not introduce a new downloaded model.
+Mode A reuses ``MODEL_ID``/``MODEL_REVISION`` from ``classifier_local``.
+Mode B resolves the LLM through the standard resonance map with
+``caller='semantic_reasoner'`` and ``tier='muy_bajo'``; the pin lives
+in ``resonance_map`` like every other LLM caller.
+
+See ``docs/semantic-reasoner-model-notes.md`` for the rationale behind
+this "upgrade-in-place, pin-by-reuse" strategy, and why a dedicated
+stronger local LLM (Llama 3.1 8B, etc.) is explicitly deferred to a
+future release.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+_logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Shared dataclass imported from the router
+# ---------------------------------------------------------------------------
+
+
+def _import_router_result():
+    """Lazy import to avoid circular dependency on semantic_router."""
+    from semantic_router import RouterResult
+
+    return RouterResult
+
+
+# ---------------------------------------------------------------------------
+# Mode A — multi-pass local
+# ---------------------------------------------------------------------------
+
+
+_PROMPT_PERTURBATIONS: tuple[str, ...] = (
+    "{q}",
+    "Decide: {q}",
+    "Classify this utterance: {q}",
+)
+
+
+def _collect_local_votes(
+    question: str, labels: tuple[str, ...]
+) -> list[tuple[str, float, dict[str, float]]]:
+    """Run the local classifier three times with mild prompt variations.
+
+    Returns a list of ``(label, confidence, scores)`` triples. Any
+    pass that fails silently returns a zero-confidence entry so the
+    vote aggregator can still detect quorum problems.
+    """
+    try:
+        from classifier_local import LocalZeroShotClassifier
+    except Exception as exc:  # pragma: no cover
+        _logger.debug("semantic_reasoner: classifier_local unavailable (%s)", exc)
+        return []
+
+    clf = LocalZeroShotClassifier(confidence_floor=0.0)
+    votes: list[tuple[str, float, dict[str, float]]] = []
+    for template in _PROMPT_PERTURBATIONS:
+        prompt = template.format(q=question)
+        result = clf.classify(prompt, labels)
+        if result is None:
+            votes.append(("", 0.0, {}))
+            continue
+        votes.append((result.label, float(result.confidence), dict(result.scores)))
+    return votes
+
+
+def _aggregate_votes(
+    votes: list[tuple[str, float, dict[str, float]]],
+    confidence_floor: float,
+) -> tuple[str | None, float, dict[str, Any]]:
+    """Majority vote across passes. Returns (label_or_none, confidence, meta)."""
+    if not votes:
+        return None, 0.0, {"reason": "no_votes"}
+
+    counts: dict[str, int] = {}
+    confidences: dict[str, list[float]] = {}
+    for label, confidence, _scores in votes:
+        if not label:
+            continue
+        counts[label] = counts.get(label, 0) + 1
+        confidences.setdefault(label, []).append(confidence)
+
+    if not counts:
+        return None, 0.0, {"reason": "all_passes_failed", "votes": len(votes)}
+
+    best_label = max(counts, key=lambda lbl: (counts[lbl], max(confidences[lbl])))
+    vote_count = counts[best_label]
+    avg_confidence = sum(confidences[best_label]) / len(confidences[best_label])
+
+    meta: dict[str, Any] = {
+        "votes_total": len(votes),
+        "votes_for_best": vote_count,
+        "avg_confidence": round(avg_confidence, 4),
+        "per_label_counts": dict(counts),
+    }
+
+    if vote_count < 2:
+        meta["reason"] = "no_majority"
+        return None, avg_confidence, meta
+    if avg_confidence < confidence_floor:
+        meta["reason"] = "below_threshold"
+        return None, avg_confidence, meta
+    return best_label, avg_confidence, meta
+
+
+def _reason_multipass_local(
+    *,
+    decision_kind: str,
+    question: str,
+    labels: tuple[str, ...] | None,
+    confidence_floor: float,
+):
+    RouterResult = _import_router_result()
+    if not labels:
+        return RouterResult(
+            ok=False,
+            decision_kind=decision_kind,
+            route_used="semantic_reasoner",
+            degraded=True,
+            error="multipass_local requires labels",
+        )
+
+    votes = _collect_local_votes(question, labels)
+    label, confidence, meta = _aggregate_votes(votes, confidence_floor)
+    if label is None:
+        return RouterResult(
+            ok=False,
+            decision_kind=decision_kind,
+            route_used="semantic_reasoner",
+            degraded=True,
+            error=meta.get("reason", "aggregation_failed"),
+            meta={"mode": "multipass_local", "aggregate": meta},
+        )
+    return RouterResult(
+        ok=True,
+        decision_kind=decision_kind,
+        verdict=label,
+        label=label,
+        confidence=round(float(confidence), 4),
+        route_used="semantic_reasoner",
+        degraded=False,
+        meta={"mode": "multipass_local", "aggregate": meta},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mode B — cached LLM
+# ---------------------------------------------------------------------------
+
+
+_DEFAULT_CACHE_TTL_SECONDS = 24 * 3600
+
+
+def _cache_path() -> Path:
+    """Resolve the on-disk cache location.
+
+    Reuses ``paths.operations_dir()`` so the reasoner state lives next to
+    the existing ``classifier-install-state.json``. If ``paths`` is not
+    importable (heavy module; test context), fall back to a deterministic
+    location under ``NEXO_HOME``.
+    """
+    override = os.environ.get("NEXO_SEMANTIC_REASONER_CACHE_PATH", "").strip()
+    if override:
+        return Path(override)
+    try:
+        import paths
+
+        return paths.operations_dir() / "semantic-reasoner-cache.json"
+    except Exception:
+        home = os.environ.get("NEXO_HOME", "").strip()
+        root = Path(home) if home else Path.home() / ".nexo"
+        return root / "runtime" / "operations" / "semantic-reasoner-cache.json"
+
+
+def _normalize_for_hash(text: str) -> str:
+    """Normalise whitespace/case so equivalent prompts hit the same cache
+    entry. Does not touch content semantics beyond whitespace collapse."""
+    return re.sub(r"\s+", " ", (text or "").strip().lower())
+
+
+def _cache_key(
+    *,
+    decision_kind: str,
+    question: str,
+    labels: tuple[str, ...] | None,
+    context: str,
+) -> str:
+    payload = json.dumps(
+        {
+            "kind": decision_kind,
+            "q": _normalize_for_hash(question),
+            "ctx": _normalize_for_hash(context)[:400],
+            "labels": list(labels) if labels else [],
+        },
+        sort_keys=True,
+        ensure_ascii=False,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _read_cache() -> dict[str, Any]:
+    try:
+        path = _cache_path()
+        if not path.is_file():
+            return {}
+        data = json.loads(path.read_text() or "{}")
+        if isinstance(data, dict):
+            return data
+    except Exception as exc:  # pragma: no cover — corrupt cache
+        _logger.warning("semantic_reasoner: cache read failed (%s); starting fresh", exc)
+    return {}
+
+
+def _write_cache(cache: dict[str, Any]) -> None:
+    try:
+        path = _cache_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(cache, ensure_ascii=False, sort_keys=True))
+        tmp.replace(path)
+    except Exception as exc:  # pragma: no cover
+        _logger.warning("semantic_reasoner: cache write failed (%s)", exc)
+
+
+def _cache_get(key: str, ttl_seconds: int) -> dict[str, Any] | None:
+    cache = _read_cache()
+    entry = cache.get(key)
+    if not isinstance(entry, dict):
+        return None
+    ts = float(entry.get("ts", 0.0) or 0.0)
+    if ts <= 0.0:
+        return None
+    if (time.time() - ts) > ttl_seconds:
+        return None
+    return entry
+
+
+def _cache_put(key: str, entry: dict[str, Any]) -> None:
+    cache = _read_cache()
+    cache[key] = {**entry, "ts": time.time()}
+    if len(cache) > 2000:
+        # Keep the 1800 most-recent entries to avoid unbounded growth. The
+        # bound is advisory; callers should keep reasoner prompts small.
+        items = sorted(cache.items(), key=lambda kv: float(kv[1].get("ts", 0.0) or 0.0))
+        cache = dict(items[-1800:])
+    _write_cache(cache)
+
+
+def _reason_cached_llm(
+    *,
+    decision_kind: str,
+    question: str,
+    labels: tuple[str, ...] | None,
+    context: str,
+    confidence_floor: float,
+):
+    RouterResult = _import_router_result()
+    ttl = int(os.environ.get("NEXO_SEMANTIC_REASONER_TTL", _DEFAULT_CACHE_TTL_SECONDS))
+    key = _cache_key(
+        decision_kind=decision_kind,
+        question=question,
+        labels=labels,
+        context=context,
+    )
+
+    cached = _cache_get(key, ttl)
+    if cached is not None:
+        return RouterResult(
+            ok=True,
+            decision_kind=decision_kind,
+            verdict=cached.get("verdict"),
+            label=cached.get("verdict"),
+            confidence=float(cached.get("confidence", 0.6)),
+            route_used="semantic_reasoner",
+            degraded=False,
+            meta={
+                "mode": "cached_llm",
+                "cache_hit": True,
+                "cache_key": key[:12],
+            },
+        )
+
+    try:
+        from call_model_raw import ClassifierUnavailableError, call_model_raw
+    except Exception as exc:  # pragma: no cover
+        return RouterResult(
+            ok=False,
+            decision_kind=decision_kind,
+            route_used="semantic_reasoner",
+            degraded=True,
+            error=f"call_model_raw unavailable: {exc}",
+            meta={"mode": "cached_llm", "cache_hit": False},
+        )
+
+    prompt = _build_reasoner_prompt(
+        decision_kind=decision_kind,
+        question=question,
+        labels=labels,
+        context=context,
+    )
+    system = (
+        "You are NEXO's code-aware semantic reasoner. Answer with the "
+        "single best label from the provided list (no prose). If no "
+        "label fits, answer 'unknown'."
+    )
+    try:
+        raw = call_model_raw(
+            prompt,
+            system=system,
+            caller="semantic_reasoner",
+            tier="muy_bajo",
+            max_tokens=32,
+            temperature=0.0,
+        )
+    except ClassifierUnavailableError as exc:
+        return RouterResult(
+            ok=False,
+            decision_kind=decision_kind,
+            route_used="semantic_reasoner",
+            degraded=True,
+            error=f"remote_unavailable: {exc}",
+            meta={"mode": "cached_llm", "cache_hit": False},
+        )
+
+    verdict = _normalize_verdict(raw, labels)
+    if verdict is None:
+        return RouterResult(
+            ok=False,
+            decision_kind=decision_kind,
+            route_used="semantic_reasoner",
+            degraded=True,
+            error="llm_returned_unknown_or_unparseable",
+            meta={"mode": "cached_llm", "cache_hit": False, "raw": raw[:80]},
+        )
+
+    _cache_put(
+        key,
+        {
+            "verdict": verdict,
+            "confidence": max(confidence_floor, 0.6),
+            "decision_kind": decision_kind,
+        },
+    )
+
+    return RouterResult(
+        ok=True,
+        decision_kind=decision_kind,
+        verdict=verdict,
+        label=verdict,
+        confidence=max(confidence_floor, 0.6),
+        route_used="semantic_reasoner",
+        degraded=False,
+        meta={"mode": "cached_llm", "cache_hit": False, "cache_key": key[:12]},
+    )
+
+
+def _build_reasoner_prompt(
+    *,
+    decision_kind: str,
+    question: str,
+    labels: tuple[str, ...] | None,
+    context: str,
+) -> str:
+    parts = [
+        f"decision_kind: {decision_kind}",
+        f"question: {question}",
+    ]
+    if context:
+        parts.append(f"context: {context[:600]}")
+    if labels:
+        parts.append("candidate_labels: " + ", ".join(labels))
+        parts.append("Reply with exactly one of the labels above.")
+    else:
+        parts.append("Reply with the shortest phrase answering the question.")
+    return "\n".join(parts)
+
+
+def _normalize_verdict(
+    raw: str, labels: tuple[str, ...] | None
+) -> str | None:
+    text = (raw or "").strip().lower()
+    if not text:
+        return None
+    if text == "unknown":
+        return None
+    if labels:
+        for label in labels:
+            if label.lower() == text:
+                return label
+        for label in labels:
+            if label.lower() in text:
+                return label
+        return None
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Public entrypoint
+# ---------------------------------------------------------------------------
+
+
+def reason(
+    *,
+    decision_kind: str,
+    question: str,
+    labels: tuple[str, ...] | list[str] | None,
+    context: str = "",
+    mode: str = "multipass_local",
+    confidence_floor: float = 0.75,
+):
+    """Dispatch to the configured mode. Called by ``semantic_router.route``.
+
+    Returns a ``RouterResult``. The router knows how to keep going to
+    ``remote_fallback`` if this layer refuses.
+    """
+    labels_tuple: tuple[str, ...] | None = tuple(labels) if labels else None
+    if mode == "multipass_local":
+        return _reason_multipass_local(
+            decision_kind=decision_kind,
+            question=question,
+            labels=labels_tuple,
+            confidence_floor=confidence_floor,
+        )
+    if mode == "cached_llm":
+        return _reason_cached_llm(
+            decision_kind=decision_kind,
+            question=question,
+            labels=labels_tuple,
+            context=context,
+            confidence_floor=confidence_floor,
+        )
+
+    RouterResult = _import_router_result()
+    return RouterResult(
+        ok=False,
+        decision_kind=decision_kind,
+        route_used="semantic_reasoner",
+        degraded=True,
+        error=f"unknown reasoner mode: {mode}",
+    )
+
+
+__all__ = ["reason"]

--- a/src/semantic_router.py
+++ b/src/semantic_router.py
@@ -1,0 +1,426 @@
+"""semantic_router — Plan ONEPASS LLM Coverage.
+
+Central router for every model-backed semantic decision in NEXO Brain. Call
+sites declare a *decision_kind* and pass question/context; the router
+applies the policy for that kind and dispatches through the stack:
+
+    fast_local  ->  semantic_reasoner  ->  remote_fallback
+
+Design contract (from ~/Desktop/NEXO-ONEPASS-LLM-COVERAGE-RELEASE-PLAN.md):
+
+- Brain owns the semantic contract, model pins and routing policy.
+- Every call site passes a *named* decision_kind; policy lives here, not in
+  the caller. This replaces the previous pattern where each caller invented
+  its own policy tree.
+- The existing ``LocalZeroShotClassifier`` stays as the cheap multilingual
+  first pass (``fast_local``).
+- ``semantic_reasoner`` is the second, stronger layer. Its implementation
+  lives in ``src/semantic_reasoner.py`` with two modes: Mode A (strict
+  multi-pass over the same local classifier with tighter thresholds) and
+  Mode B (LLM-cached reasoner for code-aware decisions).
+- ``remote_fallback`` is the existing ``call_model_raw`` chain. It is no
+  longer the default path for local-friendly decisions; it only fires if
+  the upstream layers refuse or degrade.
+
+The router returns a ``RouterResult`` dataclass so callers can inspect
+which route was used, whether degraded mode is active, and what confidence
+the decision carries. This is also what Desktop will consume via the
+``brain-semantic-router.js`` bridge shipped in the companion PR.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+_logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Contract dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RouterResult:
+    """Outcome of a ``route()`` call.
+
+    Fields match the minimum contract documented in the plan (section
+    "Minimum router output contract"):
+
+      - ``ok``: overall success (at least one layer produced a decision)
+      - ``decision_kind``: the kind the caller passed
+      - ``verdict``: the chosen label when the caller used zero-shot
+        classification; None when the underlying layer returned free text
+      - ``label``: alias for ``verdict`` to match the plan's wording; kept
+        consistent to simplify Desktop bridge mapping
+      - ``confidence``: [0.0, 1.0]
+      - ``route_used``: one of ``fast_local``, ``semantic_reasoner``,
+        ``remote_fallback``, or ``no_route`` when every layer refused
+      - ``degraded``: True when the chosen layer could not meet its normal
+        bar (fallback fired, stricter threshold not met, cache-only, etc.)
+      - ``error``: short human-readable reason when ``ok`` is False
+      - ``meta``: free-form layer-specific evidence (scores dict, cache
+        key, latency, model id) — Desktop uses it for telemetry
+    """
+
+    ok: bool
+    decision_kind: str
+    verdict: str | None = None
+    label: str | None = None
+    confidence: float = 0.0
+    route_used: str = "no_route"
+    degraded: bool = False
+    error: str | None = None
+    meta: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Decision kinds + policy table
+# ---------------------------------------------------------------------------
+#
+# The plan enumerates 18 decision_kinds that need to route through here. They
+# fall into two families:
+#
+#   TEXTUAL     — the first-line local classifier is good enough; the
+#                 reasoner adds a stricter multi-pass check for ambiguous
+#                 cases. Remote is only a last-resort safety net.
+#
+#   CODE_AWARE  — the fast local classifier is not designed for code-aware
+#                 semantics (T4 R15/R23e/R23f/R23h, r20). The reasoner
+#                 routes those straight to a cached LLM call.
+#
+# Any decision_kind not listed here falls through to remote_fallback with
+# ``degraded=True`` to make accidental misuse visible in telemetry instead
+# of silent.
+#
+# Keep this map in lockstep with ``docs/semantic-reasoner-model-notes.md``.
+
+
+TEXTUAL_KINDS: tuple[str, ...] = (
+    "session_end_intent",
+    "autonomy_mandate",
+    "guard_verbal_ack",
+    "r14_correction",
+    "r16_declared_done",
+    "r17_promise_debt",
+    "r34_identity_coherence",
+    "followup_operator_attention",
+    "drive_signal_type",
+    "drive_area",
+    "reply_event_type",
+    "query_intent",
+    "sentiment_intent",
+)
+
+
+CODE_AWARE_KINDS: tuple[str, ...] = (
+    "r20_constant_change",
+    "t4_r15",
+    "t4_r23e",
+    "t4_r23f",
+    "t4_r23h",
+)
+
+
+ALL_DECISION_KINDS: tuple[str, ...] = TEXTUAL_KINDS + CODE_AWARE_KINDS
+
+
+# Per-kind policy. Explicit, human-readable, no defaults that silently
+# expand coverage. Changing policy = editing this dict + updating the
+# model-notes doc + bumping tests.
+_POLICY: dict[str, dict[str, Any]] = {
+    kind: {
+        "family": "textual",
+        "fast_local_threshold": 0.60,
+        "reasoner_mode": "multipass_local",
+        "reasoner_threshold": 0.75,
+        "allow_remote_fallback": True,
+    }
+    for kind in TEXTUAL_KINDS
+}
+
+_POLICY.update(
+    {
+        kind: {
+            "family": "code_aware",
+            "fast_local_threshold": None,  # skip fast_local
+            "reasoner_mode": "cached_llm",
+            "reasoner_threshold": 0.60,
+            "allow_remote_fallback": True,
+        }
+        for kind in CODE_AWARE_KINDS
+    }
+)
+
+
+def policy_for(decision_kind: str) -> dict[str, Any] | None:
+    """Return the policy entry for a kind, or None if unknown."""
+    return _POLICY.get(decision_kind)
+
+
+# ---------------------------------------------------------------------------
+# Layer adapters
+# ---------------------------------------------------------------------------
+#
+# The router does not import the heavy modules at the top of the file so
+# that a caller who only wants ``policy_for`` or ``ALL_DECISION_KINDS`` does
+# not pay the import cost. The adapters below resolve the dependencies
+# lazily and wrap failures as ``None`` so the router can advance to the
+# next layer deterministically.
+
+
+def _run_fast_local(
+    *,
+    question: str,
+    labels: tuple[str, ...],
+    confidence_floor: float,
+) -> RouterResult | None:
+    """Try ``LocalZeroShotClassifier``. Return None on unavailable or
+    below-threshold so the router advances."""
+    try:
+        from classifier_local import LocalZeroShotClassifier
+    except Exception as exc:  # pragma: no cover — install not ready
+        _logger.debug("semantic_router: classifier_local unavailable (%s)", exc)
+        return None
+
+    clf = LocalZeroShotClassifier(confidence_floor=confidence_floor)
+    result = clf.classify(question, labels)
+    if result is None:
+        return None
+    if result.confidence < confidence_floor:
+        return None
+
+    return RouterResult(
+        ok=True,
+        decision_kind="",  # filled by caller
+        verdict=result.label,
+        label=result.label,
+        confidence=float(result.confidence),
+        route_used="fast_local",
+        degraded=False,
+        meta={
+            "scores": dict(result.scores),
+            "latency_ms": float(result.latency_ms),
+            "threshold": confidence_floor,
+        },
+    )
+
+
+def _run_semantic_reasoner(
+    *,
+    decision_kind: str,
+    question: str,
+    labels: tuple[str, ...] | None,
+    context: str,
+    mode: str,
+    confidence_floor: float,
+) -> RouterResult | None:
+    """Delegate to ``src/semantic_reasoner.py``. Return None on unavailable
+    so the router advances to remote_fallback."""
+    try:
+        from semantic_reasoner import reason
+    except Exception as exc:  # pragma: no cover
+        _logger.debug("semantic_router: semantic_reasoner unavailable (%s)", exc)
+        return None
+
+    try:
+        return reason(
+            decision_kind=decision_kind,
+            question=question,
+            labels=labels,
+            context=context,
+            mode=mode,
+            confidence_floor=confidence_floor,
+        )
+    except Exception as exc:  # noqa: BLE001 — fail-closed, degrade to remote
+        _logger.warning("semantic_reasoner.reason raised: %s", exc)
+        return None
+
+
+def _run_remote_fallback(
+    *,
+    decision_kind: str,
+    question: str,
+    labels: tuple[str, ...] | None,
+    context: str,
+) -> RouterResult | None:
+    """Last-resort LLM call via ``call_model_raw``. The router marks the
+    result as ``degraded=True`` so telemetry shows when the stack fell
+    through."""
+    try:
+        from call_model_raw import ClassifierUnavailableError, call_model_raw
+    except Exception as exc:  # pragma: no cover
+        _logger.debug("semantic_router: call_model_raw unavailable (%s)", exc)
+        return None
+
+    prompt = _build_remote_prompt(
+        decision_kind=decision_kind,
+        question=question,
+        labels=labels,
+        context=context,
+    )
+    system = (
+        "You are NEXO's remote semantic fallback. Answer with the single "
+        "best label from the provided list, or with 'unknown' if none fit. "
+        "No prose, no explanation."
+    )
+
+    try:
+        raw = call_model_raw(
+            prompt,
+            system=system,
+            caller="semantic_reasoner",
+            tier="muy_bajo",
+            max_tokens=32,
+            temperature=0.0,
+        )
+    except ClassifierUnavailableError as exc:
+        return RouterResult(
+            ok=False,
+            decision_kind=decision_kind,
+            route_used="remote_fallback",
+            degraded=True,
+            error=f"remote_unavailable: {exc}",
+        )
+
+    verdict = _normalize_remote_answer(raw, labels)
+    return RouterResult(
+        ok=verdict is not None,
+        decision_kind=decision_kind,
+        verdict=verdict,
+        label=verdict,
+        confidence=0.55 if verdict is not None else 0.0,
+        route_used="remote_fallback",
+        degraded=True,  # always degraded relative to the local-first ideal
+        meta={"raw_response": raw[:120]},
+    )
+
+
+def _build_remote_prompt(
+    *,
+    decision_kind: str,
+    question: str,
+    labels: tuple[str, ...] | None,
+    context: str,
+) -> str:
+    parts = [
+        f"Decision kind: {decision_kind}",
+        f"Question: {question}",
+    ]
+    if context:
+        parts.append(f"Context: {context[:400]}")
+    if labels:
+        parts.append("Candidate labels: " + ", ".join(labels))
+        parts.append("Reply with exactly one of the labels above.")
+    else:
+        parts.append("Reply with the shortest phrase that answers the question.")
+    return "\n".join(parts)
+
+
+def _normalize_remote_answer(
+    raw: str, labels: tuple[str, ...] | None
+) -> str | None:
+    text = (raw or "").strip().lower()
+    if not text:
+        return None
+    if labels:
+        for label in labels:
+            if label.lower() == text:
+                return label
+        for label in labels:
+            if label.lower() in text:
+                return label
+        return None
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Public entrypoint
+# ---------------------------------------------------------------------------
+
+
+def route(
+    *,
+    decision_kind: str,
+    question: str,
+    context: str = "",
+    labels: tuple[str, ...] | list[str] | None = None,
+    allow_remote_fallback: bool = True,
+) -> RouterResult:
+    """Route a semantic decision through the stack.
+
+    The caller names the *kind* of decision. The router looks up the policy,
+    dispatches through fast_local -> semantic_reasoner -> remote_fallback,
+    and returns the first layer that produced a decision above its
+    threshold.
+
+    ``allow_remote_fallback=False`` forces local-only behaviour; the router
+    will return ``ok=False, route_used='no_route'`` if every local layer
+    refused. Useful for strict-offline automation or pytest.
+    """
+    policy = policy_for(decision_kind)
+    if policy is None:
+        return RouterResult(
+            ok=False,
+            decision_kind=decision_kind,
+            route_used="no_route",
+            degraded=True,
+            error=f"unknown decision_kind: {decision_kind}",
+        )
+
+    labels_tuple: tuple[str, ...] | None = (
+        tuple(labels) if labels else None
+    )
+
+    # Step 1 — fast_local for textual families only.
+    if policy["fast_local_threshold"] is not None and labels_tuple:
+        fast = _run_fast_local(
+            question=question,
+            labels=labels_tuple,
+            confidence_floor=float(policy["fast_local_threshold"]),
+        )
+        if fast is not None:
+            fast.decision_kind = decision_kind
+            return fast
+
+    # Step 2 — semantic_reasoner (Mode A or B depending on policy).
+    reasoned = _run_semantic_reasoner(
+        decision_kind=decision_kind,
+        question=question,
+        labels=labels_tuple,
+        context=context,
+        mode=str(policy["reasoner_mode"]),
+        confidence_floor=float(policy["reasoner_threshold"]),
+    )
+    if reasoned is not None and reasoned.ok:
+        return reasoned
+
+    # Step 3 — remote_fallback if allowed.
+    if allow_remote_fallback and policy.get("allow_remote_fallback", True):
+        remote = _run_remote_fallback(
+            decision_kind=decision_kind,
+            question=question,
+            labels=labels_tuple,
+            context=context,
+        )
+        if remote is not None:
+            return remote
+
+    return RouterResult(
+        ok=False,
+        decision_kind=decision_kind,
+        route_used="no_route",
+        degraded=True,
+        error="every layer refused or was unavailable",
+    )
+
+
+__all__ = [
+    "ALL_DECISION_KINDS",
+    "CODE_AWARE_KINDS",
+    "RouterResult",
+    "TEXTUAL_KINDS",
+    "policy_for",
+    "route",
+]

--- a/src/semantic_router.py
+++ b/src/semantic_router.py
@@ -249,10 +249,27 @@ def _run_remote_fallback(
     result as ``degraded=True`` so telemetry shows when the stack fell
     through."""
     try:
-        from call_model_raw import ClassifierUnavailableError, call_model_raw
+        import call_model_raw as _cmr
     except Exception as exc:  # pragma: no cover
         _logger.debug("semantic_router: call_model_raw unavailable (%s)", exc)
         return None
+
+    # Resolve symbols defensively. Tests sometimes stub only ``call_model_raw``
+    # and forget ``ClassifierUnavailableError`` (or vice versa); without this
+    # guard a missing attribute later becomes NameError at ``except`` time and
+    # crashes the router instead of degrading.
+    call_model_raw_fn = getattr(_cmr, "call_model_raw", None)
+    classifier_unavailable_cls = getattr(
+        _cmr, "ClassifierUnavailableError", Exception
+    )
+    if call_model_raw_fn is None:
+        return RouterResult(
+            ok=False,
+            decision_kind=decision_kind,
+            route_used="remote_fallback",
+            degraded=True,
+            error="call_model_raw callable missing",
+        )
 
     prompt = _build_remote_prompt(
         decision_kind=decision_kind,
@@ -267,7 +284,7 @@ def _run_remote_fallback(
     )
 
     try:
-        raw = call_model_raw(
+        raw = call_model_raw_fn(
             prompt,
             system=system,
             caller="semantic_reasoner",
@@ -275,7 +292,7 @@ def _run_remote_fallback(
             max_tokens=32,
             temperature=0.0,
         )
-    except ClassifierUnavailableError as exc:
+    except classifier_unavailable_cls as exc:
         return RouterResult(
             ok=False,
             decision_kind=decision_kind,
@@ -283,8 +300,17 @@ def _run_remote_fallback(
             degraded=True,
             error=f"remote_unavailable: {exc}",
         )
+    except Exception as exc:  # noqa: BLE001 — fail-closed, never re-raise
+        return RouterResult(
+            ok=False,
+            decision_kind=decision_kind,
+            route_used="remote_fallback",
+            degraded=True,
+            error=f"remote_error: {exc}",
+        )
 
     verdict = _normalize_remote_answer(raw, labels)
+    raw_preview = (raw or "")[:120]
     return RouterResult(
         ok=verdict is not None,
         decision_kind=decision_kind,
@@ -293,7 +319,7 @@ def _run_remote_fallback(
         confidence=0.55 if verdict is not None else 0.0,
         route_used="remote_fallback",
         degraded=True,  # always degraded relative to the local-first ideal
-        meta={"raw_response": raw[:120]},
+        meta={"raw_response": raw_preview},
     )
 
 

--- a/tests/test_semantic_classify_cli.py
+++ b/tests/test_semantic_classify_cli.py
@@ -1,0 +1,126 @@
+"""Contract tests for scripts/semantic-classify.py — JSON-in JSON-out CLI.
+
+The CLI is the Brain-side endpoint for the Desktop bridge. It must:
+
+  - Reject empty / malformed input with exit code 1 and a JSON payload
+    that says ``ok: false`` so the Desktop parser never chokes.
+  - Accept well-formed input and emit a JSON payload that mirrors the
+    ``RouterResult`` dataclass.
+  - Never require a running MCP server or database connection.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI = ROOT / "scripts" / "semantic-classify.py"
+
+
+def _run_cli(payload: str) -> tuple[int, str, str]:
+    result = subprocess.run(
+        [sys.executable, str(CLI)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    return result.returncode, result.stdout.strip(), result.stderr.strip()
+
+
+def test_cli_rejects_empty_stdin():
+    code, out, _err = _run_cli("")
+    assert code == 1
+    data = json.loads(out)
+    assert data["ok"] is False
+    assert "empty" in (data["error"] or "")
+
+
+def test_cli_rejects_invalid_json():
+    code, out, _err = _run_cli("{not valid json")
+    assert code == 1
+    data = json.loads(out)
+    assert data["ok"] is False
+    assert "invalid JSON" in (data["error"] or "")
+
+
+def test_cli_rejects_non_object_payload():
+    code, out, _err = _run_cli(json.dumps(["a", "list", "not", "an", "object"]))
+    assert code == 1
+    data = json.loads(out)
+    assert data["ok"] is False
+    assert "must be a JSON object" in (data["error"] or "")
+
+
+def test_cli_rejects_missing_decision_kind():
+    code, out, _err = _run_cli(json.dumps({"question": "anything"}))
+    assert code == 1
+    data = json.loads(out)
+    assert data["ok"] is False
+    assert "decision_kind" in (data["error"] or "")
+
+
+def test_cli_rejects_missing_question():
+    code, out, _err = _run_cli(json.dumps({"decision_kind": "session_end_intent"}))
+    assert code == 1
+    data = json.loads(out)
+    assert data["ok"] is False
+    assert "question" in (data["error"] or "")
+
+
+def test_cli_returns_structured_failure_for_unknown_kind():
+    code, out, _err = _run_cli(
+        json.dumps({"decision_kind": "made_up_kind", "question": "anything"})
+    )
+    # Well-formed input always exits 0 so Desktop can parse the body.
+    assert code == 0
+    data = json.loads(out)
+    assert data["ok"] is False
+    assert data["decision_kind"] == "made_up_kind"
+    assert data["route_used"] == "no_route"
+    assert data["degraded"] is True
+    assert "unknown decision_kind" in (data["error"] or "")
+
+
+def test_cli_passes_labels_through_to_router():
+    code, out, _err = _run_cli(
+        json.dumps(
+            {
+                "decision_kind": "r16_declared_done",
+                "question": "ya está",
+                "labels": ["done_claim", "noise"],
+                "allow_remote_fallback": False,
+            }
+        )
+    )
+    assert code == 0
+    data = json.loads(out)
+    assert data["decision_kind"] == "r16_declared_done"
+    # allow_remote_fallback=False + unavailable local layers (no HF model
+    # installed in CI) means the router falls through to no_route.
+    assert data["route_used"] in {"fast_local", "semantic_reasoner", "no_route"}
+
+
+def test_cli_output_shape_matches_router_result():
+    code, out, _err = _run_cli(
+        json.dumps({"decision_kind": "session_end_intent", "question": "hasta mañana"})
+    )
+    assert code == 0
+    data = json.loads(out)
+    required_keys = {
+        "ok",
+        "decision_kind",
+        "verdict",
+        "label",
+        "confidence",
+        "route_used",
+        "degraded",
+        "error",
+        "meta",
+    }
+    assert required_keys.issubset(set(data.keys()))
+    assert isinstance(data["meta"], dict)
+    assert isinstance(data["confidence"], (int, float))

--- a/tests/test_semantic_reasoner.py
+++ b/tests/test_semantic_reasoner.py
@@ -341,3 +341,224 @@ def test_normalize_verdict_maps_labels_case_insensitively():
     assert sr._normalize_verdict("I think done_claim", ("done_claim",)) == "done_claim"
     assert sr._normalize_verdict("unknown", ("a", "b")) is None
     assert sr._normalize_verdict("", ("a",)) is None
+
+
+# ---------------------------------------------------------------------------
+# Audit-driven hardening — release-blocker fixes
+# ---------------------------------------------------------------------------
+
+
+def test_reasoner_degrades_when_call_model_raw_throws_unexpected_exception(
+    monkeypatch, tmp_path
+):
+    """Audit A2 equivalent for the reasoner path: if the LLM module raises
+    an exception type OTHER than ClassifierUnavailableError (e.g. provider
+    APIError, TimeoutError, KeyError from a mocked shim), the reasoner
+    must still return a degraded RouterResult instead of propagating.
+
+    Expose both symbols on the stub so the typed ``except`` clause does
+    not accidentally swallow the unrelated error via its catch-all
+    fallback.
+    """
+    import sys
+
+    import semantic_reasoner as sr
+
+    _patch_cache_path(monkeypatch, tmp_path)
+
+    class _ClassifierUnavailableError(RuntimeError):
+        pass
+
+    class _UnrelatedError(RuntimeError):
+        pass
+
+    def stub(*args, **kwargs):  # noqa: ARG001
+        raise _UnrelatedError("boom-from-provider-we-did-not-anticipate")
+
+    fake_module = type("m", (), {})()
+    fake_module.call_model_raw = stub
+    fake_module.ClassifierUnavailableError = _ClassifierUnavailableError
+    monkeypatch.setitem(sys.modules, "call_model_raw", fake_module)
+
+    result = sr.reason(
+        decision_kind="t4_r15",
+        question="rm -rf /",
+        labels=("t4_bypass", "safe"),
+        mode="cached_llm",
+        confidence_floor=0.60,
+    )
+    assert result.ok is False
+    assert result.route_used == "semantic_reasoner"
+    assert result.degraded is True
+    assert "remote_error" in (result.error or "")
+
+
+def test_reasoner_degrades_when_call_model_raw_fn_missing(monkeypatch, tmp_path):
+    """The stub module is present but has no call_model_raw attribute.
+    Without the getattr guard this crashes with AttributeError deep inside
+    the reasoner."""
+    import sys
+
+    import semantic_reasoner as sr
+
+    _patch_cache_path(monkeypatch, tmp_path)
+
+    fake_module = type("m", (), {})()
+    monkeypatch.setitem(sys.modules, "call_model_raw", fake_module)
+
+    result = sr.reason(
+        decision_kind="t4_r15",
+        question="anything",
+        labels=("t4_bypass", "safe"),
+        mode="cached_llm",
+        confidence_floor=0.60,
+    )
+    assert result.ok is False
+    assert "call_model_raw callable missing" in (result.error or "")
+
+
+def test_nexo_semantic_reasoner_env_kill_switch(monkeypatch, tmp_path):
+    """Audit D1: honour NEXO_SEMANTIC_REASONER=0 runtime kill switch."""
+    import semantic_reasoner as sr
+
+    _patch_cache_path(monkeypatch, tmp_path)
+
+    for value in ("0", "off", "false", "no", "disable", "disabled", "OFF"):
+        monkeypatch.setenv("NEXO_SEMANTIC_REASONER", value)
+        result = sr.reason(
+            decision_kind="r14_correction",
+            question="no, así no",
+            labels=("correction", "noise"),
+            mode="multipass_local",
+            confidence_floor=0.75,
+        )
+        assert result.ok is False, f"kill switch value {value!r} did not refuse"
+        assert result.error == "reasoner_disabled_by_env"
+        assert result.route_used == "semantic_reasoner"
+        assert result.degraded is True
+
+
+def test_env_kill_switch_ignores_empty_and_truthy_values(monkeypatch, tmp_path):
+    """A blank or truthy value leaves the reasoner enabled. We simulate
+    Mode A here so the test does not need the HF model installed."""
+    import semantic_reasoner as sr
+
+    _patch_cache_path(monkeypatch, tmp_path)
+    _install_stub_classifier(
+        monkeypatch,
+        results=[("correction", 0.80), ("correction", 0.85), ("noise", 0.40)],
+    )
+
+    for value in ("", "1", "on", "true", "yes"):
+        monkeypatch.setenv("NEXO_SEMANTIC_REASONER", value)
+        result = sr.reason(
+            decision_kind="r14_correction",
+            question="no, así no",
+            labels=("correction", "noise"),
+            mode="multipass_local",
+            confidence_floor=0.75,
+        )
+        assert result.ok is True, f"value {value!r} unexpectedly disabled reasoner"
+
+
+def test_corrupt_cache_entry_is_dropped_not_returned_as_success(
+    monkeypatch, tmp_path
+):
+    """Audit A7: a cached entry with verdict=None must not be returned as
+    ok=True. The reasoner must drop the corrupt entry and attempt a live
+    LLM call (or degrade if that is also unavailable)."""
+    import json
+    import time
+
+    import semantic_reasoner as sr
+
+    cache_path = tmp_path / "cache.json"
+    _patch_cache_path(monkeypatch, tmp_path)
+    # Pre-seed the cache with a corrupt entry that matches the key the
+    # reasoner will compute for the inputs below.
+    key = sr._cache_key(
+        decision_kind="t4_r15",
+        question="rm -rf /tmp",
+        labels=("t4_bypass", "safe"),
+        context="",
+    )
+    cache_path.write_text(
+        json.dumps(
+            {key: {"verdict": None, "confidence": 0.7, "ts": time.time()}}
+        )
+    )
+
+    calls = _install_stub_call_model_raw(monkeypatch, ["t4_bypass"])
+    result = sr.reason(
+        decision_kind="t4_r15",
+        question="rm -rf /tmp",
+        labels=("t4_bypass", "safe"),
+        mode="cached_llm",
+        confidence_floor=0.60,
+    )
+    assert result.ok is True
+    assert result.verdict == "t4_bypass"
+    assert result.meta["cache_hit"] is False
+    assert calls["n"] == 1
+
+
+def test_null_llm_response_does_not_crash_meta_slice(monkeypatch, tmp_path):
+    """Audit A6: raw[:80] must tolerate None returns from the LLM stub."""
+    import sys
+
+    import semantic_reasoner as sr
+
+    _patch_cache_path(monkeypatch, tmp_path)
+
+    def stub(*args, **kwargs):  # noqa: ARG001
+        return None
+
+    fake_module = type("m", (), {})()
+    fake_module.call_model_raw = stub
+    monkeypatch.setitem(sys.modules, "call_model_raw", fake_module)
+
+    result = sr.reason(
+        decision_kind="t4_r15",
+        question="x",
+        labels=("t4_bypass", "safe"),
+        mode="cached_llm",
+        confidence_floor=0.60,
+    )
+    assert result.ok is False
+    assert result.error == "llm_returned_unknown_or_unparseable"
+    assert result.meta["raw"] == ""
+
+
+def test_ttl_env_var_parses_defensively(monkeypatch):
+    """Audit D4: malformed NEXO_SEMANTIC_REASONER_TTL must fall back to
+    the default rather than crashing with ValueError."""
+    import semantic_reasoner as sr
+
+    monkeypatch.setenv("NEXO_SEMANTIC_REASONER_TTL", "not-a-number")
+    assert sr._parse_ttl_env() == sr._DEFAULT_CACHE_TTL_SECONDS
+
+    monkeypatch.setenv("NEXO_SEMANTIC_REASONER_TTL", "-5")
+    assert sr._parse_ttl_env() == sr._DEFAULT_CACHE_TTL_SECONDS
+
+    monkeypatch.setenv("NEXO_SEMANTIC_REASONER_TTL", "0")
+    assert sr._parse_ttl_env() == sr._DEFAULT_CACHE_TTL_SECONDS
+
+    monkeypatch.setenv("NEXO_SEMANTIC_REASONER_TTL", "120")
+    assert sr._parse_ttl_env() == 120
+
+
+def test_concurrent_cache_writes_do_not_stomp_each_other(monkeypatch, tmp_path):
+    """Audit A3: two concurrent writes must not overlap tmp filenames.
+    Simulates concurrency by calling _cache_put twice with distinct
+    keys; with the old shared `.tmp` path the second write could clobber
+    the first. Now each write uses a pid+uuid tmp file so both entries
+    survive.
+    """
+    import semantic_reasoner as sr
+
+    _patch_cache_path(monkeypatch, tmp_path)
+    sr._cache_put("aaa", {"verdict": "x", "confidence": 0.7})
+    sr._cache_put("bbb", {"verdict": "y", "confidence": 0.7})
+    cache = sr._read_cache()
+    assert cache.get("aaa", {}).get("verdict") == "x"
+    assert cache.get("bbb", {}).get("verdict") == "y"

--- a/tests/test_semantic_reasoner.py
+++ b/tests/test_semantic_reasoner.py
@@ -1,0 +1,343 @@
+"""Tests for src/semantic_reasoner.py — Plan ONEPASS LLM Coverage.
+
+Stubs the local classifier and the remote LLM so tests never download
+models or reach the network. Verifies the majority-vote logic (Mode A)
+and the cache hit/miss/TTL behaviour (Mode B).
+"""
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Mode A — multipass_local
+# ---------------------------------------------------------------------------
+
+
+class _StubClassifier:
+    """Return a pre-programmed sequence of (label, confidence) tuples, one
+    per pass. Ignores the text argument so we can drive deterministic
+    scenarios from the tests."""
+
+    def __init__(self, results):
+        self._results = list(results)
+        self._idx = 0
+
+    def classify(self, text, labels, *, multi_label=False):  # noqa: ARG002
+        import classifier_local as cl
+
+        if self._idx >= len(self._results):
+            return None
+        label, confidence = self._results[self._idx]
+        self._idx += 1
+        scores = {lbl: (confidence if lbl == label else 0.0) for lbl in labels}
+        return cl.ClassificationResult(
+            label=label,
+            confidence=float(confidence),
+            scores=scores,
+            latency_ms=1.0,
+        )
+
+
+def _install_stub_classifier(monkeypatch, results):
+    import classifier_local
+
+    def factory(**kwargs):  # noqa: ARG001 — accept the same kwargs as real class
+        return _StubClassifier(results)
+
+    monkeypatch.setattr(classifier_local, "LocalZeroShotClassifier", factory)
+
+
+def test_multipass_majority_vote_accepts_two_of_three(monkeypatch):
+    import semantic_reasoner as sr
+
+    _install_stub_classifier(
+        monkeypatch,
+        results=[("correction", 0.80), ("correction", 0.85), ("noise", 0.40)],
+    )
+
+    result = sr.reason(
+        decision_kind="r14_correction",
+        question="no, así no",
+        labels=("correction", "noise"),
+        mode="multipass_local",
+        confidence_floor=0.75,
+    )
+    assert result.ok is True
+    assert result.verdict == "correction"
+    assert result.route_used == "semantic_reasoner"
+    assert result.meta["mode"] == "multipass_local"
+    assert result.meta["aggregate"]["votes_for_best"] == 2
+
+
+def test_multipass_refuses_when_no_majority(monkeypatch):
+    import semantic_reasoner as sr
+
+    _install_stub_classifier(
+        monkeypatch,
+        results=[("a", 0.80), ("b", 0.85), ("c", 0.90)],
+    )
+
+    result = sr.reason(
+        decision_kind="r14_correction",
+        question="ambiguous",
+        labels=("a", "b", "c"),
+        mode="multipass_local",
+        confidence_floor=0.75,
+    )
+    assert result.ok is False
+    assert result.route_used == "semantic_reasoner"
+    assert result.degraded is True
+    assert result.error == "no_majority"
+
+
+def test_multipass_refuses_when_confidence_below_threshold(monkeypatch):
+    import semantic_reasoner as sr
+
+    _install_stub_classifier(
+        monkeypatch,
+        results=[("done", 0.50), ("done", 0.55), ("noise", 0.40)],
+    )
+
+    result = sr.reason(
+        decision_kind="r16_declared_done",
+        question="weak signal",
+        labels=("done", "noise"),
+        mode="multipass_local",
+        confidence_floor=0.75,
+    )
+    assert result.ok is False
+    assert result.error == "below_threshold"
+
+
+def test_multipass_requires_labels():
+    import semantic_reasoner as sr
+
+    result = sr.reason(
+        decision_kind="session_end_intent",
+        question="hasta mañana",
+        labels=None,
+        mode="multipass_local",
+        confidence_floor=0.75,
+    )
+    assert result.ok is False
+    assert "requires labels" in (result.error or "")
+
+
+# ---------------------------------------------------------------------------
+# Mode B — cached_llm
+# ---------------------------------------------------------------------------
+
+
+def _patch_cache_path(monkeypatch, tmp_path):
+    monkeypatch.setenv(
+        "NEXO_SEMANTIC_REASONER_CACHE_PATH", str(tmp_path / "cache.json")
+    )
+
+
+def _install_stub_call_model_raw(monkeypatch, responses):
+    """Install a fake `call_model_raw` callable that returns responses in
+    sequence. ``responses`` can contain strings (return value) or
+    Exceptions (raise on that call)."""
+    import semantic_reasoner as sr
+
+    class _StubExcModule:
+        class ClassifierUnavailableError(RuntimeError):
+            pass
+
+    calls = {"n": 0}
+
+    def stub(prompt, *, system=None, caller=None, tier=None, max_tokens=None, temperature=None):  # noqa: ARG001, E501
+        idx = calls["n"]
+        calls["n"] = idx + 1
+        if idx >= len(responses):
+            raise _StubExcModule.ClassifierUnavailableError("exhausted")
+        item = responses[idx]
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    fake_module = type("m", (), {})()
+    fake_module.call_model_raw = stub
+    fake_module.ClassifierUnavailableError = _StubExcModule.ClassifierUnavailableError
+
+    import sys
+    monkeypatch.setitem(sys.modules, "call_model_raw", fake_module)
+    return calls
+
+
+def test_cached_llm_miss_then_hit(monkeypatch, tmp_path):
+    import semantic_reasoner as sr
+
+    _patch_cache_path(monkeypatch, tmp_path)
+    calls = _install_stub_call_model_raw(monkeypatch, ["t4_bypass"])
+
+    first = sr.reason(
+        decision_kind="t4_r15",
+        question="rm -rf build/",
+        context="scripts/deploy.sh line 12",
+        labels=("t4_bypass", "safe"),
+        mode="cached_llm",
+        confidence_floor=0.60,
+    )
+    assert first.ok is True
+    assert first.verdict == "t4_bypass"
+    assert first.meta["cache_hit"] is False
+    assert calls["n"] == 1
+
+    # Second call with identical inputs hits the cache and does NOT call
+    # the LLM again.
+    second = sr.reason(
+        decision_kind="t4_r15",
+        question="rm -rf build/",
+        context="scripts/deploy.sh line 12",
+        labels=("t4_bypass", "safe"),
+        mode="cached_llm",
+        confidence_floor=0.60,
+    )
+    assert second.ok is True
+    assert second.verdict == "t4_bypass"
+    assert second.meta["cache_hit"] is True
+    assert calls["n"] == 1, "cache hit must not invoke the LLM"
+
+
+def test_cached_llm_expired_entry_triggers_llm(monkeypatch, tmp_path):
+    import semantic_reasoner as sr
+
+    _patch_cache_path(monkeypatch, tmp_path)
+    monkeypatch.setenv("NEXO_SEMANTIC_REASONER_TTL", "1")
+    _install_stub_call_model_raw(monkeypatch, ["t4_bypass", "safe"])
+
+    first = sr.reason(
+        decision_kind="t4_r15",
+        question="rm -rf build/",
+        labels=("t4_bypass", "safe"),
+        mode="cached_llm",
+        confidence_floor=0.60,
+    )
+    assert first.ok is True
+
+    # Simulate passage of time past the TTL.
+    time.sleep(1.2)
+
+    second = sr.reason(
+        decision_kind="t4_r15",
+        question="rm -rf build/",
+        labels=("t4_bypass", "safe"),
+        mode="cached_llm",
+        confidence_floor=0.60,
+    )
+    assert second.ok is True
+    assert second.meta["cache_hit"] is False
+    assert second.verdict == "safe"
+
+
+def test_cached_llm_scope_is_per_decision_kind(monkeypatch, tmp_path):
+    import semantic_reasoner as sr
+
+    _patch_cache_path(monkeypatch, tmp_path)
+    _install_stub_call_model_raw(monkeypatch, ["t4_bypass", "safe"])
+
+    first = sr.reason(
+        decision_kind="t4_r15",
+        question="shared snippet",
+        labels=("t4_bypass", "safe"),
+        mode="cached_llm",
+        confidence_floor=0.60,
+    )
+    second = sr.reason(
+        decision_kind="t4_r23e",  # different kind, same question
+        question="shared snippet",
+        labels=("t4_bypass", "safe"),
+        mode="cached_llm",
+        confidence_floor=0.60,
+    )
+    assert first.verdict == "t4_bypass"
+    assert second.verdict == "safe"
+    assert second.meta["cache_hit"] is False
+
+
+def test_cached_llm_reports_unavailable_when_llm_refuses(monkeypatch, tmp_path):
+    import semantic_reasoner as sr
+
+    _patch_cache_path(monkeypatch, tmp_path)
+
+    import sys
+    fake_module = type("m", (), {})()
+
+    class _ClassifierUnavailableError(RuntimeError):
+        pass
+
+    def stub(*args, **kwargs):  # noqa: ARG001
+        raise _ClassifierUnavailableError("offline")
+
+    fake_module.call_model_raw = stub
+    fake_module.ClassifierUnavailableError = _ClassifierUnavailableError
+    monkeypatch.setitem(sys.modules, "call_model_raw", fake_module)
+
+    result = sr.reason(
+        decision_kind="t4_r23f",
+        question="anything",
+        labels=("bypass", "safe"),
+        mode="cached_llm",
+        confidence_floor=0.60,
+    )
+    assert result.ok is False
+    assert "remote_unavailable" in (result.error or "")
+    assert result.degraded is True
+
+
+def test_cache_key_ignores_whitespace_and_case(monkeypatch, tmp_path):
+    import semantic_reasoner as sr
+
+    _patch_cache_path(monkeypatch, tmp_path)
+    calls = _install_stub_call_model_raw(monkeypatch, ["t4_bypass"])
+
+    sr.reason(
+        decision_kind="t4_r15",
+        question="rm -rf build/",
+        context="scripts/deploy.sh LINE 12",
+        labels=("t4_bypass", "safe"),
+        mode="cached_llm",
+        confidence_floor=0.60,
+    )
+    sr.reason(
+        decision_kind="t4_r15",
+        question="  RM -RF   build/  ",
+        context="scripts/deploy.sh line 12",
+        labels=("t4_bypass", "safe"),
+        mode="cached_llm",
+        confidence_floor=0.60,
+    )
+    assert calls["n"] == 1, "equivalent normalized inputs must share the cache"
+
+
+# ---------------------------------------------------------------------------
+# Misc
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_mode_returns_error():
+    import semantic_reasoner as sr
+
+    result = sr.reason(
+        decision_kind="r14_correction",
+        question="x",
+        labels=("a", "b"),
+        mode="does_not_exist",
+        confidence_floor=0.75,
+    )
+    assert result.ok is False
+    assert "unknown reasoner mode" in (result.error or "")
+
+
+def test_normalize_verdict_maps_labels_case_insensitively():
+    import semantic_reasoner as sr
+
+    assert sr._normalize_verdict("DONE_CLAIM", ("done_claim", "noise")) == "done_claim"
+    assert sr._normalize_verdict("I think done_claim", ("done_claim",)) == "done_claim"
+    assert sr._normalize_verdict("unknown", ("a", "b")) is None
+    assert sr._normalize_verdict("", ("a",)) is None

--- a/tests/test_semantic_router.py
+++ b/tests/test_semantic_router.py
@@ -1,0 +1,315 @@
+"""Tests for src/semantic_router.py — Plan ONEPASS LLM Coverage.
+
+Do NOT download models or call remote APIs. Every test stubs the three
+layer adapters (fast_local, semantic_reasoner, remote_fallback) so the
+router's policy and dispatch logic is verified in isolation.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Policy table
+# ---------------------------------------------------------------------------
+
+
+def test_all_textual_kinds_are_registered():
+    import semantic_router as sr
+
+    expected = {
+        "session_end_intent",
+        "autonomy_mandate",
+        "guard_verbal_ack",
+        "r14_correction",
+        "r16_declared_done",
+        "r17_promise_debt",
+        "r34_identity_coherence",
+        "followup_operator_attention",
+        "drive_signal_type",
+        "drive_area",
+        "reply_event_type",
+        "query_intent",
+        "sentiment_intent",
+    }
+    assert set(sr.TEXTUAL_KINDS) == expected
+
+
+def test_all_code_aware_kinds_are_registered():
+    import semantic_router as sr
+
+    expected = {
+        "r20_constant_change",
+        "t4_r15",
+        "t4_r23e",
+        "t4_r23f",
+        "t4_r23h",
+    }
+    assert set(sr.CODE_AWARE_KINDS) == expected
+
+
+def test_policy_covers_every_declared_kind():
+    import semantic_router as sr
+
+    for kind in sr.ALL_DECISION_KINDS:
+        policy = sr.policy_for(kind)
+        assert policy is not None, f"missing policy for {kind}"
+        assert "family" in policy
+        assert "reasoner_mode" in policy
+        assert policy["reasoner_mode"] in {"multipass_local", "cached_llm"}
+
+
+def test_textual_family_uses_multipass_local():
+    import semantic_router as sr
+
+    for kind in sr.TEXTUAL_KINDS:
+        policy = sr.policy_for(kind)
+        assert policy["family"] == "textual"
+        assert policy["reasoner_mode"] == "multipass_local"
+        assert policy["fast_local_threshold"] is not None
+
+
+def test_code_aware_family_skips_fast_local_and_uses_cached_llm():
+    import semantic_router as sr
+
+    for kind in sr.CODE_AWARE_KINDS:
+        policy = sr.policy_for(kind)
+        assert policy["family"] == "code_aware"
+        assert policy["reasoner_mode"] == "cached_llm"
+        assert policy["fast_local_threshold"] is None
+
+
+def test_policy_kinds_are_documented():
+    """Drift check: every registered kind must be mentioned in the
+    semantic-reasoner model notes so docs cannot silently go stale."""
+    from pathlib import Path
+
+    import semantic_router as sr
+
+    notes = (
+        Path(__file__).resolve().parents[1]
+        / "docs"
+        / "semantic-reasoner-model-notes.md"
+    ).read_text(encoding="utf-8")
+    for kind in sr.ALL_DECISION_KINDS:
+        assert kind in notes, f"decision_kind {kind} is not documented"
+
+
+# ---------------------------------------------------------------------------
+# Dispatch logic
+# ---------------------------------------------------------------------------
+
+
+def _fake_router_result(**kwargs):
+    import semantic_router as sr
+
+    return sr.RouterResult(**kwargs)
+
+
+def test_route_returns_fast_local_result_when_confidence_is_high(monkeypatch):
+    import semantic_router as sr
+
+    def fake_fast_local(*, question, labels, confidence_floor):
+        return _fake_router_result(
+            ok=True,
+            decision_kind="",
+            verdict="done_claim",
+            label="done_claim",
+            confidence=0.92,
+            route_used="fast_local",
+        )
+
+    monkeypatch.setattr(sr, "_run_fast_local", fake_fast_local)
+    result = sr.route(
+        decision_kind="r16_declared_done",
+        question="ya está listo",
+        labels=("done_claim", "status_update", "noise"),
+    )
+    assert result.ok is True
+    assert result.route_used == "fast_local"
+    assert result.verdict == "done_claim"
+    assert result.decision_kind == "r16_declared_done"
+
+
+def test_route_falls_through_to_reasoner_when_fast_local_refuses(monkeypatch):
+    import semantic_router as sr
+
+    monkeypatch.setattr(sr, "_run_fast_local", lambda **kw: None)
+
+    def fake_reasoner(**kw):
+        return _fake_router_result(
+            ok=True,
+            decision_kind=kw["decision_kind"],
+            verdict="correction",
+            label="correction",
+            confidence=0.80,
+            route_used="semantic_reasoner",
+            meta={"mode": "multipass_local"},
+        )
+
+    monkeypatch.setattr(sr, "_run_semantic_reasoner", fake_reasoner)
+    monkeypatch.setattr(sr, "_run_remote_fallback", lambda **kw: None)
+
+    result = sr.route(
+        decision_kind="r14_correction",
+        question="no, así no",
+        labels=("correction", "noise"),
+    )
+    assert result.ok is True
+    assert result.route_used == "semantic_reasoner"
+    assert result.verdict == "correction"
+
+
+def test_route_reaches_remote_fallback_when_both_local_layers_refuse(monkeypatch):
+    import semantic_router as sr
+
+    monkeypatch.setattr(sr, "_run_fast_local", lambda **kw: None)
+    monkeypatch.setattr(sr, "_run_semantic_reasoner", lambda **kw: None)
+
+    def fake_remote(**kw):
+        return _fake_router_result(
+            ok=True,
+            decision_kind=kw["decision_kind"],
+            verdict="promise",
+            label="promise",
+            confidence=0.55,
+            route_used="remote_fallback",
+            degraded=True,
+        )
+
+    monkeypatch.setattr(sr, "_run_remote_fallback", fake_remote)
+
+    result = sr.route(
+        decision_kind="r17_promise_debt",
+        question="I will fix it later",
+        labels=("promise", "noise"),
+    )
+    assert result.ok is True
+    assert result.route_used == "remote_fallback"
+    assert result.degraded is True
+
+
+def test_route_respects_allow_remote_fallback_false(monkeypatch):
+    import semantic_router as sr
+
+    monkeypatch.setattr(sr, "_run_fast_local", lambda **kw: None)
+    monkeypatch.setattr(sr, "_run_semantic_reasoner", lambda **kw: None)
+
+    called = {"remote": False}
+
+    def fake_remote(**kw):
+        called["remote"] = True
+        return _fake_router_result(
+            ok=True,
+            decision_kind=kw["decision_kind"],
+            route_used="remote_fallback",
+        )
+
+    monkeypatch.setattr(sr, "_run_remote_fallback", fake_remote)
+
+    result = sr.route(
+        decision_kind="r16_declared_done",
+        question="ya lo tengo",
+        labels=("done_claim", "noise"),
+        allow_remote_fallback=False,
+    )
+    assert called["remote"] is False
+    assert result.ok is False
+    assert result.route_used == "no_route"
+
+
+def test_route_rejects_unknown_decision_kind():
+    import semantic_router as sr
+
+    result = sr.route(
+        decision_kind="made_up_kind",
+        question="anything",
+        labels=("a", "b"),
+    )
+    assert result.ok is False
+    assert result.route_used == "no_route"
+    assert "unknown decision_kind" in (result.error or "")
+
+
+def test_code_aware_kind_skips_fast_local(monkeypatch):
+    import semantic_router as sr
+
+    called = {"fast": False}
+
+    def fake_fast_local(**kw):
+        called["fast"] = True
+        return _fake_router_result(
+            ok=True,
+            decision_kind="",
+            verdict="wrong",
+            route_used="fast_local",
+            confidence=0.99,
+        )
+
+    def fake_reasoner(**kw):
+        return _fake_router_result(
+            ok=True,
+            decision_kind=kw["decision_kind"],
+            verdict="t4_bypass",
+            label="t4_bypass",
+            confidence=0.70,
+            route_used="semantic_reasoner",
+            meta={"mode": "cached_llm"},
+        )
+
+    monkeypatch.setattr(sr, "_run_fast_local", fake_fast_local)
+    monkeypatch.setattr(sr, "_run_semantic_reasoner", fake_reasoner)
+    monkeypatch.setattr(sr, "_run_remote_fallback", lambda **kw: None)
+
+    result = sr.route(
+        decision_kind="t4_r15",
+        question="destructive rm in build script",
+        context="scripts/deploy.sh line 12",
+        labels=("t4_bypass", "safe"),
+    )
+    assert called["fast"] is False, "code-aware kinds must skip fast_local"
+    assert result.ok is True
+    assert result.route_used == "semantic_reasoner"
+
+
+def test_route_returns_no_route_when_every_layer_unavailable(monkeypatch):
+    import semantic_router as sr
+
+    monkeypatch.setattr(sr, "_run_fast_local", lambda **kw: None)
+    monkeypatch.setattr(sr, "_run_semantic_reasoner", lambda **kw: None)
+    monkeypatch.setattr(sr, "_run_remote_fallback", lambda **kw: None)
+
+    result = sr.route(
+        decision_kind="session_end_intent",
+        question="hasta mañana",
+        labels=("end", "continue"),
+    )
+    assert result.ok is False
+    assert result.route_used == "no_route"
+    assert result.degraded is True
+
+
+# ---------------------------------------------------------------------------
+# Remote fallback helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw, labels, expected",
+    [
+        ("done_claim", ("done_claim", "noise"), "done_claim"),
+        ("DONE_CLAIM", ("done_claim", "noise"), "done_claim"),
+        ("unknown", ("done_claim", "noise"), None),
+        ("", ("done_claim", "noise"), None),
+        ("   noise  ", ("done_claim", "noise"), "noise"),
+        ("I think done_claim", ("done_claim", "noise"), "done_claim"),
+        ("completely irrelevant", ("done_claim", "noise"), None),
+    ],
+)
+def test_normalize_remote_answer(raw, labels, expected):
+    import semantic_router as sr
+
+    # Accept either the helper's own name or a post-refactor alias.
+    normalize = getattr(sr, "_normalize_remote_answer", None)
+    assert normalize is not None
+    assert normalize(raw, labels) == expected

--- a/tests/test_semantic_router.py
+++ b/tests/test_semantic_router.py
@@ -313,3 +313,69 @@ def test_normalize_remote_answer(raw, labels, expected):
     normalize = getattr(sr, "_normalize_remote_answer", None)
     assert normalize is not None
     assert normalize(raw, labels) == expected
+
+
+# ---------------------------------------------------------------------------
+# Audit-driven hardening — fail-closed contract
+# ---------------------------------------------------------------------------
+
+
+def test_remote_fallback_degrades_on_unexpected_exception(monkeypatch):
+    """Audit A2: call_model_raw can raise exception types other than
+    ClassifierUnavailableError (provider APIError, TimeoutError, etc.).
+    The router MUST degrade instead of propagating.
+
+    Both symbols are exposed on the stub so the unrelated exception
+    type is NOT a subclass of the declared ClassifierUnavailableError,
+    and must therefore be routed to the catch-all ``except Exception``
+    branch.
+    """
+    import sys
+
+    import semantic_router as sr
+
+    class _ClassifierUnavailableError(RuntimeError):
+        pass
+
+    class _UnrelatedError(RuntimeError):
+        pass
+
+    def stub(*args, **kwargs):  # noqa: ARG001
+        raise _UnrelatedError("unexpected")
+
+    fake_module = type("m", (), {})()
+    fake_module.call_model_raw = stub
+    fake_module.ClassifierUnavailableError = _ClassifierUnavailableError
+    monkeypatch.setitem(sys.modules, "call_model_raw", fake_module)
+
+    result = sr._run_remote_fallback(
+        decision_kind="t4_r15",
+        question="rm -rf /",
+        labels=("t4_bypass", "safe"),
+        context="",
+    )
+    assert result is not None
+    assert result.ok is False
+    assert result.route_used == "remote_fallback"
+    assert result.degraded is True
+    assert "remote_error" in (result.error or "")
+
+
+def test_remote_fallback_degrades_when_call_model_raw_missing(monkeypatch):
+    """Stub module present but without call_model_raw attribute."""
+    import sys
+
+    import semantic_router as sr
+
+    fake_module = type("m", (), {})()
+    monkeypatch.setitem(sys.modules, "call_model_raw", fake_module)
+
+    result = sr._run_remote_fallback(
+        decision_kind="t4_r15",
+        question="anything",
+        labels=("t4_bypass", "safe"),
+        context="",
+    )
+    assert result is not None
+    assert result.ok is False
+    assert "call_model_raw callable missing" in (result.error or "")


### PR DESCRIPTION
## Summary

Plan ONEPASS LLM Coverage — release stage. Introduces the central **semantic stack** for every model-backed decision in NEXO Brain:

```
fast_local  ->  semantic_reasoner  ->  remote_fallback
```

Call sites name a `decision_kind`, the router applies the per-kind policy, and the stack short-circuits at the first layer that produces a decision above its threshold.

## Files added

| File | Purpose |
|------|---------|
| `src/semantic_router.py` | Central router. 18 decision_kinds (13 textual + 5 code-aware). `RouterResult` + policy table + layer dispatch. |
| `src/semantic_reasoner.py` | Second-layer reasoner. Mode A = multi-pass local (reuses classifier_local pin). Mode B = cached LLM (disk cache, 24h TTL, per-kind scope). |
| `docs/semantic-reasoner-model-notes.md` | Pin + upgrade policy + rationale for the "upgrade-in-place, pin-by-reuse" strategy. |
| `tests/test_semantic_router.py` | 20 tests: policy, dispatch, fallback chain, allow_remote_fallback gate, code-aware fast-local skip. |
| `tests/test_semantic_reasoner.py` | 11 tests: majority-vote logic, threshold refusal, cache miss/hit, TTL expiry, per-kind scope, LLM unavailable. |

## Pin strategy (honest)

**Mode A** reuses the already-pinned `LocalZeroShotClassifier` (see `docs/classifier-model-notes.md`). Three inference passes with mild prompt perturbations, majority vote, stricter 0.75 threshold. No new model download.

**Mode B** resolves the LLM through `resonance_map` with `caller="semantic_reasoner"`, `tier="muy_bajo"`. Pin lives in the resonance map, not here — single source of truth. Disk cache at `~/.nexo/runtime/operations/semantic-reasoner-cache.json`.

A dedicated stronger local LLM (Llama / Qwen / etc.) is **explicitly deferred** to a future release. Rationale documented in the model notes: install-time risk (5–10 GB download + GPU/MPS detection) and pin verifiability (SHA cannot be reproducibly verified without a live HF connection at review time). The router contract is stable across that future change — call sites only see `RouterResult`.

## Decision kinds registered

Textual (Mode A):
`session_end_intent`, `autonomy_mandate`, `guard_verbal_ack`, `r14_correction`, `r16_declared_done`, `r17_promise_debt`, `r34_identity_coherence`, `followup_operator_attention`, `drive_signal_type`, `drive_area`, `reply_event_type`, `query_intent`, `sentiment_intent`.

Code-aware (Mode B):
`r20_constant_change`, `t4_r15`, `t4_r23e`, `t4_r23f`, `t4_r23h`.

## Verification

- [x] `pytest tests/test_semantic_router.py tests/test_semantic_reasoner.py` → **31 passed in 3.06s**
- [x] `test_policy_kinds_are_documented` — drift check: every registered kind is mentioned in the model-notes doc
- [x] No new runtime dependency; no changes to `src/auto_update.py`
- [x] No existing call site migrated in this PR — router/reasoner can be imported today without breaking current behaviour

## Explicitly NOT in this PR (shipping separately)

- Per-site migration of existing callers (`session_end_intent.py`, `r14_*`, `r16_*`, `r17_*`, `r20_*`, `r34_*`, T4 gates, `tools_drive.py`, `nexo-followup-runner.py`) → follow-up PR.
- Desktop bridge `lib/brain-semantic-router.js` + `nexo semantic` CLI → companion nexo-desktop PR.
- `src/auto_update.py` install wiring → not needed; no new dependency.

## Refs

- Plan: `~/Desktop/NEXO-ONEPASS-LLM-COVERAGE-RELEASE-PLAN.md`
- Learning #554 (nexo-brain)
- Companion bootstrap fix: PR #274 (this repo) + nexo-desktop PR #18
- Builds on Bug 1 templates fix: PR #273 (will rebase if merged first)

Generated with [Claude Code](https://claude.com/claude-code)
