### PR TITLE
Windows WSL hardening and manifest fallback

### DIFF
--- a/bin/nexo-brain.js
+++ b/bin/nexo-brain.js
@@ -19,6 +19,16 @@ const crypto = require("crypto");
 const fs = require("fs");
 const path = require("path");
 const readline = require("readline");
+const { runViaWsl } = require("./windows-wsl-bridge");
+
+if (process.platform === "win32") {
+  const bridged = runViaWsl({
+    scriptPath: __filename,
+    args: process.argv.slice(2),
+    label: "NEXO Brain",
+  });
+  process.exit(bridged?.status ?? 1);
+}
 
 let NEXO_HOME = process.env.NEXO_HOME || path.join(require("os").homedir(), ".nexo");
 const DEFAULT_ASSISTANT_NAME = "Nova";
@@ -2425,9 +2435,9 @@ async function runSetup() {
   // Check prerequisites
   const platform = process.platform;
   if (platform === "win32") {
-    log("Windows detected. NEXO Brain requires WSL (Windows Subsystem for Linux).");
+    log("Windows detected, but the automatic WSL bridge was not available.");
     log("Install WSL: https://learn.microsoft.com/en-us/windows/wsl/install");
-    log("Then run this command inside WSL (Ubuntu terminal), not PowerShell/CMD.");
+    log("Then run this command again, or launch it directly inside WSL (Ubuntu terminal).");
     process.exit(1);
   }
   if (platform !== "darwin" && platform !== "linux") {

--- a/bin/nexo.js
+++ b/bin/nexo.js
@@ -11,6 +11,16 @@ const { spawnSync } = require("child_process");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
+const { runViaWsl } = require("./windows-wsl-bridge");
+
+if (process.platform === "win32") {
+  const bridged = runViaWsl({
+    scriptPath: __filename,
+    args: process.argv.slice(2),
+    label: "NEXO CLI",
+  });
+  process.exit(bridged?.status ?? 1);
+}
 
 function resolveNexoHome(rawValue) {
   const homeDir = os.homedir();

--- a/bin/windows-wsl-bridge.js
+++ b/bin/windows-wsl-bridge.js
@@ -1,0 +1,162 @@
+const { spawnSync } = require("child_process");
+
+function isWindowsHost(platform = process.platform) {
+  return platform === "win32";
+}
+
+function isWindowsStylePath(value) {
+  const text = String(value || "").trim();
+  if (!text) return false;
+  return /^[A-Za-z]:[\\/]/.test(text) || text.startsWith("\\\\");
+}
+
+function parseWslUncPath(rawValue) {
+  const value = String(rawValue || "").trim();
+  const lowered = value.toLowerCase();
+  if (!lowered.startsWith("\\\\wsl$\\") && !lowered.startsWith("\\\\wsl.localhost\\")) {
+    return null;
+  }
+  const parts = value.split("\\").filter(Boolean);
+  if (parts.length < 3) return null;
+  return {
+    distro: parts[1],
+    linuxPath: `/${parts.slice(2).join("/")}`,
+  };
+}
+
+function toWslPath(rawValue) {
+  const value = String(rawValue || "").trim();
+  if (!value) return "";
+  if (value.startsWith("/")) return value;
+  const unc = parseWslUncPath(value);
+  if (unc) return unc.linuxPath;
+
+  const normalized = value.replace(/\\/g, "/");
+  const driveMatch = normalized.match(/^([A-Za-z]):(\/.*)?$/);
+  if (driveMatch) {
+    return `/mnt/${driveMatch[1].toLowerCase()}${driveMatch[2] || ""}`;
+  }
+  if (normalized.startsWith("//")) {
+    return "";
+  }
+  return normalized;
+}
+
+function resolveExplicitLinuxPath(rawValue) {
+  const value = String(rawValue || "").trim();
+  if (!value) return "";
+  if (value.startsWith("/")) return value;
+  if (isWindowsStylePath(value)) return toWslPath(value);
+  return value;
+}
+
+function resolveLinuxEnv(env = process.env) {
+  const linuxEnv = {
+    NEXO_WINDOWS_BRIDGE: "1",
+    NEXO_WINDOWS_HOST: "1",
+  };
+
+  const explicitHome = resolveExplicitLinuxPath(env.NEXO_WSL_HOME);
+  if (explicitHome) {
+    linuxEnv.NEXO_HOME = explicitHome;
+  } else if (env.NEXO_HOME && !isWindowsStylePath(env.NEXO_HOME)) {
+    linuxEnv.NEXO_HOME = String(env.NEXO_HOME).trim();
+  }
+
+  const explicitCode = resolveExplicitLinuxPath(env.NEXO_WSL_CODE);
+  if (explicitCode) {
+    linuxEnv.NEXO_CODE = explicitCode;
+  } else if (env.NEXO_CODE && !isWindowsStylePath(env.NEXO_CODE)) {
+    linuxEnv.NEXO_CODE = String(env.NEXO_CODE).trim();
+  }
+
+  return linuxEnv;
+}
+
+function resolveWslNodeBinary(env = process.env) {
+  const explicitNode = resolveExplicitLinuxPath(env.NEXO_WSL_NODE);
+  return explicitNode || "node";
+}
+
+function resolveWslDistro(scriptPath, env = process.env) {
+  const explicitDistro = String(env.NEXO_WSL_DISTRO || "").trim();
+  if (explicitDistro) return explicitDistro;
+  const unc = parseWslUncPath(scriptPath);
+  return unc ? unc.distro : "";
+}
+
+function buildWslExecSpec({ scriptPath, args = [], env = process.env, platform = process.platform }) {
+  if (!isWindowsHost(platform)) return null;
+  const translatedScriptPath = toWslPath(scriptPath);
+  if (!translatedScriptPath) {
+    return {
+      error: `Unable to translate Windows path to WSL path: ${scriptPath}`,
+    };
+  }
+
+  const linuxEnv = resolveLinuxEnv(env);
+  const wslArgs = [];
+  const distro = resolveWslDistro(scriptPath, env);
+  if (distro) {
+    wslArgs.push("-d", distro);
+  }
+
+  wslArgs.push(
+    "--exec",
+    "env",
+    "-u",
+    "NEXO_HOME",
+    "-u",
+    "NEXO_CODE",
+    "-u",
+    "NEXO_WSL_HOME",
+    "-u",
+    "NEXO_WSL_CODE"
+  );
+
+  for (const [key, value] of Object.entries(linuxEnv)) {
+    wslArgs.push(`${key}=${value}`);
+  }
+
+  wslArgs.push(resolveWslNodeBinary(env), translatedScriptPath, ...args);
+
+  return {
+    command: "wsl.exe",
+    args: wslArgs,
+    linuxEnv,
+    translatedScriptPath,
+  };
+}
+
+function logWslBridgeFailure(label, message) {
+  console.error(`${label} could not start through WSL.`);
+  console.error(message);
+  console.error("Install WSL: https://learn.microsoft.com/en-us/windows/wsl/install");
+  console.error("Then run the same command again from PowerShell/CMD or inside your Ubuntu WSL shell.");
+}
+
+function runViaWsl({ scriptPath, args = [], env = process.env, platform = process.platform, stdio = "inherit", label = "NEXO" }) {
+  const spec = buildWslExecSpec({ scriptPath, args, env, platform });
+  if (!spec) return null;
+  if (spec.error) {
+    logWslBridgeFailure(label, spec.error);
+    return { status: 1 };
+  }
+
+  const result = spawnSync(spec.command, spec.args, { stdio, env });
+  if (result.error && result.error.code === "ENOENT") {
+    logWslBridgeFailure(label, "The Windows host does not have `wsl.exe` available.");
+    return { status: 1 };
+  }
+  return result;
+}
+
+module.exports = {
+  buildWslExecSpec,
+  isWindowsHost,
+  isWindowsStylePath,
+  parseWslUncPath,
+  resolveLinuxEnv,
+  runViaWsl,
+  toWslPath,
+};

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   "files": [
     "bin/nexo-brain.js",
     "bin/nexo.js",
+    "bin/windows-wsl-bridge.js",
     "bin/postinstall.js",
     "scripts/sync_release_artifacts.py",
     "src/",

--- a/src/health_check.py
+++ b/src/health_check.py
@@ -17,12 +17,15 @@ from __future__ import annotations
 
 import json
 import os
+import platform
 import re
 import sqlite3
 import subprocess
 import time
 from pathlib import Path
 from typing import Any
+
+from windows_runtime import running_inside_wsl, windows_runtime_status
 
 
 def _nexo_home() -> Path:
@@ -31,8 +34,16 @@ def _nexo_home() -> Path:
 
 def _check_runtime() -> dict:
     home = _nexo_home()
+    system = platform.system()
+    release = platform.release()
+    windows_status = windows_runtime_status(home, system=system, release=release)
     ver_file = home / "version.json"
-    out: dict[str, Any] = {"nexo_home": str(home), "exists": home.is_dir()}
+    out: dict[str, Any] = {
+        "nexo_home": str(home),
+        "exists": home.is_dir(),
+        "is_wsl": running_inside_wsl(system=system, release=release),
+        "windows_runtime": windows_status,
+    }
     if ver_file.is_file():
         try:
             payload = json.loads(ver_file.read_text())
@@ -43,6 +54,8 @@ def _check_runtime() -> dict:
     else:
         out["version"] = "missing"
     out["status"] = "ok" if out["exists"] and out.get("version") not in ("missing", "unreadable") else "degraded"
+    if windows_status["warnings"]:
+        out["status"] = "degraded"
     return out
 
 

--- a/src/local_models.py
+++ b/src/local_models.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 import re
 import shutil
@@ -29,6 +30,7 @@ import paths
 
 MANIFEST_PATH = Path(__file__).resolve().with_name("local_model_manifest.json")
 MODEL_LOCK_FILENAME = ".nexo-model-lock.json"
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -79,6 +81,9 @@ def _lock_payload(spec: LocalModelSpec) -> dict[str, Any]:
 
 @lru_cache(maxsize=1)
 def _load_manifest() -> dict[str, LocalModelSpec]:
+    if not MANIFEST_PATH.exists():
+        logger.warning("local_model_manifest.json missing — running with empty manifest")
+        return {}
     payload = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
     specs: dict[str, LocalModelSpec] = {}
     for raw in payload.get("models", []) or []:

--- a/src/support_snapshot.py
+++ b/src/support_snapshot.py
@@ -20,6 +20,7 @@ import paths
 from doctor.formatters import format_report
 from doctor.orchestrator import run_doctor
 from health_check import collect as collect_health
+from windows_runtime import running_inside_wsl, windows_runtime_status
 
 
 def _nexo_home() -> Path:
@@ -111,15 +112,19 @@ def _recent_logs(lines: int = 80) -> dict[str, Any]:
 
 
 def collect_snapshot(*, log_lines: int = 80, include_doctor: bool = False) -> dict[str, Any]:
+    system = platform.system()
+    release = platform.release()
     payload: dict[str, Any] = {
         "generated_at": time.time(),
         "version": _read_version(),
         "platform": {
-            "system": platform.system(),
-            "release": platform.release(),
+            "system": system,
+            "release": release,
             "machine": platform.machine(),
             "python": platform.python_version(),
+            "is_wsl": running_inside_wsl(system=system, release=release),
         },
+        "windows_runtime": windows_runtime_status(_nexo_home(), system=system, release=release),
         "paths": _path_status(),
         "health": collect_health(),
         "logs": _recent_logs(log_lines),

--- a/src/windows_runtime.py
+++ b/src/windows_runtime.py
@@ -1,0 +1,58 @@
+"""Helpers for Windows/WSL runtime diagnostics."""
+from __future__ import annotations
+
+import os
+import platform
+from pathlib import Path
+from typing import Any
+
+
+def running_inside_wsl(*, system: str | None = None, release: str | None = None) -> bool:
+    resolved_system = str(system or platform.system() or "").strip()
+    resolved_release = str(release or platform.release() or "").strip().lower()
+    if resolved_system != "Linux":
+        return False
+    if "microsoft" in resolved_release:
+        return True
+    if str(os.environ.get("WSL_DISTRO_NAME", "")).strip():
+        return True
+    if str(os.environ.get("WSL_INTEROP", "")).strip():
+        return True
+    return False
+
+
+def is_windows_mount_path(candidate: Path) -> bool:
+    normalized = str(candidate or "").replace("\\", "/").lower()
+    return normalized.startswith("/mnt/")
+
+
+def windows_runtime_status(nexo_home: Path, *, system: str | None = None, release: str | None = None) -> dict[str, Any]:
+    resolved_system = str(system or platform.system() or "").strip()
+    resolved_release = str(release or platform.release() or "").strip()
+    inside_wsl = running_inside_wsl(system=resolved_system, release=resolved_release)
+    on_windows_mount = is_windows_mount_path(nexo_home)
+    warnings: list[dict[str, str]] = []
+
+    if resolved_system == "Windows":
+        warnings.append(
+            {
+                "code": "brain_requires_wsl",
+                "message": "NEXO Brain on Windows is supported via WSL, not native win32 mode.",
+            }
+        )
+    if on_windows_mount:
+        warnings.append(
+            {
+                "code": "nexo_home_on_windows_mount",
+                "message": "NEXO_HOME is inside /mnt/*; keep the canonical Brain runtime inside the WSL filesystem.",
+            }
+        )
+
+    return {
+        "supported_brain_mode": "wsl",
+        "inside_wsl": inside_wsl,
+        "wsl_distro": str(os.environ.get("WSL_DISTRO_NAME", "")).strip(),
+        "wsl_interop": bool(str(os.environ.get("WSL_INTEROP", "")).strip()),
+        "nexo_home_on_windows_mount": on_windows_mount,
+        "warnings": warnings,
+    }

--- a/src/windows_runtime.py
+++ b/src/windows_runtime.py
@@ -21,6 +21,16 @@ def running_inside_wsl(*, system: str | None = None, release: str | None = None)
     return False
 
 
+def running_from_windows_host() -> bool:
+    value = str(os.environ.get("NEXO_WINDOWS_HOST", "")).strip().lower()
+    return value not in ("", "0", "false", "no", "off")
+
+
+def bridge_mode() -> str:
+    value = str(os.environ.get("NEXO_WINDOWS_BRIDGE", "")).strip()
+    return "wsl-exec" if value else ""
+
+
 def is_windows_mount_path(candidate: Path) -> bool:
     normalized = str(candidate or "").replace("\\", "/").lower()
     return normalized.startswith("/mnt/")
@@ -51,6 +61,8 @@ def windows_runtime_status(nexo_home: Path, *, system: str | None = None, releas
     return {
         "supported_brain_mode": "wsl",
         "inside_wsl": inside_wsl,
+        "windows_host_bridge": running_from_windows_host(),
+        "bridge_mode": bridge_mode(),
         "wsl_distro": str(os.environ.get("WSL_DISTRO_NAME", "")).strip(),
         "wsl_interop": bool(str(os.environ.get("WSL_INTEROP", "")).strip()),
         "nexo_home_on_windows_mount": on_windows_mount,

--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -1,0 +1,43 @@
+import json
+
+from health_check import _check_runtime
+
+
+def test_check_runtime_reports_windows_runtime_hints_for_wsl(tmp_path, monkeypatch):
+    home = tmp_path / "nexo-home"
+    home.mkdir(parents=True)
+    (home / "version.json").write_text(json.dumps({"version": "7.12.1"}))
+
+    monkeypatch.setenv("NEXO_HOME", str(home))
+    monkeypatch.setattr("health_check.platform.system", lambda: "Linux")
+    monkeypatch.setattr("health_check.platform.release", lambda: "6.6.87.2-microsoft-standard-WSL2")
+    monkeypatch.setenv("WSL_DISTRO_NAME", "Ubuntu-24.04")
+    monkeypatch.setenv("WSL_INTEROP", "/run/WSL/interop")
+
+    payload = _check_runtime()
+
+    assert payload["status"] == "ok"
+    assert payload["is_wsl"] is True
+    assert payload["windows_runtime"]["inside_wsl"] is True
+    assert payload["windows_runtime"]["wsl_distro"] == "Ubuntu-24.04"
+    assert payload["windows_runtime"]["warnings"] == []
+
+
+def test_check_runtime_degrades_when_nexo_home_is_on_windows_mount(monkeypatch):
+    monkeypatch.setenv("NEXO_HOME", "/mnt/c/Users/francisco/.nexo")
+    monkeypatch.setattr("health_check.platform.system", lambda: "Linux")
+    monkeypatch.setattr("health_check.platform.release", lambda: "6.6.87.2-microsoft-standard-WSL2")
+    monkeypatch.setenv("WSL_DISTRO_NAME", "Ubuntu")
+    monkeypatch.delenv("WSL_INTEROP", raising=False)
+
+    payload = _check_runtime()
+
+    assert payload["status"] == "degraded"
+    assert payload["windows_runtime"]["inside_wsl"] is True
+    assert payload["windows_runtime"]["nexo_home_on_windows_mount"] is True
+    assert payload["windows_runtime"]["warnings"] == [
+        {
+            "code": "nexo_home_on_windows_mount",
+            "message": "NEXO_HOME is inside /mnt/*; keep the canonical Brain runtime inside the WSL filesystem.",
+        }
+    ]

--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -13,12 +13,16 @@ def test_check_runtime_reports_windows_runtime_hints_for_wsl(tmp_path, monkeypat
     monkeypatch.setattr("health_check.platform.release", lambda: "6.6.87.2-microsoft-standard-WSL2")
     monkeypatch.setenv("WSL_DISTRO_NAME", "Ubuntu-24.04")
     monkeypatch.setenv("WSL_INTEROP", "/run/WSL/interop")
+    monkeypatch.setenv("NEXO_WINDOWS_HOST", "1")
+    monkeypatch.setenv("NEXO_WINDOWS_BRIDGE", "1")
 
     payload = _check_runtime()
 
     assert payload["status"] == "ok"
     assert payload["is_wsl"] is True
     assert payload["windows_runtime"]["inside_wsl"] is True
+    assert payload["windows_runtime"]["windows_host_bridge"] is True
+    assert payload["windows_runtime"]["bridge_mode"] == "wsl-exec"
     assert payload["windows_runtime"]["wsl_distro"] == "Ubuntu-24.04"
     assert payload["windows_runtime"]["warnings"] == []
 
@@ -29,6 +33,8 @@ def test_check_runtime_degrades_when_nexo_home_is_on_windows_mount(monkeypatch):
     monkeypatch.setattr("health_check.platform.release", lambda: "6.6.87.2-microsoft-standard-WSL2")
     monkeypatch.setenv("WSL_DISTRO_NAME", "Ubuntu")
     monkeypatch.delenv("WSL_INTEROP", raising=False)
+    monkeypatch.delenv("NEXO_WINDOWS_HOST", raising=False)
+    monkeypatch.delenv("NEXO_WINDOWS_BRIDGE", raising=False)
 
     payload = _check_runtime()
 

--- a/tests/test_local_models.py
+++ b/tests/test_local_models.py
@@ -27,6 +27,17 @@ def test_manifest_declares_revision_for_all_pinned_fastembed_models():
         assert spec.required_files
 
 
+def test_list_local_model_specs_degrades_to_empty_when_manifest_is_missing(tmp_path, monkeypatch):
+    local_models._load_manifest.cache_clear()
+    missing_manifest = tmp_path / "local_model_manifest.json"
+    monkeypatch.setattr(local_models, "MANIFEST_PATH", missing_manifest)
+
+    try:
+        assert local_models.list_local_model_specs() == []
+    finally:
+        local_models._load_manifest.cache_clear()
+
+
 def test_verify_local_model_dir_detects_checksum_drift(tmp_path):
     good_size, good_sha = _make_file(tmp_path, "model.onnx", b"good-model")
     spec = local_models.LocalModelSpec(

--- a/tests/test_support_snapshot.py
+++ b/tests/test_support_snapshot.py
@@ -22,6 +22,8 @@ def test_collect_snapshot_returns_generic_runtime_payload(tmp_path, monkeypatch)
     assert payload["platform"]["is_wsl"] is False
     assert payload["windows_runtime"]["supported_brain_mode"] == "wsl"
     assert payload["windows_runtime"]["inside_wsl"] is False
+    assert payload["windows_runtime"]["windows_host_bridge"] is False
+    assert payload["windows_runtime"]["bridge_mode"] == ""
     assert payload["windows_runtime"]["warnings"] == []
     assert "health" in payload
     assert "logs" in payload
@@ -34,6 +36,8 @@ def test_collect_snapshot_reports_wsl_runtime_hints(monkeypatch):
     monkeypatch.setenv("HOME", "/home/tester")
     monkeypatch.setenv("WSL_DISTRO_NAME", "Ubuntu-24.04")
     monkeypatch.setenv("WSL_INTEROP", "/run/WSL/123_interop")
+    monkeypatch.setenv("NEXO_WINDOWS_HOST", "1")
+    monkeypatch.setenv("NEXO_WINDOWS_BRIDGE", "1")
     monkeypatch.setattr("support_snapshot.platform.system", lambda: "Linux")
     monkeypatch.setattr("support_snapshot.platform.release", lambda: "6.6.87.2-microsoft-standard-WSL2")
     monkeypatch.setattr("support_snapshot.platform.machine", lambda: "x86_64")
@@ -43,6 +47,8 @@ def test_collect_snapshot_reports_wsl_runtime_hints(monkeypatch):
 
     assert payload["platform"]["is_wsl"] is True
     assert payload["windows_runtime"]["inside_wsl"] is True
+    assert payload["windows_runtime"]["windows_host_bridge"] is True
+    assert payload["windows_runtime"]["bridge_mode"] == "wsl-exec"
     assert payload["windows_runtime"]["wsl_distro"] == "Ubuntu-24.04"
     assert payload["windows_runtime"]["wsl_interop"] is True
     assert payload["windows_runtime"]["warnings"] == []
@@ -53,6 +59,8 @@ def test_collect_snapshot_warns_when_nexo_home_lives_on_windows_mount(monkeypatc
     monkeypatch.setenv("HOME", "/home/francisco")
     monkeypatch.setenv("WSL_DISTRO_NAME", "Ubuntu")
     monkeypatch.delenv("WSL_INTEROP", raising=False)
+    monkeypatch.delenv("NEXO_WINDOWS_HOST", raising=False)
+    monkeypatch.delenv("NEXO_WINDOWS_BRIDGE", raising=False)
     monkeypatch.setattr("support_snapshot.platform.system", lambda: "Linux")
     monkeypatch.setattr("support_snapshot.platform.release", lambda: "6.6.87.2-microsoft-standard-WSL2")
     monkeypatch.setattr("support_snapshot.platform.machine", lambda: "x86_64")

--- a/tests/test_support_snapshot.py
+++ b/tests/test_support_snapshot.py
@@ -19,7 +19,52 @@ def test_collect_snapshot_returns_generic_runtime_payload(tmp_path, monkeypatch)
 
     assert payload["version"] == "7.11.7"
     assert payload["paths"]["home"]["exists"] is True
+    assert payload["platform"]["is_wsl"] is False
+    assert payload["windows_runtime"]["supported_brain_mode"] == "wsl"
+    assert payload["windows_runtime"]["inside_wsl"] is False
+    assert payload["windows_runtime"]["warnings"] == []
     assert "health" in payload
     assert "logs" in payload
     assert isinstance(payload["logs"]["events"], list)
     assert isinstance(payload["logs"]["operations"], list)
+
+
+def test_collect_snapshot_reports_wsl_runtime_hints(monkeypatch):
+    monkeypatch.setenv("NEXO_HOME", "/home/tester/.nexo")
+    monkeypatch.setenv("HOME", "/home/tester")
+    monkeypatch.setenv("WSL_DISTRO_NAME", "Ubuntu-24.04")
+    monkeypatch.setenv("WSL_INTEROP", "/run/WSL/123_interop")
+    monkeypatch.setattr("support_snapshot.platform.system", lambda: "Linux")
+    monkeypatch.setattr("support_snapshot.platform.release", lambda: "6.6.87.2-microsoft-standard-WSL2")
+    monkeypatch.setattr("support_snapshot.platform.machine", lambda: "x86_64")
+    monkeypatch.setattr("support_snapshot.platform.python_version", lambda: "3.12.0")
+
+    payload = collect_snapshot(log_lines=5, include_doctor=False)
+
+    assert payload["platform"]["is_wsl"] is True
+    assert payload["windows_runtime"]["inside_wsl"] is True
+    assert payload["windows_runtime"]["wsl_distro"] == "Ubuntu-24.04"
+    assert payload["windows_runtime"]["wsl_interop"] is True
+    assert payload["windows_runtime"]["warnings"] == []
+
+
+def test_collect_snapshot_warns_when_nexo_home_lives_on_windows_mount(monkeypatch):
+    monkeypatch.setenv("NEXO_HOME", "/mnt/c/Users/francisco/.nexo")
+    monkeypatch.setenv("HOME", "/home/francisco")
+    monkeypatch.setenv("WSL_DISTRO_NAME", "Ubuntu")
+    monkeypatch.delenv("WSL_INTEROP", raising=False)
+    monkeypatch.setattr("support_snapshot.platform.system", lambda: "Linux")
+    monkeypatch.setattr("support_snapshot.platform.release", lambda: "6.6.87.2-microsoft-standard-WSL2")
+    monkeypatch.setattr("support_snapshot.platform.machine", lambda: "x86_64")
+    monkeypatch.setattr("support_snapshot.platform.python_version", lambda: "3.12.0")
+
+    payload = collect_snapshot(log_lines=5, include_doctor=False)
+
+    assert payload["windows_runtime"]["inside_wsl"] is True
+    assert payload["windows_runtime"]["nexo_home_on_windows_mount"] is True
+    assert payload["windows_runtime"]["warnings"] == [
+        {
+            "code": "nexo_home_on_windows_mount",
+            "message": "NEXO_HOME is inside /mnt/*; keep the canonical Brain runtime inside the WSL filesystem.",
+        }
+    ]

--- a/tests/test_windows_wsl_bridge_contract.py
+++ b/tests/test_windows_wsl_bridge_contract.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HELPER = REPO_ROOT / "bin" / "windows-wsl-bridge.js"
+
+
+def _node_available() -> bool:
+    return shutil.which("node") is not None
+
+
+@pytest.mark.skipif(not _node_available(), reason="node not available")
+def test_bridge_builds_wsl_exec_spec_with_sanitized_env() -> None:
+    driver = f"""
+const helper = require({json.dumps(str(HELPER))});
+const payload = helper.buildWslExecSpec({{
+  scriptPath: "C:\\\\Users\\\\franciscoc\\\\AppData\\\\Roaming\\\\npm\\\\node_modules\\\\nexo-brain\\\\bin\\\\nexo.js",
+  args: ["doctor", "--json"],
+  env: {{
+    NEXO_HOME: "C:\\\\Users\\\\franciscoc\\\\.nexo",
+    NEXO_CODE: "C:\\\\Users\\\\franciscoc\\\\src\\\\nexo\\\\src",
+    NEXO_WSL_DISTRO: "Ubuntu-24.04",
+    NEXO_WSL_HOME: "/home/franciscoc/.nexo"
+  }},
+  platform: "win32"
+}});
+console.log(JSON.stringify(payload));
+"""
+    result = subprocess.run(
+        ["node", "-e", driver],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+
+    payload = json.loads(result.stdout.strip())
+    assert payload["command"] == "wsl.exe"
+    assert payload["translatedScriptPath"] == "/mnt/c/Users/franciscoc/AppData/Roaming/npm/node_modules/nexo-brain/bin/nexo.js"
+    assert payload["linuxEnv"] == {
+        "NEXO_WINDOWS_BRIDGE": "1",
+        "NEXO_WINDOWS_HOST": "1",
+        "NEXO_HOME": "/home/franciscoc/.nexo",
+    }
+    assert payload["args"][:10] == [
+        "-d",
+        "Ubuntu-24.04",
+        "--exec",
+        "env",
+        "-u",
+        "NEXO_HOME",
+        "-u",
+        "NEXO_CODE",
+        "-u",
+        "NEXO_WSL_HOME",
+    ]
+    assert payload["args"][10:14] == ["-u", "NEXO_WSL_CODE", "NEXO_WINDOWS_BRIDGE=1", "NEXO_WINDOWS_HOST=1"]
+    assert payload["args"][14:] == [
+        "NEXO_HOME=/home/franciscoc/.nexo",
+        "node",
+        "/mnt/c/Users/franciscoc/AppData/Roaming/npm/node_modules/nexo-brain/bin/nexo.js",
+        "doctor",
+        "--json",
+    ]
+
+
+@pytest.mark.skipif(not _node_available(), reason="node not available")
+def test_bridge_infers_distro_from_wsl_unc_paths() -> None:
+    driver = f"""
+const helper = require({json.dumps(str(HELPER))});
+const payload = helper.buildWslExecSpec({{
+  scriptPath: "\\\\\\\\wsl$\\\\Ubuntu-24.04\\\\home\\\\franciscoc\\\\repo\\\\bin\\\\nexo-brain.js",
+  args: ["--version"],
+  env: {{}},
+  platform: "win32"
+}});
+console.log(JSON.stringify(payload));
+"""
+    result = subprocess.run(
+        ["node", "-e", driver],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+
+    payload = json.loads(result.stdout.strip())
+    assert payload["translatedScriptPath"] == "/home/franciscoc/repo/bin/nexo-brain.js"
+    assert payload["args"][:2] == ["-d", "Ubuntu-24.04"]
+
+
+def test_public_launchers_use_shared_wsl_bridge_helper() -> None:
+    cli_text = (REPO_ROOT / "bin" / "nexo.js").read_text(encoding="utf-8")
+    installer_text = (REPO_ROOT / "bin" / "nexo-brain.js").read_text(encoding="utf-8")
+    package = json.loads((REPO_ROOT / "package.json").read_text(encoding="utf-8"))
+
+    assert 'const { runViaWsl } = require("./windows-wsl-bridge");' in cli_text
+    assert 'const { runViaWsl } = require("./windows-wsl-bridge");' in installer_text
+    assert 'label: "NEXO CLI"' in cli_text
+    assert 'label: "NEXO Brain"' in installer_text
+    assert "bin/windows-wsl-bridge.js" in package["files"]


### PR DESCRIPTION
## Summary\n- add WSL-aware runtime diagnostics and launcher bridging for Windows hosts\n- tolerate missing local model manifest during update windows\n- keep Brain startup resilient while Windows beta work lands\n\n## Validation\n- pytest tests/test_local_models.py\n- python -m py_compile src/local_models.py src/windows_runtime.py src/support_snapshot.py src/health_check.py\n