### PR TITLE
release: brain 7.23.3 followup done filtering

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "7.23.2",
+  "version": "7.23.3",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/.well-known/llms.txt
+++ b/.well-known/llms.txt
@@ -1,9 +1,11 @@
 # NEXO Brain
 
-> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v7.23.0). NEXO Desktop is a separate closed-source companion app distributed at nexo-desktop.com; its source does not ship in this repo. Mentions of "NEXO Desktop" in changelog entries describe coordinated client releases that consume the Brain CLI / MCP contract. For the commercial Desktop product, contact info@wazion.com.
+> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v7.23.3). NEXO Desktop is a separate closed-source companion app distributed at nexo-desktop.com; its source does not ship in this repo. Mentions of "NEXO Desktop" in changelog entries describe coordinated client releases that consume the Brain CLI / MCP contract. For the commercial Desktop product, contact info@wazion.com.
 
 NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. It adds a local shared brain across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, smarter retrieval defaults, long-horizon overnight analysis, and 150+ MCP tools.
 
+v7.23.3: patch release. Followup runner executable batches now treat DONE as a terminal status alongside BLOCKED, ARCHIVED, DELETED and WAITING, so already-finished followups are not reselected.
+v7.23.2: patch release. Desktop-facing version checks refresh stale latest-version cache entries when the cached latest version is missing, equal, or older than the installed Brain version, so a just-published update is not hidden in Desktop.
 v7.23.0: minor release. Pre-answer routing consults continuity evidence before visible replies, Memory Observations queue processing converges through bounded repair/backfill, and read-only audits expose saved-but-not-used stores, automation drift excluding Evolution, MCP live/catalog gaps, transcript coverage and artifact locations.
 v7.20.24: patch release. Local Memory performance profile writes now retry transient SQLite busy states, close stale connections between attempts, and shorten indexer write locks so Desktop can save indexing speed while indexing is active.
 v7.20.23: patch release. Local Memory status reads the real split sidecar database read-only, returns retryable keyed errors without false zeroes when the sidecar is busy or invalid, and keeps Desktop recovery copy localizable in Spanish and English.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [7.23.3] - 2026-05-19
+
+### Fixed — Followup runner status filtering
+
+- **Followup runner no longer reselects already-done followups.** The executable batch query now treats `DONE` as terminal alongside `BLOCKED`, `ARCHIVED`, `DELETED` and `WAITING`, preserving the local runtime fix found during release cleanup.
+- **Coverage:** static followup-runner regression test for the `DONE` terminal status.
+
 ## [7.23.2] - 2026-05-19
 
 ### Fixed — Desktop Brain update detection

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@
 
 [Watch the overview video](https://nexo-brain.com/watch/) · [Watch on YouTube](https://www.youtube.com/watch?v=i2lkGhKyVqI) · [Open the infographic](https://nexo-brain.com/assets/nexo-brain-infographic-v5.png)
 
-Version `7.23.2` is the current packaged-runtime line. Patch over v7.23.1 - Desktop-facing version checks refresh stale latest-version cache entries so a just-published Brain update can still appear inside NEXO Desktop.
+Version `7.23.3` is the current packaged-runtime line. Patch over v7.23.2 - Followup runner skips DONE terminal statuses so already-finished followups do not re-enter executable batches.
+
+Previously in `7.23.2`: patch over v7.23.1 - Desktop-facing version checks refresh stale latest-version cache entries so a just-published Brain update can still appear inside NEXO Desktop.
 
 Previously in `7.23.1`: express patch over v7.23.0 - headless automations no longer hang on silent Claude children, synthetic followup prompts no longer trigger session-end loops, and runtime backups self-prune under a hard cap before creating new large artifacts.
 

--- a/blog/index.html
+++ b/blog/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Blog — NEXO Brain</title>
-    <meta name="description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the current 7.23.2 Desktop update detection patch.">
+    <meta name="description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the current 7.23.3 followup runner status filtering patch.">
     <meta name="robots" content="index, follow">
     <link rel="canonical" href="https://nexo-brain.com/blog/">
 
@@ -12,7 +12,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://nexo-brain.com/blog/">
     <meta property="og:title" content="Blog — NEXO Brain">
-    <meta property="og:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the current 7.23.2 Desktop update detection patch.">
+    <meta property="og:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the current 7.23.3 followup runner status filtering patch.">
     <meta property="og:image" content="https://nexo-brain.com/assets/og/og-blog.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -20,7 +20,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Blog — NEXO Brain">
-    <meta name="twitter:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the current 7.23.2 Desktop update detection patch.">
+    <meta name="twitter:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the current 7.23.3 followup runner status filtering patch.">
     <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-blog.png">
 
     <script type="application/ld+json">
@@ -28,7 +28,7 @@
         "@context": "https://schema.org",
         "@type": "CollectionPage",
         "name": "Blog — NEXO Brain",
-        "description": "Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the current 7.23.2 Desktop update detection patch.",
+        "description": "Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the current 7.23.3 followup runner status filtering patch.",
         "url": "https://nexo-brain.com/blog/",
         "isPartOf": {
             "@type": "WebSite",
@@ -134,7 +134,7 @@
                     <span class="page-chip">Shared brain product notes</span>
                 </div>
                 <div class="hero-actions" style="justify-content:flex-start;">
-                    <a href="/blog/nexo-7-23-2/" class="btn btn-primary">Read latest release</a>
+                    <a href="/blog/nexo-7-23-3/" class="btn btn-primary">Read latest release</a>
                     <a href="/changelog/" class="btn btn-secondary">Latest release notes</a>
                     <a href="/evolution/" class="btn btn-secondary">See Evolution</a>
                 </div>
@@ -144,20 +144,20 @@
                 <div class="section-label">Latest release</div>
                 <div class="blog-featured-meta">
                     <span class="compare-chip">May 19, 2026</span>
-                    <span class="compare-chip">Desktop update checks</span>
-                    <span class="compare-chip">Latest cache refresh</span>
+                    <span class="compare-chip">Followup runner</span>
+                    <span class="compare-chip">DONE status</span>
                     <span class="compare-chip">Patch</span>
                 </div>
-                <h2>NEXO 7.23.2: fresh Desktop Brain update detection</h2>
-                <p>Patch over v7.23.1. Desktop-facing version checks refresh stale latest-version cache entries when a Brain release publishes shortly after a user checked versions.</p>
+                <h2>NEXO 7.23.3: followup runner DONE filtering</h2>
+                <p>Patch over v7.23.2. Followup runner executable batches now treat DONE as terminal, so already-finished followups do not re-enter automation queues.</p>
                 <div class="hero-actions" style="justify-content:flex-start;margin-bottom:18px;">
-                    <a href="/blog/nexo-7-23-2/" class="btn btn-primary">Open article</a>
-                    <a href="/changelog/#v7232" class="btn btn-secondary">Open changelog</a>
+                    <a href="/blog/nexo-7-23-3/" class="btn btn-primary">Open article</a>
+                    <a href="/changelog/#v7233" class="btn btn-secondary">Open changelog</a>
                 </div>
                 <div class="blog-mini-stack">
                     <div class="blog-mini-card">
                         <strong>Companion view</strong>
-                        <span><a href="/changelog/#v7232">See the full v7.23.2 changelog</a></span>
+                        <span><a href="/changelog/#v7233">See the full v7.23.3 changelog</a></span>
                     </div>
                     <div class="blog-mini-card">
                         <strong>Previous release</strong>
@@ -195,10 +195,10 @@
 
             <div class="blog-card">
                 <div class="blog-card-date">May 19, 2026</div>
-                <h2><a href="/blog/nexo-7-23-2/">NEXO 7.23.2: fresh Desktop Brain update detection</a></h2>
-                <p>Patch release. Desktop-facing version checks refresh stale latest-version cache entries so freshly published Brain updates are not hidden by an older local check.</p>
+                <h2><a href="/blog/nexo-7-23-3/">NEXO 7.23.3: followup runner DONE filtering</a></h2>
+                <p>Patch release. Followup runner executable batches now exclude DONE items alongside the other terminal statuses.</p>
                 <div class="hero-actions" style="justify-content:flex-start;">
-                    <a href="/blog/nexo-7-23-2/" class="btn btn-secondary">Read more</a>
+                    <a href="/blog/nexo-7-23-3/" class="btn btn-secondary">Read more</a>
                 </div>
             </div>
 

--- a/blog/nexo-7-23-3/index.html
+++ b/blog/nexo-7-23-3/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>NEXO 7.23.3: followup runner DONE filtering</title>
+<meta name="description" content="NEXO Brain v7.23.3 keeps followup runner batches from reselecting DONE items.">
+<meta name="robots" content="index, follow">
+<link rel="canonical" href="https://nexo-brain.com/blog/nexo-7-23-3/">
+<link rel="stylesheet" href="/assets/style.css">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"NEXO 7.23.3: followup runner DONE filtering","datePublished":"2026-05-19","author":{"@type":"Person","name":"Francisco Cerda Puigserver"},"publisher":{"@type":"Organization","name":"WAzion"}}</script>
+</head>
+<body class="features-page">
+<main class="section-compact">
+<div class="container" style="max-width:860px;">
+<p class="section-label">Release notes</p>
+<h1>NEXO 7.23.3 - followup runner DONE filtering</h1>
+<p>v7.23.3 is a small Brain patch for followup automation hygiene. The followup runner executable-batch query now treats DONE as terminal alongside BLOCKED, ARCHIVED, DELETED and WAITING.</p>
+<p>The practical fix is that already-finished followups stay out of automation queues instead of being picked up again during background execution.</p>
+<pre><code>scripts/pre-release-verify.sh --release v7.23.3
+# release gate for Brain 7.23.3</code></pre>
+<p><a href="/changelog/#v7233">Read the full v7.23.3 changelog</a></p>
+</div>
+</main>
+</body>
+</html>

--- a/changelog/index.html
+++ b/changelog/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Changelog — NEXO Brain</title>
-    <meta name="description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v7.23.2 refreshes stale Desktop-facing latest-version cache entries during Brain update checks.">
+    <meta name="description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v7.23.3 keeps followup runner batches from reselecting DONE items.">
     <meta name="robots" content="index, follow">
     <link rel="canonical" href="https://nexo-brain.com/changelog/">
 
@@ -12,7 +12,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://nexo-brain.com/changelog/">
     <meta property="og:title" content="Changelog — NEXO Brain">
-    <meta property="og:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v7.23.2 refreshes stale Desktop-facing latest-version cache entries during Brain update checks.">
+    <meta property="og:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v7.23.3 keeps followup runner batches from reselecting DONE items.">
     <meta property="og:image" content="https://nexo-brain.com/assets/og/og-changelog.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -20,7 +20,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Changelog — NEXO Brain">
-    <meta name="twitter:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v7.23.2 refreshes stale Desktop-facing latest-version cache entries during Brain update checks.">
+    <meta name="twitter:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v7.23.3 keeps followup runner batches from reselecting DONE items.">
     <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-changelog.png">
 
     <script type="application/ld+json">
@@ -28,7 +28,7 @@
         "@context": "https://schema.org",
         "@type": "CollectionPage",
         "name": "Changelog — NEXO Brain",
-        "description": "Full version history for NEXO Brain cognitive runtime. Latest release: v7.23.2 refreshes stale Desktop-facing latest-version cache entries during Brain update checks.",
+        "description": "Full version history for NEXO Brain cognitive runtime. Latest release: v7.23.3 keeps followup runner batches from reselecting DONE items.",
         "url": "https://nexo-brain.com/changelog/",
         "isPartOf": {
             "@type": "WebSite",
@@ -87,13 +87,13 @@
                 <h1 class="section-title" style="font-size:clamp(32px,5vw,56px);">Changelog</h1>
                 <p class="section-subtitle">Every feature, fix, and improvement &mdash; from the beginning, with the same visual clarity as the rest of the site.</p>
                 <div class="page-chip-row">
-                    <span class="page-chip">v7.23.2 live</span>
+                    <span class="page-chip">v7.23.3 live</span>
                     <span class="page-chip">Local Context Layer</span>
                     <span class="page-chip">Background memory index</span>
                     <span class="page-chip">Desktop 0.33.0 companion</span>
                 </div>
                 <div class="hero-actions" style="justify-content:flex-start;">
-                    <a href="#v7232" class="btn btn-primary">Start with v7.23.2</a>
+                    <a href="#v7233" class="btn btn-primary">Start with v7.23.3</a>
                     <a href="#v7122" class="btn btn-secondary">See v7.12.2</a>
                     <a href="/evolution/" class="btn btn-secondary">See Evolution</a>
                 </div>
@@ -101,8 +101,8 @@
             <div class="page-visual">
                 <div class="page-stack">
                     <div class="page-stack-card">
-                        <strong>v7.23.2</strong>
-                        <span>Patch - Desktop-facing version checks refresh stale latest cache entries so new Brain updates remain visible.</span>
+                        <strong>v7.23.3</strong>
+                        <span>Patch - Followup runner executable batches skip DONE terminal statuses.</span>
                     </div>
                     <div class="page-stack-card">
                         <strong>v7.17.8</strong>
@@ -347,11 +347,11 @@
     </div>
 </section>
 
-<section id="v7232" class="section-compact" style="background:linear-gradient(135deg,#0f172a 0%,#0ea5e9 100%);">
+<section id="v7233" class="section-compact" style="background:linear-gradient(135deg,#0f172a 0%,#0ea5e9 100%);">
     <div class="container">
-        <div class="section-label">New in v7.23.2 <span style="opacity:.5;font-weight:400;">&mdash; May 19, 2026 &mdash; <strong>PATCH</strong></span></div>
-        <h2 class="section-title">Fresh Desktop Brain update detection</h2>
-        <p class="section-subtitle">Desktop-facing version checks refresh stale latest-version cache entries when the cached latest version is missing, equal, or older than the installed Brain version, so a just-published update remains visible inside NEXO Desktop.</p>
+        <div class="section-label">New in v7.23.3 <span style="opacity:.5;font-weight:400;">&mdash; May 19, 2026 &mdash; <strong>PATCH</strong></span></div>
+        <h2 class="section-title">Followup runner DONE filtering</h2>
+        <p class="section-subtitle">Followup runner executable batches now treat DONE as terminal alongside BLOCKED, ARCHIVED, DELETED and WAITING, so already-finished followups do not re-enter automation queues.</p>
     </div>
 </section>
 

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 7.23.2
+version: 7.23.3
 metadata:
   openclaw:
     requires:

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents</title>
-    <meta name="description" content="Libre/open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients. Version 7.23.2 keeps Desktop-facing Brain update detection fresh when releases publish minutes after a version check.">
+    <meta name="description" content="Libre/open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients. Version 7.23.3 keeps followup runner batches from reselecting DONE items.">
     <meta name="keywords" content="AI memory, cognitive architecture, MCP, Claude Code, Codex, Claude Desktop, agent memory, vector search, AI agents, shared brain, open source">
     <meta name="author" content="WAzion">
     <meta name="robots" content="index, follow">
@@ -14,7 +14,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://nexo-brain.com">
     <meta property="og:title" content="NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents">
-    <meta property="og:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 7.23.2 keeps Desktop-facing Brain update detection fresh when releases publish minutes after a version check.">
+    <meta property="og:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 7.23.3 keeps followup runner batches from reselecting DONE items.">
     <meta property="og:image" content="https://nexo-brain.com/assets/og/og-home.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -22,7 +22,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents">
-    <meta name="twitter:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 7.23.2 keeps Desktop-facing Brain update detection fresh when releases publish minutes after a version check.">
+    <meta name="twitter:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 7.23.3 keeps followup runner batches from reselecting DONE items.">
     <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-home.png">
 
     <!-- Google Analytics (GA4) -->
@@ -46,12 +46,12 @@
         "@context": "https://schema.org",
         "@type": "SoftwareApplication",
         "name": "NEXO Brain",
-        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 7.23.2 keeps Desktop-facing Brain update detection fresh when releases publish minutes after a version check.",
+        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 7.23.3 keeps followup runner batches from reselecting DONE items.",
         "applicationCategory": "DeveloperApplication",
         "operatingSystem": "macOS, Linux, Windows",
         "url": "https://nexo-brain.com",
         "downloadUrl": "https://www.npmjs.com/package/nexo-brain",
-        "softwareVersion": "7.23.2",
+        "softwareVersion": "7.23.3",
         "license": "https://www.gnu.org/licenses/agpl-3.0",
         "author": {
             "@type": "Organization",
@@ -697,7 +697,7 @@
     <div class="container">
         <div class="hero-badge fade-up">
             <span class="dot"></span>
-            <span id="version-badge">v7.23.2</span> Patch release - Desktop-facing version checks refresh stale latest cache entries after a new Brain release. <a href="/changelog/#v7232">Read the v7.23.2 notes</a>.
+            <span id="version-badge">v7.23.3</span> Patch release - Followup runner skips DONE terminal statuses during executable batch selection. <a href="/changelog/#v7233">Read the v7.23.3 notes</a>.
         </div>
         <div class="fade-up" style="display:flex;gap:8px;justify-content:center;margin-bottom:12px;">
             <img src="https://img.shields.io/npm/v/nexo-brain?color=7C3AED&label=npm" alt="npm version">

--- a/llms.txt
+++ b/llms.txt
@@ -1,9 +1,10 @@
 # NEXO Brain
 
-> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v7.23.2). NEXO Desktop is a separate closed-source companion app distributed at nexo-desktop.com; its source does not ship in this repo. Mentions of "NEXO Desktop" in changelog entries describe coordinated client releases that consume the Brain CLI / MCP contract. For the commercial Desktop product, contact info@wazion.com.
+> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v7.23.3). NEXO Desktop is a separate closed-source companion app distributed at nexo-desktop.com; its source does not ship in this repo. Mentions of "NEXO Desktop" in changelog entries describe coordinated client releases that consume the Brain CLI / MCP contract. For the commercial Desktop product, contact info@wazion.com.
 
 NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. It adds a local shared brain across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, smarter retrieval defaults, long-horizon overnight analysis, and 150+ MCP tools.
 
+v7.23.3: patch release. Followup runner executable batches now treat DONE as a terminal status alongside BLOCKED, ARCHIVED, DELETED and WAITING, so already-finished followups are not reselected.
 v7.23.2: patch release. Desktop-facing version checks refresh stale latest-version cache entries when the cached latest version is missing, equal, or older than the installed Brain version, so a just-published update is not hidden in Desktop.
 v7.23.0: minor release. Pre-answer routing consults continuity evidence before visible replies, Memory Observations queue processing converges through bounded repair/backfill, and read-only audits expose saved-but-not-used stores, automation drift excluding Evolution, MCP live/catalog gaps, transcript coverage and artifact locations.
 v7.22.0: minor release. Heartbeat stays fast in Desktop-managed sessions, MCP writes can be accepted through a durable file-backed queue before SQLite commit, Brain exposes compliance state for Desktop gates, and Local Context adds Entity Dossier for open-domain local evidence aggregation without changing the existing semantic search path.

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "7.23.2",
+  "version": "7.23.3",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "7.23.2" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "7.23.3" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "7.23.2",
+  "version": "7.23.3",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -19,7 +19,7 @@
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://nexo-brain.com/blog/nexo-7-23-2/</loc>
+    <loc>https://nexo-brain.com/blog/nexo-7-23-3/</loc>
     <lastmod>2026-05-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>

--- a/src/scripts/nexo-followup-runner.py
+++ b/src/scripts/nexo-followup-runner.py
@@ -301,7 +301,7 @@ def get_all_active_followups(state: dict) -> dict:
         rows = conn.execute(
             "SELECT id, description, date, reasoning, verification, priority, recurrence, status, owner, updated_at "
             "FROM followups WHERE status NOT LIKE 'COMPLETED%' "
-            "AND UPPER(COALESCE(status, '')) NOT IN ('BLOCKED', 'ARCHIVED', 'DELETED', 'WAITING') "
+            "AND UPPER(COALESCE(status, '')) NOT IN ('BLOCKED', 'ARCHIVED', 'DELETED', 'WAITING', 'DONE') "
             "AND description NOT LIKE '[Abandoned]%' "
             "ORDER BY "
             "  CASE priority "

--- a/tests/test_followup_triage_static.py
+++ b/tests/test_followup_triage_static.py
@@ -15,6 +15,12 @@ def test_followup_runner_triages_stale_items_out_of_executable_batch():
     assert "MAX_NEEDS_OPERATOR_BRIEFING" in src
 
 
+def test_followup_runner_excludes_done_status_from_executable_batch():
+    src = (REPO_ROOT / "src" / "scripts" / "nexo-followup-runner.py").read_text(encoding="utf-8")
+
+    assert "'BLOCKED', 'ARCHIVED', 'DELETED', 'WAITING', 'DONE'" in src
+
+
 def test_followup_hygiene_escalates_stale_items_instead_of_only_logging():
     src = (REPO_ROOT / "src" / "scripts" / "nexo-followup-hygiene.py").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- release Brain 7.23.3 with followup runner DONE terminal-status filtering
- preserve the local runtime cleanup fix found in the canonical checkout
- update public release surfaces and gh-pages readiness inputs

## Verification
- pytest tests/test_followup_triage_static.py -q: 3 passed
- python3 scripts/verify_release_readiness.py --ci: 219 passed, website OK, release-readiness OK
- scripts/pre-release-verify.sh --release v7.23.3: 5 passed, 0 failed, 0 skipped; pytest 2761 passed, 2 skipped, 1 xfailed, 4 xpassed