### PR TITLE
release: brain 7.23.4 publish verification

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "7.23.3",
+  "version": "7.23.4",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [7.23.4] - 2026-05-20
+
+### Fixed — Release publish verification
+
+- **Brain release tags now fail when npm publication fails.** The publish workflow no longer turns every `npm publish` error into "Version already exists"; it only tolerates real already-published responses and then verifies the exact version in the public npm registry.
+- **OpenClaw release metadata stays fully synchronized.** The release artifact synchronizer now updates `openclaw-plugin/package-lock.json` alongside `package.json`, `openclaw.plugin.json` and the MCP bridge version, preventing packaged OpenClaw releases from carrying stale lockfile metadata.
+- **Coverage:** GitHub PR checks for release readiness, OpenClaw packaging, ClawHub metadata, client parity, lint/security and full pytest, plus local full pytest and OpenClaw build/test/pack validation.
+
 ## [7.23.3] - 2026-05-19
 
 ### Fixed — Followup runner status filtering

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@
 
 [Watch the overview video](https://nexo-brain.com/watch/) · [Watch on YouTube](https://www.youtube.com/watch?v=i2lkGhKyVqI) · [Open the infographic](https://nexo-brain.com/assets/nexo-brain-infographic-v5.png)
 
-Version `7.23.3` is the current packaged-runtime line. Patch over v7.23.2 - Followup runner skips DONE terminal statuses so already-finished followups do not re-enter executable batches.
+Version `7.23.4` is the current packaged-runtime line. Patch over v7.23.3 - release tags now fail closed when npm publication fails and OpenClaw lockfile metadata stays synchronized with the release version.
+
+Previously in `7.23.3`: patch over v7.23.2 - Followup runner skips DONE terminal statuses so already-finished followups do not re-enter executable batches.
 
 Previously in `7.23.2`: patch over v7.23.1 - Desktop-facing version checks refresh stale latest-version cache entries so a just-published Brain update can still appear inside NEXO Desktop.
 

--- a/blog/index.html
+++ b/blog/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Blog — NEXO Brain</title>
-    <meta name="description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the current 7.23.3 followup runner status filtering patch.">
+    <meta name="description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the current 7.23.4 release publish verification patch.">
     <meta name="robots" content="index, follow">
     <link rel="canonical" href="https://nexo-brain.com/blog/">
 
@@ -12,7 +12,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://nexo-brain.com/blog/">
     <meta property="og:title" content="Blog — NEXO Brain">
-    <meta property="og:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the current 7.23.3 followup runner status filtering patch.">
+    <meta property="og:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the current 7.23.4 release publish verification patch.">
     <meta property="og:image" content="https://nexo-brain.com/assets/og/og-blog.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -20,7 +20,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Blog — NEXO Brain">
-    <meta name="twitter:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the current 7.23.3 followup runner status filtering patch.">
+    <meta name="twitter:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the current 7.23.4 release publish verification patch.">
     <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-blog.png">
 
     <script type="application/ld+json">
@@ -28,7 +28,7 @@
         "@context": "https://schema.org",
         "@type": "CollectionPage",
         "name": "Blog — NEXO Brain",
-        "description": "Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the current 7.23.3 followup runner status filtering patch.",
+        "description": "Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the current 7.23.4 release publish verification patch.",
         "url": "https://nexo-brain.com/blog/",
         "isPartOf": {
             "@type": "WebSite",
@@ -134,7 +134,7 @@
                     <span class="page-chip">Shared brain product notes</span>
                 </div>
                 <div class="hero-actions" style="justify-content:flex-start;">
-                    <a href="/blog/nexo-7-23-3/" class="btn btn-primary">Read latest release</a>
+                    <a href="/blog/nexo-7-23-4/" class="btn btn-primary">Read latest release</a>
                     <a href="/changelog/" class="btn btn-secondary">Latest release notes</a>
                     <a href="/evolution/" class="btn btn-secondary">See Evolution</a>
                 </div>
@@ -143,21 +143,21 @@
             <div class="blog-featured-card">
                 <div class="section-label">Latest release</div>
                 <div class="blog-featured-meta">
-                    <span class="compare-chip">May 19, 2026</span>
-                    <span class="compare-chip">Followup runner</span>
-                    <span class="compare-chip">DONE status</span>
+                    <span class="compare-chip">May 20, 2026</span>
+                    <span class="compare-chip">npm publish</span>
+                    <span class="compare-chip">OpenClaw lockfile</span>
                     <span class="compare-chip">Patch</span>
                 </div>
-                <h2>NEXO 7.23.3: followup runner DONE filtering</h2>
-                <p>Patch over v7.23.2. Followup runner executable batches now treat DONE as terminal, so already-finished followups do not re-enter automation queues.</p>
+                <h2>NEXO 7.23.4: release publish verification</h2>
+                <p>Patch over v7.23.3. Brain release tags now stop on real npm publish failures, verify exact registry versions, and keep OpenClaw lockfile metadata synchronized.</p>
                 <div class="hero-actions" style="justify-content:flex-start;margin-bottom:18px;">
-                    <a href="/blog/nexo-7-23-3/" class="btn btn-primary">Open article</a>
-                    <a href="/changelog/#v7233" class="btn btn-secondary">Open changelog</a>
+                    <a href="/blog/nexo-7-23-4/" class="btn btn-primary">Open article</a>
+                    <a href="/changelog/#v7234" class="btn btn-secondary">Open changelog</a>
                 </div>
                 <div class="blog-mini-stack">
                     <div class="blog-mini-card">
                         <strong>Companion view</strong>
-                        <span><a href="/changelog/#v7233">See the full v7.23.3 changelog</a></span>
+                        <span><a href="/changelog/#v7234">See the full v7.23.4 changelog</a></span>
                     </div>
                     <div class="blog-mini-card">
                         <strong>Previous release</strong>
@@ -192,6 +192,15 @@
 <section class="section-flush-top">
     <div class="container">
             <div class="blog-grid">
+
+            <div class="blog-card">
+                <div class="blog-card-date">May 20, 2026</div>
+                <h2><a href="/blog/nexo-7-23-4/">NEXO 7.23.4: release publish verification</a></h2>
+                <p>Patch release. npm publish errors now stop Brain release tags unless they are real already-published responses, and OpenClaw lockfile metadata stays in sync.</p>
+                <div class="hero-actions" style="justify-content:flex-start;">
+                    <a href="/blog/nexo-7-23-4/" class="btn btn-secondary">Read more</a>
+                </div>
+            </div>
 
             <div class="blog-card">
                 <div class="blog-card-date">May 19, 2026</div>

--- a/blog/nexo-7-23-4/index.html
+++ b/blog/nexo-7-23-4/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>NEXO 7.23.4: release publish verification</title>
+<meta name="description" content="NEXO Brain v7.23.4 fail-closes npm release publishing and keeps OpenClaw lockfile metadata synchronized.">
+<meta name="robots" content="index, follow">
+<link rel="canonical" href="https://nexo-brain.com/blog/nexo-7-23-4/">
+<link rel="stylesheet" href="/assets/style.css">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"NEXO 7.23.4: release publish verification","datePublished":"2026-05-20","author":{"@type":"Person","name":"Francisco Cerda Puigserver"},"publisher":{"@type":"Organization","name":"WAzion"}}</script>
+</head>
+<body class="features-page">
+<main class="section-compact">
+<div class="container" style="max-width:860px;">
+<p class="section-label">Release notes</p>
+<h1>NEXO 7.23.4 - release publish verification</h1>
+<p>v7.23.4 is a Brain release-engineering patch. The publish workflow now stops on real npm publication failures instead of turning every failed publish into a misleading "Version already exists" message.</p>
+<p>The release also keeps OpenClaw package-lock metadata synchronized with the public package version, so package.json, lockfile, ClawHub metadata and the MCP bridge version move together.</p>
+<pre><code>python3 scripts/verify_release_readiness.py --ci
+npm view nexo-brain@7.23.4 version
+npm view @wazionapps/openclaw-memory-nexo-brain@7.23.4 version</code></pre>
+<p><a href="/changelog/#v7234">Read the full v7.23.4 changelog</a></p>
+</div>
+</main>
+</body>
+</html>

--- a/changelog/index.html
+++ b/changelog/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Changelog — NEXO Brain</title>
-    <meta name="description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v7.23.3 keeps followup runner batches from reselecting DONE items.">
+    <meta name="description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v7.23.4 fail-closes npm publish verification and synchronizes OpenClaw lockfile metadata.">
     <meta name="robots" content="index, follow">
     <link rel="canonical" href="https://nexo-brain.com/changelog/">
 
@@ -12,7 +12,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://nexo-brain.com/changelog/">
     <meta property="og:title" content="Changelog — NEXO Brain">
-    <meta property="og:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v7.23.3 keeps followup runner batches from reselecting DONE items.">
+    <meta property="og:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v7.23.4 fail-closes npm publish verification and synchronizes OpenClaw lockfile metadata.">
     <meta property="og:image" content="https://nexo-brain.com/assets/og/og-changelog.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -20,7 +20,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Changelog — NEXO Brain">
-    <meta name="twitter:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v7.23.3 keeps followup runner batches from reselecting DONE items.">
+    <meta name="twitter:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v7.23.4 fail-closes npm publish verification and synchronizes OpenClaw lockfile metadata.">
     <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-changelog.png">
 
     <script type="application/ld+json">
@@ -28,7 +28,7 @@
         "@context": "https://schema.org",
         "@type": "CollectionPage",
         "name": "Changelog — NEXO Brain",
-        "description": "Full version history for NEXO Brain cognitive runtime. Latest release: v7.23.3 keeps followup runner batches from reselecting DONE items.",
+        "description": "Full version history for NEXO Brain cognitive runtime. Latest release: v7.23.4 fail-closes npm publish verification and synchronizes OpenClaw lockfile metadata.",
         "url": "https://nexo-brain.com/changelog/",
         "isPartOf": {
             "@type": "WebSite",
@@ -87,13 +87,13 @@
                 <h1 class="section-title" style="font-size:clamp(32px,5vw,56px);">Changelog</h1>
                 <p class="section-subtitle">Every feature, fix, and improvement &mdash; from the beginning, with the same visual clarity as the rest of the site.</p>
                 <div class="page-chip-row">
-                    <span class="page-chip">v7.23.3 live</span>
+                    <span class="page-chip">v7.23.4 live</span>
                     <span class="page-chip">Local Context Layer</span>
                     <span class="page-chip">Background memory index</span>
                     <span class="page-chip">Desktop 0.33.0 companion</span>
                 </div>
                 <div class="hero-actions" style="justify-content:flex-start;">
-                    <a href="#v7233" class="btn btn-primary">Start with v7.23.3</a>
+                    <a href="#v7234" class="btn btn-primary">Start with v7.23.4</a>
                     <a href="#v7122" class="btn btn-secondary">See v7.12.2</a>
                     <a href="/evolution/" class="btn btn-secondary">See Evolution</a>
                 </div>
@@ -101,8 +101,8 @@
             <div class="page-visual">
                 <div class="page-stack">
                     <div class="page-stack-card">
-                        <strong>v7.23.3</strong>
-                        <span>Patch - Followup runner executable batches skip DONE terminal statuses.</span>
+                        <strong>v7.23.4</strong>
+                        <span>Patch - release tags fail closed on npm publish failures and OpenClaw lockfile metadata stays synchronized.</span>
                     </div>
                     <div class="page-stack-card">
                         <strong>v7.17.8</strong>
@@ -344,6 +344,14 @@
 <section class="section-compact" style="background:rgba(124,58,237,0.08);">
     <div class="container desktop-disclaimer" style="max-width:860px;font-size:13px;line-height:1.55;">
         <p><strong>About NEXO Desktop.</strong> NEXO Desktop is a separate closed-source companion client distributed at <a href="https://nexo-desktop.com/">nexo-desktop.com</a>. When a changelog entry mentions NEXO Desktop it refers to a coordinated client release that consumes the Brain CLI/MCP contract. Desktop source does not live in this repo; the Brain (AGPL-3.0) remains fully usable on its own from terminal, Codex, Claude Code, or any MCP client.</p>
+    </div>
+</section>
+
+<section id="v7234" class="section-compact" style="background:linear-gradient(135deg,#0f172a 0%,#0ea5e9 100%);">
+    <div class="container">
+        <div class="section-label">New in v7.23.4 <span style="opacity:.5;font-weight:400;">&mdash; May 20, 2026 &mdash; <strong>PATCH</strong></span></div>
+        <h2 class="section-title">Release publish verification</h2>
+        <p class="section-subtitle">Brain release tags now fail when npm publication fails, verify the exact public registry version after publish, and keep OpenClaw package-lock metadata synchronized with release artifacts.</p>
     </div>
 </section>
 

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 7.23.3
+version: 7.23.4
 metadata:
   openclaw:
     requires:

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents</title>
-    <meta name="description" content="Libre/open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients. Version 7.23.3 keeps followup runner batches from reselecting DONE items.">
+    <meta name="description" content="Libre/open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients. Version 7.23.4 fail-closes npm release publishing and synchronizes OpenClaw lockfile metadata.">
     <meta name="keywords" content="AI memory, cognitive architecture, MCP, Claude Code, Codex, Claude Desktop, agent memory, vector search, AI agents, shared brain, open source">
     <meta name="author" content="WAzion">
     <meta name="robots" content="index, follow">
@@ -14,7 +14,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://nexo-brain.com">
     <meta property="og:title" content="NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents">
-    <meta property="og:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 7.23.3 keeps followup runner batches from reselecting DONE items.">
+    <meta property="og:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 7.23.4 fail-closes npm release publishing and synchronizes OpenClaw lockfile metadata.">
     <meta property="og:image" content="https://nexo-brain.com/assets/og/og-home.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -22,7 +22,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents">
-    <meta name="twitter:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 7.23.3 keeps followup runner batches from reselecting DONE items.">
+    <meta name="twitter:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 7.23.4 fail-closes npm release publishing and synchronizes OpenClaw lockfile metadata.">
     <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-home.png">
 
     <!-- Google Analytics (GA4) -->
@@ -46,12 +46,12 @@
         "@context": "https://schema.org",
         "@type": "SoftwareApplication",
         "name": "NEXO Brain",
-        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 7.23.3 keeps followup runner batches from reselecting DONE items.",
+        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 7.23.4 fail-closes npm release publishing and synchronizes OpenClaw lockfile metadata.",
         "applicationCategory": "DeveloperApplication",
         "operatingSystem": "macOS, Linux, Windows",
         "url": "https://nexo-brain.com",
         "downloadUrl": "https://www.npmjs.com/package/nexo-brain",
-        "softwareVersion": "7.23.3",
+        "softwareVersion": "7.23.4",
         "license": "https://www.gnu.org/licenses/agpl-3.0",
         "author": {
             "@type": "Organization",
@@ -697,7 +697,7 @@
     <div class="container">
         <div class="hero-badge fade-up">
             <span class="dot"></span>
-            <span id="version-badge">v7.23.3</span> Patch release - Followup runner skips DONE terminal statuses during executable batch selection. <a href="/changelog/#v7233">Read the v7.23.3 notes</a>.
+            <span id="version-badge">v7.23.4</span> Patch release - npm publish failures now stop release tags and OpenClaw lockfile metadata stays synchronized. <a href="/changelog/#v7234">Read the v7.23.4 notes</a>.
         </div>
         <div class="fade-up" style="display:flex;gap:8px;justify-content:center;margin-bottom:12px;">
             <img src="https://img.shields.io/npm/v/nexo-brain?color=7C3AED&label=npm" alt="npm version">

--- a/llms.txt
+++ b/llms.txt
@@ -1,9 +1,10 @@
 # NEXO Brain
 
-> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v7.23.3). NEXO Desktop is a separate closed-source companion app distributed at nexo-desktop.com; its source does not ship in this repo. Mentions of "NEXO Desktop" in changelog entries describe coordinated client releases that consume the Brain CLI / MCP contract. For the commercial Desktop product, contact info@wazion.com.
+> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v7.23.4). NEXO Desktop is a separate closed-source companion app distributed at nexo-desktop.com; its source does not ship in this repo. Mentions of "NEXO Desktop" in changelog entries describe coordinated client releases that consume the Brain CLI / MCP contract. For the commercial Desktop product, contact info@wazion.com.
 
 NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. It adds a local shared brain across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, smarter retrieval defaults, long-horizon overnight analysis, and 150+ MCP tools.
 
+v7.23.4: patch release. Release tags now fail closed when npm publication fails, verify exact npm registry versions after publish, and keep OpenClaw package-lock metadata synchronized with release artifacts.
 v7.23.3: patch release. Followup runner executable batches now treat DONE as a terminal status alongside BLOCKED, ARCHIVED, DELETED and WAITING, so already-finished followups are not reselected.
 v7.23.2: patch release. Desktop-facing version checks refresh stale latest-version cache entries when the cached latest version is missing, equal, or older than the installed Brain version, so a just-published update is not hidden in Desktop.
 v7.23.0: minor release. Pre-answer routing consults continuity evidence before visible replies, Memory Observations queue processing converges through bounded repair/backfill, and read-only audits expose saved-but-not-used stores, automation drift excluding Evolution, MCP live/catalog gaps, transcript coverage and artifact locations.

--- a/openclaw-plugin/package-lock.json
+++ b/openclaw-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "7.23.3",
+  "version": "7.23.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wazionapps/openclaw-memory-nexo-brain",
-      "version": "7.23.3",
+      "version": "7.23.4",
       "license": "AGPL-3.0",
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "7.23.3",
+  "version": "7.23.4",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "7.23.3" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "7.23.4" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "7.23.3",
+  "version": "7.23.4",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -14,7 +14,13 @@
   </url>
   <url>
     <loc>https://nexo-brain.com/blog/</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-05-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://nexo-brain.com/blog/nexo-7-23-4/</loc>
+    <lastmod>2026-05-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>


### PR DESCRIPTION
## Summary
- bump Brain release surfaces to 7.23.4
- sync OpenClaw, Claude plugin, ClawHub skill, changelog, llms and website metadata
- add 7.23.4 blog/changelog public surfaces

## Verification
- scripts/pre-release-verify.sh --release v7.23.4
- release readiness: 219 passed
- pytest smoke: 2761 passed, 2 skipped, 1 xfailed, 4 xpassed
- npm pack --dry-run for nexo-brain and @wazionapps/openclaw-memory-nexo-brain