### PR TITLE
Bump home page to v7.9.34

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
         "operatingSystem": "macOS, Linux, Windows",
         "url": "https://nexo-brain.com",
         "downloadUrl": "https://www.npmjs.com/package/nexo-brain",
-        "softwareVersion": "7.9.33",
+        "softwareVersion": "7.9.34",
         "license": "https://www.gnu.org/licenses/agpl-3.0",
         "author": {
             "@type": "Organization",
@@ -697,7 +697,7 @@
     <div class="container">
         <div class="hero-badge fade-up">
             <span class="dot"></span>
-            <span id="version-badge">v7.9.33</span> Patch release — hotfix for Bandit B324 finding in 7.9.32 (SHA-1 needs <code>usedforsecurity=False</code>); first npm release that carries the 7.9.32 email-recovery checkpoints. <a href="/changelog/#v7933">Read the v7.9.33 notes</a>.
+            <span id="version-badge">v7.9.34</span> Patch release — fixes silent email drops on Q-encoded RFC822 headers (Header objects now coerced via <code>_decode_header</code>) and hardens the PreToolUse Guardian hook with stderr + exit 2 enforcement so terminal Claude cannot ignore a hard block. <a href="/changelog/#v7934">Read the v7.9.34 notes</a>.
         </div>
         <div class="fade-up" style="display:flex;gap:8px;justify-content:center;margin-bottom:12px;">
             <img src="https://img.shields.io/npm/v/nexo-brain?color=7C3AED&label=npm" alt="npm version">


### PR DESCRIPTION
Update version-badge text and JSON-LD softwareVersion on the landing index.html so verify_release_readiness.py --ci passes. The 7.9.34 PR (#303) bumped CHANGELOG, llms.txt, README, blog, changelog, and sitemap but missed the home page surface, which is what verify_release_readiness scans for the version-badge / softwareVersion drift signals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)