### PR TITLE
fix(tests): repair two pre-existing failures on main

### DIFF
--- a/tests/parity/fixtures.json
+++ b/tests/parity/fixtures.json
@@ -16,13 +16,14 @@
     },
     {
       "id": "R13-pre-edit-no-guard",
+      "_comment": "Tests R13 in isolation. new_string is intentionally a non-constant function definition so R20_constant_change does NOT classify it as a shared-constant edit. The original 'SECRET = abc' content was triggering R20 in addition to R13, masking R13's behavior in parity tests.",
       "seq": [
         {
           "op": "tool",
           "name": "Edit",
           "input": {
             "file_path": "/repo/x.py",
-            "new_string": "SECRET = 'abc'"
+            "new_string": "def hello(): return 1"
           }
         }
       ],

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1981,6 +1981,14 @@ class TestRuntimeChecks:
         monkeypatch.setattr(runtime, "_recent_permission_denial", lambda cron_id: False)
         monkeypatch.setattr(runtime.os, "getuid", lambda: 501)
         monkeypatch.setattr(runtime, "PROTECTED_MACOS_ROOTS", (Path("/Users/tester/Documents"),))
+        # The fix path delegates cron syncing and launchagent reload to two
+        # helpers whose real implementations require a `crons/sync.py` script
+        # and a working `launchctl bootstrap`. Neither is meaningful for this
+        # test — we are exercising `_repair_special_launchagent_plists` (the
+        # env-normalizing helper). Stub the siblings so they don't drag a real
+        # filesystem or launchd dependency into the assertion.
+        monkeypatch.setattr(runtime, "_sync_launchagents_from_manifest", lambda: (True, []))
+        monkeypatch.setattr(runtime, "_repair_launchagents", lambda items: (True, []))
 
         calls = {"print": 0}
 


### PR DESCRIPTION
## Summary

Repairs the two test failures that have been red on `main` for several releases. Both reproduce on a clean checkout of `main` (`5c11ac0`, Release 7.10.1) before any of the v7.11.0 / v7.11.1 work landed. Test-only changes; runtime code under `src/` is untouched.

### 1. `tests/parity/test_python_driver.py::test_parity_python[R13-pre-edit-no-guard]`

The fixture content was `"SECRET = 'abc'"` — a shared-constant assignment. `R20_constant_change` (mode `soft` in the default Guardian config, runs through the local zero-shot classifier in `src/r20_constant_change.py`) correctly classifies it and enqueues an injection. The fixture's `expect_rule_ids` declared only `R13_pre_edit_guard`, so the parity assertion failed with an extra observed item.

The test's intent is to verify R13 fires when an `Edit` happens without a prior `nexo_guard_check`. R13 depends only on tool name + file path, not on `new_string` content. Changing the fixture content to `"def hello(): return 1"` — a non-constant function definition — keeps R13 firing while removing the incidental R20 trigger. Verified locally: classifier returns `False` for the new content, `True` for the old. Added a `_comment` field documenting the constraint so a future editor doesn't switch it back.

### 2. `tests/test_doctor.py::TestRuntimeChecks::test_launchagent_integrity_fix_normalizes_special_launchagent_env`

The test exercises `check_launchagent_integrity(fix=True)`, whose fix path calls three helpers in series:

```
sync_ok, _ = _sync_launchagents_from_manifest()
special_ok, _ = _repair_special_launchagent_plists(...)
repaired, _ = _repair_launchagents(...)
```

Only when all three return `True` does the function re-run the check and mark `fixed=True`. The first helper looks for `crons/sync.py` first under `NEXO_HOME` (the test's tmp_path, no sync.py) and then under `NEXO_CODE`, which on a developer machine resolves into the live install (`~/.nexo/core/current/crons/sync.py`). When that fallback isn't accessible from the test process, `sync_ok` stays `False`, the post-check branch never runs, and `check.fixed` stays `False` — even though `_repair_special_launchagent_plists` (the helper this test is actually about) ran successfully and rewrote the plist's `NEXO_CODE` exactly as intended.

The fix is to stub the two siblings so the assertion isolates to the env-normalization helper under test. The plist-rewrite assertion that follows still exercises the real code path.

## Test plan

- [x] `pytest tests/parity/ tests/test_doctor.py` → 111 passed locally.
- [x] `pytest tests/` full suite → **2305 passed, 0 failed** (was 2304 passed, 1 failed before this PR).
- [x] Both failures reproduced on clean `main` via `git stash` of unrelated changes — confirmed pre-existing, not introduced by recent work.
- [ ] CI must stay green on Linux runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)