### PR TITLE
Release v7.12.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "7.12.2",
+  "version": "7.12.3",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [7.12.3] - 2026-05-02
+
+### Fixed
+- **Windows 11 clean install no longer hangs at the Brain bootstrap stage.** The WSL bridge (`bin/windows-wsl-bridge.js`) now stages multi-KB shell scripts to a file and invokes `dash <file>` instead of `dash -c "<inline>"`, inserts a `--` separator before `env -i` so `wsl.exe` does not consume `-u VAR` flags, and exports a defensive `PATH` fallback so subshells never see an empty PATH.
+- **Bundle-aware bootstrap detects `claude-code .tgz`, Python wheels, and pre-staged models in `<package>/{claude-code,python-wheels,models}` and runs offline-first.** `bin/nexo-brain.js` installs `claude-code` from the local tarball with `npm install -g`, runs `pip install --no-index --find-links` against the bundled wheels, and copies the prebuilt embedding/reranker models into the runtime so a fresh first-install does not need any network access.
+- **`fastembed` is pinned to `>=0.8.0` in `src/requirements.txt`** so pip stops iterating over older incompatible releases on Python 3.12.
+- **`finalizeF06Layout` now points `PYTHONPATH` at `runtimeCodeDir(nexoHome)` instead of `nexoHome`,** unblocking `import auto_update` during the final stage of a fresh install.
+
+### Tests
+- `pytest tests/test_windows_wsl_bridge_contract.py tests/test_packaged_update_runtime.py` → green
+- `python3 scripts/verify_client_parity.py` → 194 passed
+
 ## [7.12.2] - 2026-04-30
 
 ### Fixed

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 7.12.2
+version: 7.12.3
 metadata:
   openclaw:
     requires:

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "7.12.2",
+  "version": "7.12.3",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "7.12.2" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "7.12.3" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "7.12.2",
+  "version": "7.12.3",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",


### PR DESCRIPTION
## Summary

Patch release that ships the Win11 clean install fixes already on main (PR #321):
- Bundle-aware bootstrap (claude-code .tgz + python wheels + LLM models offline).
- Per-user WSL distro fallback.
- Hardened bridge with file-staged shell script + dash, sanitized env (-i + --).
- `fastembed>=0.8.0` pin.
- `finalizeF06Layout` PYTHONPATH fix.

No new features vs 7.12.2 — same fixes, version bump so the npm package + Desktop bundle pick them up. Tag `v7.12.3` already pushed; npm publish workflow running.

## Test plan
- [x] `python3 scripts/sync_release_artifacts.py --release-version 7.12.3` synced 4 derived files
- [x] `python3 scripts/verify_client_parity.py` → 194 passed, parity OK
- [ ] CI publish workflow completes (npm publish, etc.)
