### PR TITLE
Windows runtime parity hardening

### DIFF
--- a/bin/windows-wsl-bridge.js
+++ b/bin/windows-wsl-bridge.js
@@ -1,4 +1,5 @@
 const { spawnSync } = require("child_process");
+const path = require("path");
 
 function isWindowsHost(platform = process.platform) {
   return platform === "win32";
@@ -73,6 +74,26 @@ function resolveLinuxEnv(env = process.env) {
   return linuxEnv;
 }
 
+function inferLinuxUserHomeFromRuntimeHome(runtimeHome = "") {
+  const value = String(runtimeHome || "").trim();
+  if (!value.startsWith("/")) return "";
+  if (path.posix.basename(value) === ".nexo") {
+    return path.posix.dirname(value) || "";
+  }
+  return "";
+}
+
+function resolveLinuxUserHome({ env = process.env, linuxEnv = {}, defaultValue = "" } = {}) {
+  const explicitHome = resolveExplicitLinuxPath(env.NEXO_WSL_USER_HOME);
+  if (explicitHome) return explicitHome;
+
+  const runtimeHome = inferLinuxUserHomeFromRuntimeHome(linuxEnv.NEXO_HOME || "");
+  if (runtimeHome) return runtimeHome;
+
+  const defaultHome = resolveExplicitLinuxPath(defaultValue);
+  return defaultHome || "";
+}
+
 function resolveWslNodeBinary(env = process.env) {
   const explicitNode = resolveExplicitLinuxPath(env.NEXO_WSL_NODE);
   return explicitNode || "node";
@@ -85,7 +106,35 @@ function resolveWslDistro(scriptPath, env = process.env) {
   return unc ? unc.distro : "";
 }
 
-function buildWslExecSpec({ scriptPath, args = [], env = process.env, platform = process.platform }) {
+function probeWslUserHome({ distro = "", env = process.env } = {}) {
+  const probeArgs = [];
+  if (distro) {
+    probeArgs.push("-d", distro);
+  }
+  probeArgs.push("--cd", "~", "--exec", "pwd");
+
+  const result = spawnSync("wsl.exe", probeArgs, {
+    env,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.error || result.status !== 0) return "";
+
+  const lines = String(result.stdout || "")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const candidate = lines.length ? lines[lines.length - 1] : "";
+  return candidate.startsWith("/") ? candidate : "";
+}
+
+function buildWslExecSpec({
+  scriptPath,
+  args = [],
+  env = process.env,
+  platform = process.platform,
+  linuxHome = "",
+}) {
   if (!isWindowsHost(platform)) return null;
   const translatedScriptPath = toWslPath(scriptPath);
   if (!translatedScriptPath) {
@@ -100,10 +149,15 @@ function buildWslExecSpec({ scriptPath, args = [], env = process.env, platform =
   if (distro) {
     wslArgs.push("-d", distro);
   }
+  const resolvedLinuxHome = resolveLinuxUserHome({ env, linuxEnv, defaultValue: linuxHome });
+
+  wslArgs.push("--cd", resolvedLinuxHome || "~");
 
   wslArgs.push(
     "--exec",
     "env",
+    "-u",
+    "HOME",
     "-u",
     "NEXO_HOME",
     "-u",
@@ -111,9 +165,18 @@ function buildWslExecSpec({ scriptPath, args = [], env = process.env, platform =
     "-u",
     "NEXO_WSL_HOME",
     "-u",
-    "NEXO_WSL_CODE"
+    "NEXO_WSL_CODE",
+    "-u",
+    "USERPROFILE",
+    "-u",
+    "HOMEDRIVE",
+    "-u",
+    "HOMEPATH"
   );
 
+  if (resolvedLinuxHome) {
+    wslArgs.push(`HOME=${resolvedLinuxHome}`);
+  }
   for (const [key, value] of Object.entries(linuxEnv)) {
     wslArgs.push(`${key}=${value}`);
   }
@@ -136,7 +199,9 @@ function logWslBridgeFailure(label, message) {
 }
 
 function runViaWsl({ scriptPath, args = [], env = process.env, platform = process.platform, stdio = "inherit", label = "NEXO" }) {
-  const spec = buildWslExecSpec({ scriptPath, args, env, platform });
+  const distro = resolveWslDistro(scriptPath, env);
+  const linuxHome = probeWslUserHome({ distro, env });
+  const spec = buildWslExecSpec({ scriptPath, args, env, platform, linuxHome });
   if (!spec) return null;
   if (spec.error) {
     logWslBridgeFailure(label, spec.error);
@@ -153,10 +218,13 @@ function runViaWsl({ scriptPath, args = [], env = process.env, platform = proces
 
 module.exports = {
   buildWslExecSpec,
+  inferLinuxUserHomeFromRuntimeHome,
   isWindowsHost,
   isWindowsStylePath,
   parseWslUncPath,
+  probeWslUserHome,
   resolveLinuxEnv,
+  resolveLinuxUserHome,
   runViaWsl,
   toWslPath,
 };

--- a/src/cli.py
+++ b/src/cli.py
@@ -2518,6 +2518,7 @@ def _skills_compose(args):
 def _uninstall(args):
     """Stop all crons, remove MCP config and hooks, preserve user data."""
     from pathlib import Path
+    from windows_runtime import cleanup_windows_host_artifacts, running_inside_wsl, running_from_windows_host
 
     nexo_home = Path(os.environ.get("NEXO_HOME", Path.home() / ".nexo"))
     dry_run = args.dry_run
@@ -2565,6 +2566,20 @@ def _uninstall(args):
                 log_action("remove-systemd", unit.name, str(unit))
             if not dry_run:
                 subprocess.run(["systemctl", "--user", "daemon-reload"], capture_output=True)
+
+        if running_inside_wsl() or running_from_windows_host():
+            host_cleanup = cleanup_windows_host_artifacts(
+                delete_data=delete_data,
+                dry_run=dry_run,
+            )
+            for action in host_cleanup.get("actions", []):
+                log_action(
+                    action.get("category", "remove-win-host-artifact"),
+                    action.get("detail", ""),
+                    action.get("path", ""),
+                )
+            for error in host_cleanup.get("errors", []):
+                errors.append(f"Windows host cleanup: {error}")
 
     # ── 2. Remove MCP server and hooks from Claude Code settings ──
     claude_settings = Path.home() / ".claude" / "settings.json"

--- a/src/health_check.py
+++ b/src/health_check.py
@@ -25,7 +25,7 @@ import time
 from pathlib import Path
 from typing import Any
 
-from windows_runtime import running_inside_wsl, windows_runtime_status
+from windows_runtime import query_windows_host_tasks, running_inside_wsl, windows_runtime_status
 
 
 def _nexo_home() -> Path:
@@ -83,17 +83,53 @@ def _check_database() -> dict:
 
 def _check_crons() -> dict:
     out: dict[str, Any] = {}
-    # macOS LaunchAgents
-    agents_dir = Path.home() / "Library" / "LaunchAgents"
-    if agents_dir.is_dir():
+    system = platform.system()
+    release = platform.release()
+
+    if system == "Darwin":
+        agents_dir = Path.home() / "Library" / "LaunchAgents"
+        out["platform"] = "macos"
+        if agents_dir.is_dir():
+            try:
+                plists = [p for p in agents_dir.glob("com.nexo.*.plist")]
+                out["launch_agents"] = len(plists)
+            except Exception as exc:
+                out["error"] = str(exc)
+                out["status"] = "degraded"
+                return out
+        out["status"] = "ok"
+        return out
+
+    if system == "Linux":
+        unit_dir = Path.home() / ".config" / "systemd" / "user"
+        inside_wsl = running_inside_wsl(system=system, release=release)
+        out["platform"] = "wsl" if inside_wsl else "linux"
+        out["inside_wsl"] = inside_wsl
         try:
-            plists = [p for p in agents_dir.glob("com.nexo.*.plist")]
-            out["launch_agents"] = len(plists)
-            out["platform"] = "macos"
+            services = sorted(unit_dir.glob("nexo-*.service")) if unit_dir.is_dir() else []
+            timers = sorted(unit_dir.glob("nexo-*.timer")) if unit_dir.is_dir() else []
+            out["systemd_services"] = len(services)
+            out["systemd_timers"] = len(timers)
         except Exception as exc:
             out["error"] = str(exc)
-    else:
-        out["platform"] = "unknown"
+            out["status"] = "degraded"
+            return out
+        if inside_wsl:
+            out["windows_host_tasks"] = query_windows_host_tasks()
+        out["status"] = "ok" if (out.get("systemd_services", 0) or out.get("systemd_timers", 0)) else "degraded"
+        if out["status"] == "degraded":
+            out["reason"] = "no_nexo_systemd_units_detected"
+        return out
+
+    if system == "Windows":
+        out["platform"] = "windows"
+        out["windows_host_tasks"] = query_windows_host_tasks()
+        out["status"] = "ok" if out["windows_host_tasks"].get("available") else "degraded"
+        if out["status"] == "degraded":
+            out["reason"] = "windows_task_scheduler_unavailable"
+        return out
+
+    out["platform"] = "unknown"
     out["status"] = "ok"
     return out
 

--- a/src/support_snapshot.py
+++ b/src/support_snapshot.py
@@ -20,7 +20,7 @@ import paths
 from doctor.formatters import format_report
 from doctor.orchestrator import run_doctor
 from health_check import collect as collect_health
-from windows_runtime import running_inside_wsl, windows_runtime_status
+from windows_runtime import query_windows_host_tasks, running_inside_wsl, windows_runtime_status
 
 
 def _nexo_home() -> Path:
@@ -125,6 +125,9 @@ def collect_snapshot(*, log_lines: int = 80, include_doctor: bool = False) -> di
             "is_wsl": running_inside_wsl(system=system, release=release),
         },
         "windows_runtime": windows_runtime_status(_nexo_home(), system=system, release=release),
+        "windows_host": {
+            "tasks": query_windows_host_tasks(),
+        },
         "paths": _path_status(),
         "health": collect_health(),
         "logs": _recent_logs(log_lines),

--- a/src/windows_runtime.py
+++ b/src/windows_runtime.py
@@ -1,8 +1,13 @@
 """Helpers for Windows/WSL runtime diagnostics."""
 from __future__ import annotations
 
+import csv
+import io
+import json
 import os
 import platform
+import shutil
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -36,6 +41,257 @@ def is_windows_mount_path(candidate: Path) -> bool:
     return normalized.startswith("/mnt/")
 
 
+def _default_windows_runner(args: list[str], *, timeout: int = 20) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, capture_output=True, text=True, timeout=timeout)
+
+
+def resolve_windows_host_binary(
+    command: str,
+    *,
+    which_func=shutil.which,
+) -> str:
+    direct = str(which_func(command) or "").strip()
+    if direct:
+        return direct
+    fallbacks = {
+        "powershell.exe": [
+            "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe",
+            "/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe",
+        ],
+        "schtasks.exe": [
+            "/mnt/c/Windows/System32/schtasks.exe",
+            "/c/Windows/System32/schtasks.exe",
+        ],
+    }
+    for candidate in fallbacks.get(command.lower(), ()):
+        if Path(candidate).exists():
+            return candidate
+    return ""
+
+
+def windows_host_interop_available(*, which_func=shutil.which) -> bool:
+    return bool(
+        resolve_windows_host_binary("powershell.exe", which_func=which_func)
+        or resolve_windows_host_binary("schtasks.exe", which_func=which_func)
+    )
+
+
+def query_windows_host_special_folders(
+    *,
+    runner=_default_windows_runner,
+    which_func=shutil.which,
+) -> dict[str, Any]:
+    powershell = resolve_windows_host_binary("powershell.exe", which_func=which_func)
+    if not powershell:
+        return {
+            "available": False,
+            "error": "powershell_missing",
+            "folders": {},
+        }
+
+    script = (
+        "$obj = [ordered]@{"
+        "LocalApplicationData=[Environment]::GetFolderPath('LocalApplicationData');"
+        "ApplicationData=[Environment]::GetFolderPath('ApplicationData');"
+        "Programs=[Environment]::GetFolderPath('Programs')"
+        "};"
+        "$obj | ConvertTo-Json -Compress"
+    )
+    try:
+        result = runner([powershell, "-NoProfile", "-Command", script], timeout=20)
+    except Exception as exc:
+        return {
+            "available": False,
+            "error": str(exc),
+            "folders": {},
+        }
+    raw = str(result.stdout or "").strip()
+    if result.returncode != 0 or not raw:
+        return {
+            "available": False,
+            "error": str(result.stderr or result.stdout or "windows_special_folders_failed").strip(),
+            "folders": {},
+        }
+    try:
+        payload = json.loads(raw)
+    except Exception as exc:
+        return {
+            "available": False,
+            "error": f"invalid_json: {exc}",
+            "folders": {},
+        }
+    if not isinstance(payload, dict):
+        return {
+            "available": False,
+            "error": "invalid_payload",
+            "folders": {},
+        }
+    folders = {str(key): str(value or "").strip() for key, value in payload.items()}
+    return {
+        "available": True,
+        "folders": folders,
+    }
+
+
+def query_windows_host_tasks(
+    *,
+    runner=_default_windows_runner,
+    which_func=shutil.which,
+) -> dict[str, Any]:
+    schtasks = resolve_windows_host_binary("schtasks.exe", which_func=which_func)
+    if not schtasks:
+        return {
+            "available": False,
+            "error": "schtasks_missing",
+            "tasks": [],
+        }
+
+    try:
+        result = runner([schtasks, "/Query", "/FO", "CSV", "/NH"], timeout=30)
+    except Exception as exc:
+        return {
+            "available": False,
+            "error": str(exc),
+            "tasks": [],
+        }
+
+    if result.returncode != 0:
+        return {
+            "available": False,
+            "error": str(result.stderr or result.stdout or "schtasks_query_failed").strip(),
+            "tasks": [],
+        }
+
+    tasks: list[str] = []
+    try:
+        reader = csv.reader(io.StringIO(str(result.stdout or "")))
+        for row in reader:
+            if not row:
+                continue
+            name = str(row[0] or "").strip()
+            if name and "nexo" in name.lower():
+                tasks.append(name)
+    except Exception as exc:
+        return {
+            "available": False,
+            "error": f"invalid_csv: {exc}",
+            "tasks": [],
+        }
+
+    return {
+        "available": True,
+        "tasks": sorted(set(tasks)),
+    }
+
+
+def build_windows_host_cleanup_plan(
+    *,
+    delete_data: bool = False,
+    runner=_default_windows_runner,
+    which_func=shutil.which,
+) -> dict[str, Any]:
+    folders_payload = query_windows_host_special_folders(runner=runner, which_func=which_func)
+    tasks_payload = query_windows_host_tasks(runner=runner, which_func=which_func)
+    folders = folders_payload.get("folders", {}) if folders_payload.get("available") else {}
+    local = str(folders.get("LocalApplicationData", "")).strip()
+    roaming = str(folders.get("ApplicationData", "")).strip()
+    programs = str(folders.get("Programs", "")).strip()
+
+    runtime_paths = [
+        path for path in (
+            f"{local}\\Programs\\NEXO Desktop" if local else "",
+            f"{local}\\Programs\\NEXO Desktop Support" if local else "",
+        ) if path
+    ]
+    data_paths = [
+        path for path in (
+            f"{roaming}\\NEXO Desktop" if roaming else "",
+            f"{roaming}\\NEXO Desktop Support" if roaming else "",
+            f"{local}\\NEXO Desktop" if local else "",
+            f"{local}\\NEXO Desktop Support" if local else "",
+        ) if path
+    ]
+    shortcut_paths = [
+        path for path in (
+            f"{programs}\\NEXO Desktop.lnk" if programs else "",
+            f"{programs}\\NEXO Desktop Support.lnk" if programs else "",
+        ) if path
+    ]
+    return {
+        "available": bool(folders_payload.get("available") or tasks_payload.get("available")),
+        "folders": folders,
+        "runtime_paths": runtime_paths,
+        "data_paths": data_paths if delete_data else [],
+        "shortcut_paths": shortcut_paths,
+        "tasks": list(tasks_payload.get("tasks", [])),
+        "errors": [
+            value for value in (
+                folders_payload.get("error"),
+                tasks_payload.get("error"),
+            ) if value
+        ],
+    }
+
+
+def cleanup_windows_host_artifacts(
+    *,
+    delete_data: bool = False,
+    dry_run: bool = False,
+    runner=_default_windows_runner,
+    which_func=shutil.which,
+) -> dict[str, Any]:
+    powershell = resolve_windows_host_binary("powershell.exe", which_func=which_func)
+    schtasks = resolve_windows_host_binary("schtasks.exe", which_func=which_func)
+    plan = build_windows_host_cleanup_plan(
+        delete_data=delete_data,
+        runner=runner,
+        which_func=which_func,
+    )
+    actions: list[dict[str, str]] = []
+    errors = list(plan.get("errors", []))
+
+    for path in plan["runtime_paths"]:
+        actions.append({"category": "remove-win-host-app", "detail": Path(path).name, "path": path})
+    for path in plan["shortcut_paths"]:
+        actions.append({"category": "remove-win-host-shortcut", "detail": Path(path).name, "path": path})
+    for path in plan["data_paths"]:
+        actions.append({"category": "remove-win-host-data", "detail": Path(path).name, "path": path})
+    for task_name in plan["tasks"]:
+        actions.append({"category": "remove-win-host-task", "detail": task_name, "path": task_name})
+
+    if dry_run or not plan["available"]:
+        return {"available": plan["available"], "actions": actions, "errors": errors}
+
+    if powershell:
+        remove_targets = plan["runtime_paths"] + plan["shortcut_paths"] + plan["data_paths"]
+        if remove_targets:
+            quoted = ", ".join(json.dumps(target) for target in remove_targets)
+            script = (
+                f"$targets = @({quoted}); "
+                "foreach ($target in $targets) { "
+                "if (Test-Path -LiteralPath $target) { "
+                "Remove-Item -LiteralPath $target -Recurse -Force -ErrorAction SilentlyContinue "
+                "} }"
+            )
+            try:
+                result = runner([powershell, "-NoProfile", "-Command", script], timeout=60)
+                if result.returncode != 0:
+                    errors.append(str(result.stderr or result.stdout or "windows_remove_failed").strip())
+            except Exception as exc:
+                errors.append(str(exc))
+
+    if schtasks:
+        for task_name in plan["tasks"]:
+            try:
+                result = runner([schtasks, "/Delete", "/TN", task_name, "/F"], timeout=20)
+                if result.returncode != 0:
+                    errors.append(str(result.stderr or result.stdout or f"task_delete_failed:{task_name}").strip())
+            except Exception as exc:
+                errors.append(f"{task_name}: {exc}")
+
+    return {"available": plan["available"], "actions": actions, "errors": errors}
+
+
 def windows_runtime_status(nexo_home: Path, *, system: str | None = None, release: str | None = None) -> dict[str, Any]:
     resolved_system = str(system or platform.system() or "").strip()
     resolved_release = str(release or platform.release() or "").strip()
@@ -63,6 +319,7 @@ def windows_runtime_status(nexo_home: Path, *, system: str | None = None, releas
         "inside_wsl": inside_wsl,
         "windows_host_bridge": running_from_windows_host(),
         "bridge_mode": bridge_mode(),
+        "windows_host_interop": windows_host_interop_available(),
         "wsl_distro": str(os.environ.get("WSL_DISTRO_NAME", "")).strip(),
         "wsl_interop": bool(str(os.environ.get("WSL_INTEROP", "")).strip()),
         "nexo_home_on_windows_mount": on_windows_mount,

--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -1,6 +1,6 @@
 import json
 
-from health_check import _check_runtime
+from health_check import _check_crons, _check_runtime
 
 
 def test_check_runtime_reports_windows_runtime_hints_for_wsl(tmp_path, monkeypatch):
@@ -47,3 +47,27 @@ def test_check_runtime_degrades_when_nexo_home_is_on_windows_mount(monkeypatch):
             "message": "NEXO_HOME is inside /mnt/*; keep the canonical Brain runtime inside the WSL filesystem.",
         }
     ]
+
+
+def test_check_crons_reports_systemd_units_inside_wsl(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    unit_dir = home / ".config" / "systemd" / "user"
+    unit_dir.mkdir(parents=True)
+    (unit_dir / "nexo-watchdog.service").write_text("[Unit]\n")
+    (unit_dir / "nexo-watchdog.timer").write_text("[Timer]\n")
+
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("NEXO_HOME", str(home / ".nexo"))
+    monkeypatch.setenv("WSL_DISTRO_NAME", "Ubuntu")
+    monkeypatch.setenv("WSL_INTEROP", "/run/WSL/interop")
+    monkeypatch.setattr("health_check.platform.system", lambda: "Linux")
+    monkeypatch.setattr("health_check.platform.release", lambda: "6.6.87.2-microsoft-standard-WSL2")
+    monkeypatch.setattr("health_check.query_windows_host_tasks", lambda: {"available": False, "tasks": [], "error": "schtasks_missing"})
+
+    payload = _check_crons()
+
+    assert payload["platform"] == "wsl"
+    assert payload["systemd_services"] == 1
+    assert payload["systemd_timers"] == 1
+    assert payload["status"] == "ok"
+    assert payload["windows_host_tasks"]["available"] is False

--- a/tests/test_support_snapshot.py
+++ b/tests/test_support_snapshot.py
@@ -24,6 +24,7 @@ def test_collect_snapshot_returns_generic_runtime_payload(tmp_path, monkeypatch)
     assert payload["windows_runtime"]["inside_wsl"] is False
     assert payload["windows_runtime"]["windows_host_bridge"] is False
     assert payload["windows_runtime"]["bridge_mode"] == ""
+    assert payload["windows_host"]["tasks"]["available"] is False
     assert payload["windows_runtime"]["warnings"] == []
     assert "health" in payload
     assert "logs" in payload
@@ -51,6 +52,7 @@ def test_collect_snapshot_reports_wsl_runtime_hints(monkeypatch):
     assert payload["windows_runtime"]["bridge_mode"] == "wsl-exec"
     assert payload["windows_runtime"]["wsl_distro"] == "Ubuntu-24.04"
     assert payload["windows_runtime"]["wsl_interop"] is True
+    assert "windows_host" in payload
     assert payload["windows_runtime"]["warnings"] == []
 
 

--- a/tests/test_windows_runtime.py
+++ b/tests/test_windows_runtime.py
@@ -1,0 +1,104 @@
+import json
+
+from windows_runtime import (
+    build_windows_host_cleanup_plan,
+    query_windows_host_special_folders,
+    query_windows_host_tasks,
+    windows_runtime_status,
+)
+
+
+class _Result:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_query_windows_host_special_folders_parses_powershell_json(monkeypatch):
+    def fake_runner(args, timeout=20):
+        assert "powershell.exe" in args[0]
+        return _Result(
+            0,
+            json.dumps(
+                {
+                    "LocalApplicationData": r"C:\Users\nero\AppData\Local",
+                    "ApplicationData": r"C:\Users\nero\AppData\Roaming",
+                    "Programs": r"C:\Users\nero\AppData\Roaming\Microsoft\Windows\Start Menu\Programs",
+                }
+            ),
+            "",
+        )
+
+    payload = query_windows_host_special_folders(
+        runner=fake_runner,
+        which_func=lambda command: command if command == "powershell.exe" else "",
+    )
+
+    assert payload["available"] is True
+    assert payload["folders"]["LocalApplicationData"].endswith(r"AppData\Local")
+    assert payload["folders"]["ApplicationData"].endswith(r"AppData\Roaming")
+
+
+def test_query_windows_host_tasks_filters_nexo_task_names():
+    csv_rows = "\n".join(
+        [
+            '"\\NEXO Desktop","Ready","..."',
+            '"\\Microsoft\\Windows\\Defrag","Ready","..."',
+            '"\\com.nexo.watchdog","Ready","..."',
+        ]
+    )
+
+    payload = query_windows_host_tasks(
+        runner=lambda args, timeout=30: _Result(0, csv_rows, ""),
+        which_func=lambda command: command if command == "schtasks.exe" else "",
+    )
+
+    assert payload["available"] is True
+    assert payload["tasks"] == ["\\NEXO Desktop", "\\com.nexo.watchdog"]
+
+
+def test_build_windows_host_cleanup_plan_collects_runtime_data_and_shortcuts():
+    def fake_runner(args, timeout=20):
+        if "powershell.exe" in args[0]:
+            return _Result(
+                0,
+                json.dumps(
+                    {
+                        "LocalApplicationData": r"C:\Users\nero\AppData\Local",
+                        "ApplicationData": r"C:\Users\nero\AppData\Roaming",
+                        "Programs": r"C:\Users\nero\AppData\Roaming\Microsoft\Windows\Start Menu\Programs",
+                    }
+                ),
+                "",
+            )
+        return _Result(0, '"\\NEXO Desktop","Ready","..."\n', "")
+
+    plan = build_windows_host_cleanup_plan(
+        delete_data=True,
+        runner=fake_runner,
+        which_func=lambda command: command,
+    )
+
+    assert plan["available"] is True
+    assert r"C:\Users\nero\AppData\Local\Programs\NEXO Desktop" in plan["runtime_paths"]
+    assert r"C:\Users\nero\AppData\Roaming\NEXO Desktop" in plan["data_paths"]
+    assert r"C:\Users\nero\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\NEXO Desktop.lnk" in plan["shortcut_paths"]
+    assert plan["tasks"] == ["\\NEXO Desktop"]
+
+
+def test_windows_runtime_status_reports_host_interop_flag(monkeypatch):
+    monkeypatch.setenv("NEXO_WINDOWS_HOST", "1")
+    monkeypatch.setenv("NEXO_WINDOWS_BRIDGE", "1")
+    monkeypatch.setenv("WSL_DISTRO_NAME", "Ubuntu")
+    monkeypatch.setenv("WSL_INTEROP", "/run/WSL/interop")
+
+    payload = windows_runtime_status(
+        candidate := __import__("pathlib").Path("/home/nero/.nexo"),
+        system="Linux",
+        release="6.6.87.2-microsoft-standard-WSL2",
+    )
+
+    assert payload["inside_wsl"] is True
+    assert payload["windows_host_bridge"] is True
+    assert "windows_host_interop" in payload

--- a/tests/test_windows_wsl_bridge_contract.py
+++ b/tests/test_windows_wsl_bridge_contract.py
@@ -49,20 +49,36 @@ console.log(JSON.stringify(payload));
         "NEXO_WINDOWS_HOST": "1",
         "NEXO_HOME": "/home/franciscoc/.nexo",
     }
-    assert payload["args"][:10] == [
+    assert payload["args"][:12] == [
         "-d",
         "Ubuntu-24.04",
+        "--cd",
+        "/home/franciscoc",
         "--exec",
         "env",
+        "-u",
+        "HOME",
         "-u",
         "NEXO_HOME",
         "-u",
         "NEXO_CODE",
+    ]
+    assert payload["args"][12:24] == [
         "-u",
         "NEXO_WSL_HOME",
+        "-u",
+        "NEXO_WSL_CODE",
+        "-u",
+        "USERPROFILE",
+        "-u",
+        "HOMEDRIVE",
+        "-u",
+        "HOMEPATH",
+        "HOME=/home/franciscoc",
+        "NEXO_WINDOWS_BRIDGE=1",
     ]
-    assert payload["args"][10:14] == ["-u", "NEXO_WSL_CODE", "NEXO_WINDOWS_BRIDGE=1", "NEXO_WINDOWS_HOST=1"]
-    assert payload["args"][14:] == [
+    assert payload["args"][24:] == [
+        "NEXO_WINDOWS_HOST=1",
         "NEXO_HOME=/home/franciscoc/.nexo",
         "node",
         "/mnt/c/Users/franciscoc/AppData/Roaming/npm/node_modules/nexo-brain/bin/nexo.js",
@@ -93,7 +109,7 @@ console.log(JSON.stringify(payload));
 
     payload = json.loads(result.stdout.strip())
     assert payload["translatedScriptPath"] == "/home/franciscoc/repo/bin/nexo-brain.js"
-    assert payload["args"][:2] == ["-d", "Ubuntu-24.04"]
+    assert payload["args"][:4] == ["-d", "Ubuntu-24.04", "--cd", "~"]
 
 
 def test_public_launchers_use_shared_wsl_bridge_helper() -> None:


### PR DESCRIPTION
## Summary\n- preserve the canonical Linux home when bridging from Windows host into WSL\n- inspect Windows host runtime surfaces and clean Desktop artifacts during uninstall\n- keep the Windows validation slice ready for the clean installer smoke\n\n## Testing\n- pytest -q tests/test_windows_wsl_bridge_contract.py\n- pytest -q tests/test_windows_runtime.py\n