### PR TITLE
docs(site): add v7.9.5 public surfaces

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -134,7 +134,7 @@
                     <span class="page-chip">Shared brain product notes</span>
                 </div>
                 <div class="hero-actions" style="justify-content:flex-start;">
-                    <a href="/blog/nexo-7-9-4/" class="btn btn-primary">Read latest release</a>
+                    <a href="/blog/nexo-7-9-5/" class="btn btn-primary">Read latest release</a>
                     <a href="/changelog/" class="btn btn-secondary">Latest release notes</a>
                     <a href="/evolution/" class="btn btn-secondary">See Evolution</a>
                 </div>
@@ -145,22 +145,22 @@
                 <div class="blog-featured-meta">
                     <span class="compare-chip">April 23, 2026</span>
                     <span class="compare-chip">Patch</span>
-                    <span class="compare-chip">diary evidence gate</span>
+                    <span class="compare-chip">diary alias confirmation</span>
                 </div>
-                <h2>NEXO 7.9.4: diary evidence gate, onboarding fixes, and model warmup</h2>
-                <p>Patch over v7.9.3. Brain canonical lifecycle now requires real session_diary evidence before stop/archive/delete/quit, fixes npm onboarding so subcommands never launch the wizard with valid calibration, and adds warmup-models for local model predownload during install/update.</p>
+                <h2>NEXO 7.9.5: Desktop diary alias confirmation</h2>
+                <p>Patch over v7.9.4. Brain now resolves Desktop/Claude session UUIDs through NEXO SID aliases before checking session_diary, so canonical archive/delete/close/quit can confirm the diary that was actually written before Desktop stops the session.</p>
                 <div class="hero-actions" style="justify-content:flex-start;margin-bottom:18px;">
-                    <a href="/blog/nexo-7-9-4/" class="btn btn-primary">Open article</a>
-                    <a href="/changelog/#v794" class="btn btn-secondary">Open changelog</a>
+                    <a href="/blog/nexo-7-9-5/" class="btn btn-primary">Open article</a>
+                    <a href="/changelog/#v795" class="btn btn-secondary">Open changelog</a>
                 </div>
                 <div class="blog-mini-stack">
                     <div class="blog-mini-card">
                         <strong>Companion view</strong>
-                        <span><a href="/changelog/#v794">See the full v7.9.4 changelog</a></span>
+                        <span><a href="/changelog/#v795">See the full v7.9.5 changelog</a></span>
                     </div>
                     <div class="blog-mini-card">
                         <strong>Previous release</strong>
-                        <span><a href="/blog/nexo-7-9-3/">NEXO 7.9.3: canonical lifecycle plan shape v2 for exact-once Desktop diary</a>.</span>
+                        <span><a href="/blog/nexo-7-9-4/">NEXO 7.9.4: diary evidence gate, onboarding fixes, and model warmup</a>.</span>
                     </div>
                 </div>
             </div>
@@ -191,6 +191,15 @@
 <section class="section-flush-top">
     <div class="container">
             <div class="blog-grid">
+
+            <div class="blog-card">
+                <div class="blog-card-date">April 23, 2026</div>
+                <h2><a href="/blog/nexo-7-9-5/">NEXO 7.9.5: Desktop diary alias confirmation</a></h2>
+                <p>Patch over v7.9.4. Brain canonical diary confirmation now follows Desktop/Claude session aliases to the active NEXO SID, preventing false timeouts when the diary exists under the real writer session.</p>
+                <div class="hero-actions" style="justify-content:flex-start;">
+                    <a href="/blog/nexo-7-9-5/" class="btn btn-secondary">Read more</a>
+                </div>
+            </div>
 
             <div class="blog-card">
                 <div class="blog-card-date">April 23, 2026</div>

--- a/blog/nexo-7-9-5/index.html
+++ b/blog/nexo-7-9-5/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>NEXO 7.9.5: Desktop diary alias confirmation</title>
+<meta name="description" content="NEXO Brain v7.9.5 patch release. Confirms Desktop canonical diaries written under the active NEXO SID by resolving Desktop session aliases before stop/archive/delete/quit completion.">
+<meta name="robots" content="index, follow">
+<link rel="canonical" href="https://nexo-brain.com/blog/nexo-7-9-5/">
+<link rel="stylesheet" href="/assets/style.css">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"NEXO 7.9.5: Desktop diary alias confirmation","datePublished":"2026-04-23","author":{"@type":"Person","name":"Francisco Cerda Puigserver"},"publisher":{"@type":"Organization","name":"WAzion"}}</script>
+</head><body><main><article style="max-width:760px;margin:80px auto;padding:0 24px;line-height:1.75;">
+<h1>NEXO 7.9.5 — Desktop diary alias confirmation</h1>
+<p><em>Published 2026-04-23. Patch release over v7.9.4.</em></p>
+
+<p>v7.9.5 fixes the remaining real-world Desktop lifecycle failure: the canonical diary was being written, but Brain looked for it under the Desktop conversation UUID while <code>nexo_session_diary_write</code> stored it under the active <code>nexo-...</code> session SID.</p>
+
+<h2>Diary confirmation now follows session aliases</h2>
+<p>Brain now resolves Desktop/Claude session UUIDs through <code>session_claude_aliases</code> and <code>sessions</code> before checking <code>session_diary</code>. Archive, delete, close, window-close, and app-exit can therefore confirm the diary that the canonical prompt actually wrote.</p>
+
+<h2>Stale diaries cannot satisfy new lifecycle events</h2>
+<p>The diary high-water checkpoint includes alias-linked NEXO SIDs. A new archive/delete/app-exit attempt must see a diary row after its own lifecycle checkpoint, so older manual or previous canonical diaries cannot falsely complete the event.</p>
+
+<h2>Coordinated Desktop release</h2>
+<p>This Brain patch is coordinated with NEXO Desktop v0.28.6, which waits for diary confirmation before <code>stop_session</code>, keeps normal app-exit conversations active, respects pending archive/delete actions during quit, and rejects stale replay rows that no longer match a live session.</p>
+
+<h2>Verification</h2>
+<p>Targeted Brain lifecycle suite: <code>pytest tests/test_lifecycle_events.py</code> with <code>28 passed</code>. Local smoke evidence confirmed a Desktop archive event resolving diary <code>#1931</code> through the NEXO SID alias before completion.</p>
+
+<p><a href="/changelog/#v795">Full changelog entry &rarr;</a></p>
+</article></main></body></html>

--- a/changelog/index.html
+++ b/changelog/index.html
@@ -87,22 +87,22 @@
                 <h1 class="section-title" style="font-size:clamp(32px,5vw,56px);">Changelog</h1>
                 <p class="section-subtitle">Every feature, fix, and improvement &mdash; from the beginning, with the same visual clarity as the rest of the site.</p>
                 <div class="page-chip-row">
-                    <span class="page-chip">v7.9.4 live</span>
+                    <span class="page-chip">v7.9.5 live</span>
                     <span class="page-chip">Guardian active</span>
                     <span class="page-chip">F0.6 hardening</span>
                     <span class="page-chip">Adaptive empirical</span>
                 </div>
                 <div class="hero-actions" style="justify-content:flex-start;">
-                    <a href="#v794" class="btn btn-primary">Start with v7.9.4</a>
-                    <a href="#v793" class="btn btn-secondary">See v7.9.3</a>
+                    <a href="#v795" class="btn btn-primary">Start with v7.9.5</a>
+                    <a href="#v794" class="btn btn-secondary">See v7.9.4</a>
                     <a href="/evolution/" class="btn btn-secondary">See Evolution</a>
                 </div>
             </div>
             <div class="page-visual">
                 <div class="page-stack">
                     <div class="page-stack-card">
-                        <strong>v7.9.4</strong>
-                        <span>Patch — diary evidence gate for Desktop close/archive/delete/quit, npm onboarding guard fixes, atomic calibration writes, and install/update model warmup. Full Brain pytest, release-readiness, npm pack dry-run, and Desktop v0.28.3 checks passed.</span>
+                        <strong>v7.9.5</strong>
+                        <span>Patch — Desktop canonical diary confirmation now resolves session aliases before checking session_diary, so archive/delete/close/quit can confirm diaries written under the active NEXO SID. Targeted lifecycle tests and coordinated Desktop v0.28.6 checks passed.</span>
                     </div>
                     <div class="page-stack-card">
                         <strong>v7.9.2</strong>
@@ -236,6 +236,16 @@
 <section class="section-compact" style="background:rgba(124,58,237,0.08);">
     <div class="container desktop-disclaimer" style="max-width:860px;font-size:13px;line-height:1.55;">
         <p><strong>Sobre NEXO Desktop.</strong> NEXO Desktop es un cliente acompa&ntilde;ante closed-source distribuido aparte en <a href="https://nexo-desktop.com/">nexo-desktop.com</a>. Cuando una entrada de changelog menciona "NEXO Desktop" se refiere a una versi&oacute;n coordinada de ese cliente que consume el contrato CLI/MCP del Brain. El c&oacute;digo de Desktop no vive en este repo; el Brain (AGPL-3.0) es 100% usable por s&iacute; solo desde terminal, Codex, Claude Code, o cualquier cliente MCP.</p>
+    </div>
+</section>
+
+<section id="v795" class="section-compact" style="background:linear-gradient(135deg,#0f172a 0%,#7c3aed 100%);">
+    <div class="container" style="max-width:860px;">
+        <div class="section-label">New in v7.9.5 <span style="opacity:.5;font-weight:400;">&mdash; April 23, 2026 &mdash; <strong>PATCH</strong></span></div>
+        <h2 style="color:white;margin-bottom:16px;">Desktop diary alias confirmation</h2>
+        <p style="color:rgba(255,255,255,0.85);line-height:1.7;">
+            Patch over v7.9.4. Brain now resolves Desktop/Claude session UUIDs through <code>session_claude_aliases</code> and <code>sessions</code> before checking <code>session_diary</code>. This fixes the real archive/app-exit failure where the canonical prompt wrote the required diary under the active <code>nexo-...</code> SID while diary confirmation kept polling the Desktop UUID and timed out. The diary high-water checkpoint also includes alias-linked NEXO SIDs, so old manual or previous canonical diary rows cannot satisfy a new lifecycle event. Validation: <code>pytest tests/test_lifecycle_events.py</code> (28 passing) plus coordinated Desktop v0.28.6 archive/delete/app-exit checks.
+        </p>
     </div>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -46,12 +46,12 @@
         "@context": "https://schema.org",
         "@type": "SoftwareApplication",
         "name": "NEXO Brain",
-        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 7.9.4 requires real canonical diary evidence before Desktop stop/archive/delete/quit, fixes npm onboarding, and adds model warmup.",
+        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 7.9.5 confirms Desktop canonical diaries written under active NEXO SID aliases before stop/archive/delete/quit.",
         "applicationCategory": "DeveloperApplication",
         "operatingSystem": "macOS, Linux, Windows",
         "url": "https://nexo-brain.com",
         "downloadUrl": "https://www.npmjs.com/package/nexo-brain",
-        "softwareVersion": "7.9.4",
+        "softwareVersion": "7.9.5",
         "license": "https://www.gnu.org/licenses/agpl-3.0",
         "author": {
             "@type": "Organization",
@@ -697,7 +697,7 @@
     <div class="container">
         <div class="hero-badge fade-up">
             <span class="dot"></span>
-            <span id="version-badge">v7.9.4</span> Patch release — canonical lifecycle now waits for real <code>session_diary</code> evidence before <code>stop_session</code>, fixes npm onboarding, and adds model warmup for install/update. <a href="/changelog/#v794">Read the v7.9.4 notes</a>.
+            <span id="version-badge">v7.9.5</span> Patch release — Desktop canonical diary confirmation now resolves session aliases before <code>stop_session</code>, so archive/delete/quit can complete only after the diary row written by the active NEXO SID is confirmed. <a href="/changelog/#v795">Read the v7.9.5 notes</a>.
         </div>
         <div class="fade-up" style="display:flex;gap:8px;justify-content:center;margin-bottom:12px;">
             <img src="https://img.shields.io/npm/v/nexo-brain?color=7C3AED&label=npm" alt="npm version">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -61,6 +61,12 @@
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://nexo-brain.com/blog/nexo-7-9-5/</loc>
+    <lastmod>2026-04-23</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
     <loc>https://nexo-brain.com/blog/nexo-7-9-4/</loc>
     <lastmod>2026-04-23</lastmod>
     <changefreq>weekly</changefreq>


### PR DESCRIPTION
Adds the source-repo public surfaces required for the published v7.9.5 release: homepage badge, blog index/post, changelog anchor, and sitemap entry.\n\nLocal validation:\n- python3 scripts/verify_release_readiness.py --ci: OK, 182 passed\n- scripts/sync_release_artifacts.py --check: OK\n- nexo-gh-pages already pushed with matching v7.9.5 surfaces