### PR TITLE
Fix LocalIndex update migration for legacy sidecars

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "7.25.5",
+  "version": "7.25.6",
   "description": "Local cognitive runtime for Claude Code \u2014 persistent memory, overnight learning, doctor diagnostics, personal scripts, recovery-aware jobs, startup preflight, and optional dashboard/power helper.",
   "author": {
     "name": "NEXO Brain",

--- a/.well-known/llms.txt
+++ b/.well-known/llms.txt
@@ -1,9 +1,10 @@
 # NEXO Brain
 
-> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v7.25.5). NEXO Desktop is a separate closed-source companion app distributed at nexo-desktop.com; its source does not ship in this repo. Mentions of "NEXO Desktop" in changelog entries describe coordinated client releases that consume the Brain CLI / MCP contract. For the commercial Desktop product, contact info@wazion.com.
+> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v7.25.6). NEXO Desktop is a separate closed-source companion app distributed at nexo-desktop.com; its source does not ship in this repo. Mentions of "NEXO Desktop" in changelog entries describe coordinated client releases that consume the Brain CLI / MCP contract. For the commercial Desktop product, contact info@wazion.com.
 
 NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. It adds a local shared brain across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, smarter retrieval defaults, long-horizon overnight analysis, and 150+ MCP tools.
 
+v7.25.6: patch release. Existing Local Memory sidecar databases repair legacy root/exclusion columns before source-dependent indexes are created, and core background crons prefer the NEXO-managed Python runtime.
 v7.25.5: patch release. Explicit user-included Local Memory roots can override default system/noisy-tree skips, Brain LocalIndex operator messages stay English, and Desktop-managed installs keep the Core-pinned Python 3.12 runtime contract.
 v7.25.4: patch release. Local Memory starts from safe user-content and email roots instead of whole-disk roots, adds configurable file-type include/exclude rules, and cleans legacy whole-disk index state with backup or archive-rebuild safety.
 v7.25.0: minor release. Adds Memory Fabric: fast transcript index refresh, exact/prefix transcript lookup, historical backup diary reconciliation before retention cleanup, unified search/KG links for recovered diary evidence, and update/doctor repair hooks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [7.25.6] - 2026-05-24
+
+### Fixed — Local Memory update migration hardening
+
+- **Existing Local Memory sidecar databases now repair legacy root/exclusion columns before source-dependent indexes are created.** Updates from older installs no longer fail with `no such column: source` before the v2 roots/file-type migration can run.
+- **Core cron LaunchAgents and Linux timers now prefer the NEXO-managed Python runtime.** Background Local Memory and other core crons avoid accidentally using Homebrew/system Python versions that differ from the managed Brain virtual environment.
+- **Coverage:** Local Context legacy sidecar migration regression, core cron managed-Python LaunchAgent regression, full Local Context suite, full cron sync suite, and Python syntax validation.
+
 ## [7.25.5] - 2026-05-24
 
 ### Fixed — Local Memory explicit include overrides

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [Watch the overview video](https://nexo-brain.com/watch/) · [Watch on YouTube](https://www.youtube.com/watch?v=i2lkGhKyVqI) · [Open the infographic](https://nexo-brain.com/assets/nexo-brain-infographic-v5.png)
 
-Version `7.25.5` is the current packaged-runtime line. Patch release over v7.25.4 - explicit user-included Local Memory roots can override default system/noisy-tree skips, while Brain LocalIndex operator messages stay in English and Desktop continues to enforce the Core-pinned Python 3.12 runtime.
+Version `7.25.6` is the current packaged-runtime line. Patch release over v7.25.5 - existing Local Memory sidecar databases repair legacy root/exclusion columns before source-dependent indexes are created, and core background crons prefer the NEXO-managed Python runtime.
 
 Previously in `7.25.4`: patch release over v7.25.3 - Local Memory starts from safe user-content and email roots, adds configurable included/excluded file types, and cleans legacy whole-disk index state with backup or archive-rebuild safety.
 

--- a/blog/index.html
+++ b/blog/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Blog — NEXO Brain</title>
-    <meta name="description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the current 7.25.5 Local Memory explicit-include patch release.">
+    <meta name="description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the current 7.25.6 Local Memory update-migration patch release.">
     <meta name="robots" content="index, follow">
     <link rel="canonical" href="https://nexo-brain.com/blog/">
 
@@ -12,7 +12,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://nexo-brain.com/blog/">
     <meta property="og:title" content="Blog — NEXO Brain">
-    <meta property="og:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the current 7.25.5 Local Memory explicit-include patch release.">
+    <meta property="og:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the current 7.25.6 Local Memory update-migration patch release.">
     <meta property="og:image" content="https://nexo-brain.com/assets/og/og-blog.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -20,7 +20,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Blog — NEXO Brain">
-    <meta name="twitter:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the current 7.25.5 Local Memory explicit-include patch release.">
+    <meta name="twitter:description" content="Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the current 7.25.6 Local Memory update-migration patch release.">
     <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-blog.png">
 
     <script type="application/ld+json">
@@ -28,7 +28,7 @@
         "@context": "https://schema.org",
         "@type": "CollectionPage",
         "name": "Blog — NEXO Brain",
-        "description": "Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the current 7.25.5 Local Memory explicit-include patch release.",
+        "description": "Articles on AI agent memory, cognitive runtimes, release engineering, and the science behind NEXO Brain, including the current 7.25.6 Local Memory update-migration patch release.",
         "url": "https://nexo-brain.com/blog/",
         "isPartOf": {
             "@type": "WebSite",
@@ -134,7 +134,7 @@
                     <span class="page-chip">Shared brain product notes</span>
                 </div>
                 <div class="hero-actions" style="justify-content:flex-start;">
-                    <a href="/blog/nexo-7-25-5/" class="btn btn-primary">Read latest release</a>
+                    <a href="/blog/nexo-7-25-6/" class="btn btn-primary">Read latest release</a>
                     <a href="/changelog/" class="btn btn-secondary">Latest release notes</a>
                     <a href="/evolution/" class="btn btn-secondary">See Evolution</a>
                 </div>
@@ -148,16 +148,16 @@
                     <span class="compare-chip">File types</span>
                     <span class="compare-chip">Patch</span>
                 </div>
-                <h2>NEXO 7.25.5: explicit Local Memory include overrides</h2>
-                <p>Patch release over v7.25.4. Explicit user-included roots can now override default skipped/system/noisy-tree rules, Brain LocalIndex messages stay English, and Desktop Python guidance matches the Core-pinned 3.12 runtime.</p>
+                <h2>NEXO 7.25.6: Local Memory update migration hardening</h2>
+                <p>Patch release over v7.25.5. Existing Local Memory sidecar databases repair legacy root/exclusion columns before source-dependent indexes are created, and core background crons prefer the managed Python runtime.</p>
                 <div class="hero-actions" style="justify-content:flex-start;margin-bottom:18px;">
-                    <a href="/blog/nexo-7-25-5/" class="btn btn-primary">Open article</a>
-                    <a href="/changelog/#v7255" class="btn btn-secondary">Open changelog</a>
+                    <a href="/blog/nexo-7-25-6/" class="btn btn-primary">Open article</a>
+                    <a href="/changelog/#v7256" class="btn btn-secondary">Open changelog</a>
                 </div>
                 <div class="blog-mini-stack">
                     <div class="blog-mini-card">
                         <strong>Companion view</strong>
-                        <span><a href="/changelog/#v7255">See the full v7.25.5 changelog</a></span>
+                        <span><a href="/changelog/#v7256">See the full v7.25.6 changelog</a></span>
                     </div>
                     <div class="blog-mini-card">
                         <strong>Previous release</strong>

--- a/blog/nexo-7-25-6/index.html
+++ b/blog/nexo-7-25-6/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>NEXO 7.25.6: Local Memory update migration hardening</title>
+<meta name="description" content="NEXO Brain v7.25.6 repairs legacy Local Memory sidecar schemas before source-dependent indexes are created and keeps core crons on the managed Python runtime.">
+<link rel="canonical" href="https://nexo-brain.com/blog/nexo-7-25-6/">
+<meta name="robots" content="index, follow">
+<link rel="stylesheet" href="/assets/style.css">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"NEXO 7.25.6: Local Memory update migration hardening","datePublished":"2026-05-24","author":{"@type":"Person","name":"Francisco Cerda Puigserver"},"publisher":{"@type":"Organization","name":"WAzion"}}</script>
+</head>
+<body>
+<main class="section-compact">
+<div class="container" style="max-width:860px;">
+<a href="/blog/">Back to blog</a>
+<p class="section-label">Release notes</p>
+<h1>NEXO 7.25.6 - Local Memory update migration hardening</h1>
+<p>v7.25.6 is a focused hotfix for existing installs that already had an older Local Memory sidecar database. Those databases could contain root and exclusion tables without the newer <code>source</code> metadata columns.</p>
+<p>The update path now repairs those legacy columns before creating indexes that depend on them, so migration reaches the roots/file-type cleanup step instead of stopping with <code>no such column: source</code>.</p>
+<p>The release also keeps core background crons, including Local Memory indexing, on the NEXO-managed Python runtime first. This avoids accidental use of a different Homebrew or system Python version after an install or update.</p>
+<pre><code>nexo update
+nexo local-context status --json
+nexo doctor --tier runtime</code></pre>
+<p><a href="/changelog/#v7256">Read the full v7.25.6 changelog</a></p>
+</div>
+</main>
+</body>
+</html>

--- a/changelog/index.html
+++ b/changelog/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Changelog — NEXO Brain</title>
-    <meta name="description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v7.25.5 adds explicit Local Memory include overrides.">
+    <meta name="description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v7.25.6 hardens Local Memory update migration.">
     <meta name="robots" content="index, follow">
     <link rel="canonical" href="https://nexo-brain.com/changelog/">
 
@@ -12,7 +12,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://nexo-brain.com/changelog/">
     <meta property="og:title" content="Changelog — NEXO Brain">
-    <meta property="og:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v7.25.5 adds explicit Local Memory include overrides.">
+    <meta property="og:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v7.25.6 hardens Local Memory update migration.">
     <meta property="og:image" content="https://nexo-brain.com/assets/og/og-changelog.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -20,7 +20,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Changelog — NEXO Brain">
-    <meta name="twitter:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v7.25.5 adds explicit Local Memory include overrides.">
+    <meta name="twitter:description" content="Full version history for NEXO Brain cognitive runtime. Latest release: v7.25.6 hardens Local Memory update migration.">
     <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-changelog.png">
 
     <script type="application/ld+json">
@@ -28,7 +28,7 @@
         "@context": "https://schema.org",
         "@type": "CollectionPage",
         "name": "Changelog — NEXO Brain",
-        "description": "Full version history for NEXO Brain cognitive runtime. Latest release: v7.25.5 adds explicit Local Memory include overrides.",
+        "description": "Full version history for NEXO Brain cognitive runtime. Latest release: v7.25.6 hardens Local Memory update migration.",
         "url": "https://nexo-brain.com/changelog/",
         "isPartOf": {
             "@type": "WebSite",
@@ -87,13 +87,13 @@
                 <h1 class="section-title" style="font-size:clamp(32px,5vw,56px);">Changelog</h1>
                 <p class="section-subtitle">Every feature, fix, and improvement &mdash; from the beginning, with the same visual clarity as the rest of the site.</p>
                 <div class="page-chip-row">
-                    <span class="page-chip">v7.25.5 live</span>
-                    <span class="page-chip">Explicit includes</span>
-                    <span class="page-chip">Python 3.12</span>
+                    <span class="page-chip">v7.25.6 live</span>
+                    <span class="page-chip">Migration repair</span>
+                    <span class="page-chip">Managed Python</span>
                     <span class="page-chip">Patch release</span>
                 </div>
                 <div class="hero-actions" style="justify-content:flex-start;">
-                    <a href="#v7255" class="btn btn-primary">Start with v7.25.5</a>
+                    <a href="#v7256" class="btn btn-primary">Start with v7.25.6</a>
                     <a href="#v7122" class="btn btn-secondary">See v7.12.2</a>
                     <a href="/evolution/" class="btn btn-secondary">See Evolution</a>
                 </div>
@@ -101,8 +101,8 @@
             <div class="page-visual">
                 <div class="page-stack">
                     <div class="page-stack-card">
-                        <strong>v7.25.5</strong>
-                        <span>Patch - explicit user-included Local Memory roots override default skipped/system/noisy-tree rules, while Brain messages stay English and Desktop Python guidance stays on 3.12.</span>
+                        <strong>v7.25.6</strong>
+                        <span>Patch - existing Local Memory sidecar databases repair legacy root/exclusion columns before source-dependent indexes are created, and core crons prefer the managed Python runtime.</span>
                     </div>
                     <div class="page-stack-card">
                         <strong>v7.17.8</strong>
@@ -344,6 +344,14 @@
 <section class="section-compact" style="background:rgba(124,58,237,0.08);">
     <div class="container desktop-disclaimer" style="max-width:860px;font-size:13px;line-height:1.55;">
         <p><strong>About NEXO Desktop.</strong> NEXO Desktop is a separate closed-source companion client distributed at <a href="https://nexo-desktop.com/">nexo-desktop.com</a>. When a changelog entry mentions NEXO Desktop it refers to a coordinated client release that consumes the Brain CLI/MCP contract. Desktop source does not live in this repo; the Brain (AGPL-3.0) remains fully usable on its own from terminal, Codex, Claude Code, or any MCP client.</p>
+    </div>
+</section>
+
+<section id="v7256" class="section-compact" style="background:linear-gradient(135deg,#1f2937 0%,#7c3aed 100%);">
+    <div class="container">
+        <div class="section-label">New in v7.25.6 <span style="opacity:.5;font-weight:400;">&mdash; May 24, 2026 &mdash; <strong>PATCH</strong></span></div>
+        <h2 class="section-title">Local Memory update migration hardening</h2>
+        <p class="section-subtitle">Existing Local Memory sidecar databases now repair legacy root/exclusion columns before source-dependent indexes are created, and core background crons prefer the NEXO-managed Python runtime.</p>
     </div>
 </section>
 

--- a/clawhub-skill/SKILL.md
+++ b/clawhub-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nexo-brain
 description: Cognitive memory system for AI agents — Atkinson-Shiffrin memory model, semantic RAG, trust scoring, and metacognitive error prevention. Gives your agent persistent memory that learns, forgets, and adapts.
-version: 7.25.5
+version: 7.25.6
 metadata:
   openclaw:
     requires:

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents</title>
-    <meta name="description" content="Libre/open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients. Version 7.25.5 adds explicit Local Memory include overrides and keeps Desktop-managed Python on the Core-pinned 3.12 runtime.">
+    <meta name="description" content="Libre/open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients. Version 7.25.6 hardens Local Memory update migration and keeps core crons on the managed Python runtime.">
     <meta name="keywords" content="AI memory, cognitive architecture, MCP, Claude Code, Codex, Claude Desktop, agent memory, vector search, AI agents, shared brain, open source">
     <meta name="author" content="WAzion">
     <meta name="robots" content="index, follow">
@@ -14,7 +14,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://nexo-brain.com">
     <meta property="og:title" content="NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents">
-    <meta property="og:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 7.25.5 adds explicit Local Memory include overrides and keeps Desktop-managed Python on the Core-pinned 3.12 runtime.">
+    <meta property="og:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 7.25.6 hardens Local Memory update migration and keeps core crons on the managed Python runtime.">
     <meta property="og:image" content="https://nexo-brain.com/assets/og/og-home.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -22,7 +22,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="NEXO Brain — Libre Shared Brain for Claude Code, Codex, and MCP Agents">
-    <meta name="twitter:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 7.25.5 adds explicit Local Memory include overrides and keeps Desktop-managed Python on the Core-pinned 3.12 runtime.">
+    <meta name="twitter:description" content="Libre/open-source cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 7.25.6 hardens Local Memory update migration and keeps core crons on the managed Python runtime.">
     <meta name="twitter:image" content="https://nexo-brain.com/assets/og/og-home.png">
 
     <!-- Google Analytics (GA4) -->
@@ -46,12 +46,12 @@
         "@context": "https://schema.org",
         "@type": "SoftwareApplication",
         "name": "NEXO Brain",
-        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 7.25.5 adds explicit Local Memory include overrides and keeps Desktop-managed Python on the Core-pinned 3.12 runtime.",
+        "description": "Libre/open-source local cognitive runtime with a shared brain across Claude Code, Codex, Claude Desktop, and other MCP clients. Version 7.25.6 hardens Local Memory update migration and keeps core crons on the managed Python runtime.",
         "applicationCategory": "DeveloperApplication",
         "operatingSystem": "macOS, Linux, Windows",
         "url": "https://nexo-brain.com",
         "downloadUrl": "https://www.npmjs.com/package/nexo-brain",
-        "softwareVersion": "7.25.5",
+        "softwareVersion": "7.25.6",
         "license": "https://www.gnu.org/licenses/agpl-3.0",
         "author": {
             "@type": "Organization",
@@ -697,7 +697,7 @@
     <div class="container">
         <div class="hero-badge fade-up">
             <span class="dot"></span>
-            <span id="version-badge">v7.25.5</span> Patch release - explicit user-included Local Memory roots override default skipped/system/noisy-tree rules, with Brain messages kept English and Desktop Python guidance aligned to 3.12. <a href="/changelog/#v7255">Read the v7.25.5 notes</a>.
+            <span id="version-badge">v7.25.6</span> Patch release - existing Local Memory sidecar databases repair legacy root/exclusion columns before source-dependent indexes are created, and core crons use the managed Python runtime. <a href="/changelog/#v7256">Read the v7.25.6 notes</a>.
         </div>
         <div class="fade-up" style="display:flex;gap:8px;justify-content:center;margin-bottom:12px;">
             <img src="https://img.shields.io/npm/v/nexo-brain?color=7C3AED&label=npm" alt="npm version">

--- a/llms.txt
+++ b/llms.txt
@@ -1,9 +1,10 @@
 # NEXO Brain
 
-> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v7.25.5). NEXO Desktop is a separate closed-source companion app distributed at nexo-desktop.com; its source does not ship in this repo. Mentions of "NEXO Desktop" in changelog entries describe coordinated client releases that consume the Brain CLI / MCP contract. For the commercial Desktop product, contact info@wazion.com.
+> Open-source cognitive runtime with a shared brain for Claude Code, Codex, Claude Desktop, and other MCP clients (v7.25.6). NEXO Desktop is a separate closed-source companion app distributed at nexo-desktop.com; its source does not ship in this repo. Mentions of "NEXO Desktop" in changelog entries describe coordinated client releases that consume the Brain CLI / MCP contract. For the commercial Desktop product, contact info@wazion.com.
 
 NEXO Brain gives AI agents persistent memory using the Atkinson-Shiffrin cognitive architecture. It adds a local shared brain across supported clients, configurable terminal and automation backends, recovery-aware background jobs, startup preflight, runtime self-healing, smarter retrieval defaults, long-horizon overnight analysis, and 150+ MCP tools.
 
+v7.25.6: patch release. Existing Local Memory sidecar databases repair legacy root/exclusion columns before source-dependent indexes are created, and core background crons prefer the NEXO-managed Python runtime.
 v7.25.5: patch release. Explicit user-included Local Memory roots can override default system/noisy-tree skips, Brain LocalIndex operator messages stay English, and Desktop-managed installs keep the Core-pinned Python 3.12 runtime contract.
 v7.25.4: patch release. Local Memory starts from safe user-content and email roots instead of whole-disk roots, adds configurable file-type include/exclude rules, and cleans legacy whole-disk index state with backup or archive-rebuild safety.
 v7.25.3: patch release. Desktop-managed Brain installs require the same Python ABI as the bundled wheels and repair incompatible managed virtual environments before reuse.

--- a/openclaw-plugin/package-lock.json
+++ b/openclaw-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "7.25.5",
+  "version": "7.25.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wazionapps/openclaw-memory-nexo-brain",
-      "version": "7.25.5",
+      "version": "7.25.6",
       "license": "AGPL-3.0",
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazionapps/openclaw-memory-nexo-brain",
-  "version": "7.25.5",
+  "version": "7.25.6",
   "description": "OpenClaw native memory plugin powered by NEXO Brain \u2014 Atkinson-Shiffrin cognitive memory, semantic RAG, trust scoring, and metacognitive guard.",
   "type": "module",
   "main": "dist/index.js",

--- a/openclaw-plugin/src/mcp-bridge.ts
+++ b/openclaw-plugin/src/mcp-bridge.ts
@@ -82,7 +82,7 @@ export class McpBridge {
     await this.send("initialize", {
       protocolVersion: "2024-11-05",
       capabilities: {},
-      clientInfo: { name: "openclaw-memory-nexo-brain", version: "7.25.5" },
+      clientInfo: { name: "openclaw-memory-nexo-brain", version: "7.25.6" },
     });
 
     await this.send("notifications/initialized", {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "7.25.5",
+  "version": "7.25.6",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/release-contracts/smoke/v7.25.6.json
+++ b/release-contracts/smoke/v7.25.6.json
@@ -1,0 +1,141 @@
+{
+  "release_line": "v7.25",
+  "version": "7.25.6",
+  "generated_at": "2026-05-24T19:20:18.849341+00:00",
+  "ok": true,
+  "groups": [
+    {
+      "id": "local_index_legacy_sidecar_migration",
+      "description": "Existing Local Memory sidecar DBs repair legacy v2 columns before source-dependent indexes",
+      "command": [
+        "/opt/homebrew/opt/python@3.14/bin/python3.14",
+        "-m",
+        "pytest",
+        "-q",
+        "tests/test_local_context.py::test_local_context_repairs_legacy_sidecar_v2_columns_before_source_indexes"
+      ],
+      "targets": [
+        "tests/test_local_context.py::test_local_context_repairs_legacy_sidecar_v2_columns_before_source_indexes"
+      ],
+      "returncode": 0,
+      "ok": true,
+      "duration_seconds": 2.49,
+      "stdout": ".                                                                        [100%]Running teardown with pytest sessionfinish...\n\n1 passed in 0.12s\n",
+      "stderr": ""
+    },
+    {
+      "id": "managed_python_core_crons",
+      "description": "Core cron LaunchAgents prefer the NEXO-managed Python runtime",
+      "command": [
+        "/opt/homebrew/opt/python@3.14/bin/python3.14",
+        "-m",
+        "pytest",
+        "-q",
+        "tests/test_cron_sync.py::test_build_plist_uses_managed_runtime_python"
+      ],
+      "targets": [
+        "tests/test_cron_sync.py::test_build_plist_uses_managed_runtime_python"
+      ],
+      "returncode": 0,
+      "ok": true,
+      "duration_seconds": 2.33,
+      "stdout": ".                                                                        [100%]Running teardown with pytest sessionfinish...\n\n1 passed in 0.12s\n",
+      "stderr": ""
+    },
+    {
+      "id": "local_index_roots_v2",
+      "description": "Local Memory roots v2 starts conservative, preserves email/user content, and supports explicit includes",
+      "command": [
+        "/opt/homebrew/opt/python@3.14/bin/python3.14",
+        "-m",
+        "pytest",
+        "-q",
+        "tests/test_local_context.py::test_file_type_rules_allow_user_include_and_exclude_overrides",
+        "tests/test_local_context.py::test_roots_seed_v2_migration_removes_legacy_disk_root_but_keeps_user_content",
+        "tests/test_local_context.py::test_user_include_overrides_default_skipped_tree_under_core_root",
+        "tests/test_local_context.py::test_windows_drive_roots_detect_nested_paths"
+      ],
+      "targets": [
+        "tests/test_local_context.py::test_file_type_rules_allow_user_include_and_exclude_overrides",
+        "tests/test_local_context.py::test_roots_seed_v2_migration_removes_legacy_disk_root_but_keeps_user_content",
+        "tests/test_local_context.py::test_user_include_overrides_default_skipped_tree_under_core_root",
+        "tests/test_local_context.py::test_windows_drive_roots_detect_nested_paths"
+      ],
+      "returncode": 0,
+      "ok": true,
+      "duration_seconds": 3.36,
+      "stdout": "....                                                                     [100%]Running teardown with pytest sessionfinish...\n\n4 passed in 1.12s\n",
+      "stderr": ""
+    },
+    {
+      "id": "local_index_privacy_hygiene",
+      "description": "Default root scans avoid system/noisy trees while repair paths clean removed or unsafe state",
+      "command": [
+        "/opt/homebrew/opt/python@3.14/bin/python3.14",
+        "-m",
+        "pytest",
+        "-q",
+        "tests/test_local_context.py::test_default_roots_include_local_email_sources_and_extract_messages",
+        "tests/test_local_context.py::test_system_volume_scan_excludes_system_but_reads_shared_app_data",
+        "tests/test_local_context.py::test_system_temporary_paths_are_skipped_from_root_scan",
+        "tests/test_local_context.py::test_installer_volume_is_not_a_default_mounted_root",
+        "tests/test_local_context.py::test_doctor_local_index_hygiene_repairs_removed_root_residue"
+      ],
+      "targets": [
+        "tests/test_local_context.py::test_default_roots_include_local_email_sources_and_extract_messages",
+        "tests/test_local_context.py::test_system_volume_scan_excludes_system_but_reads_shared_app_data",
+        "tests/test_local_context.py::test_system_temporary_paths_are_skipped_from_root_scan",
+        "tests/test_local_context.py::test_installer_volume_is_not_a_default_mounted_root",
+        "tests/test_local_context.py::test_doctor_local_index_hygiene_repairs_removed_root_residue"
+      ],
+      "returncode": 0,
+      "ok": true,
+      "duration_seconds": 2.43,
+      "stdout": ".....                                                                    [100%]Running teardown with pytest sessionfinish...\n\n5 passed in 0.39s\n",
+      "stderr": ""
+    },
+    {
+      "id": "managed_python_contract",
+      "description": "Desktop-managed Brain installs reject non-Core-pinned Python ABI versions",
+      "command": [
+        "/opt/homebrew/opt/python@3.14/bin/python3.14",
+        "-m",
+        "pytest",
+        "-q",
+        "tests/test_startup_preflight.py::test_desktop_managed_venv_only_accepts_core_pinned_python"
+      ],
+      "targets": [
+        "tests/test_startup_preflight.py::test_desktop_managed_venv_only_accepts_core_pinned_python"
+      ],
+      "returncode": 0,
+      "ok": true,
+      "duration_seconds": 2.36,
+      "stdout": ".                                                                        [100%]Running teardown with pytest sessionfinish...\n\n1 passed in 0.12s\n",
+      "stderr": ""
+    },
+    {
+      "id": "release_surface_contract",
+      "description": "Release-facing public surfaces and contract metadata stay aligned for v7.25.6",
+      "command": [
+        "/opt/homebrew/opt/python@3.14/bin/python3.14",
+        "scripts/verify_release_readiness.py",
+        "--ci",
+        "--contract",
+        "release-contracts/v7.25.6.json",
+        "--require-contract-complete"
+      ],
+      "targets": [
+        "scripts/verify_release_readiness.py",
+        "--ci",
+        "--contract",
+        "release-contracts/v7.25.6.json",
+        "--require-contract-complete"
+      ],
+      "returncode": 0,
+      "ok": true,
+      "duration_seconds": 27.43,
+      "stdout": "[sync-release-artifacts] OK\n........................................................................ [ 32%]\n........................................................................ [ 64%]\n........................................................................ [ 97%]\n......                                                                   [100%]Running teardown with pytest sessionfinish...\n\n222 passed in 24.56s\n[client-parity] docs OK\n[client-parity] parity tests OK\n[release-readiness] changelog OK (7.25.6)\n[release-readiness] repo public surfaces OK (/Users/franciscoc/Documents/_PhpstormProjects/nexo)\n[release-readiness] duplicate artifact hygiene OK (/Users/franciscoc/Documents/_PhpstormProjects/nexo)\n[release-readiness] $ /opt/homebrew/opt/python@3.14/bin/python3.14 scripts/sync_release_artifacts.py --check\n[release-readiness] $ /opt/homebrew/opt/python@3.14/bin/python3.14 scripts/verify_client_parity.py\n[release-readiness] website skipped (missing /Users/franciscoc/Documents/_PhpstormProjects/nexo-gh-pages)\n[release-readiness] publication state OK (status=ready, checklist_complete=True)\n[release-readiness] contract OK (release-contracts/v7.25.6.json, release_line=v7.25, target_version=7.25.6, gates=4)\n[release-readiness] OK\n",
+      "stderr": ""
+    }
+  ]
+}

--- a/release-contracts/v7.25.6.json
+++ b/release-contracts/v7.25.6.json
@@ -1,0 +1,100 @@
+{
+  "release_line": "v7.25",
+  "target_version": "7.25.6",
+  "scope_owner": "NEXO",
+  "distribution": {
+    "git_updates_on": "merge_to_main",
+    "packaged_release_on": "tag_publish"
+  },
+  "required_repo_files": [
+    "package.json",
+    "CHANGELOG.md",
+    "README.md",
+    "llms.txt",
+    ".well-known/llms.txt",
+    "sitemap.xml",
+    "index.html",
+    "blog/index.html",
+    "blog/nexo-7-25-6/index.html",
+    "changelog/index.html",
+    "release-contracts/v7.25.6.json",
+    "scripts/run_v7_25_smoke.py",
+    "scripts/sync_release_artifacts.py",
+    "scripts/verify_release_readiness.py",
+    ".claude-plugin/plugin.json",
+    "clawhub-skill/SKILL.md",
+    "openclaw-plugin/package.json",
+    "openclaw-plugin/src/mcp-bridge.ts",
+    "src/db/_schema.py",
+    "src/crons/sync.py",
+    "tests/test_local_context.py",
+    "tests/test_cron_sync.py"
+  ],
+  "required_website_files": [
+    "index.html",
+    "blog/index.html",
+    "blog/nexo-7-25-6/index.html",
+    "changelog/index.html",
+    "llms.txt",
+    ".well-known/llms.txt",
+    "sitemap.xml"
+  ],
+  "smoke": {
+    "required_groups": [
+      "local_index_legacy_sidecar_migration",
+      "managed_python_core_crons",
+      "local_index_roots_v2",
+      "local_index_privacy_hygiene",
+      "managed_python_contract",
+      "release_surface_contract"
+    ],
+    "max_age_hours": 48
+  },
+  "publication": {
+    "status": "ready",
+    "checklist_complete": true,
+    "blockers": []
+  },
+  "gates": [
+    {
+      "id": "legacy_sidecar_schema_repair",
+      "title": "Local Memory repairs legacy sidecar schema before source-dependent indexes",
+      "status": "complete",
+      "evidence_required": [
+        "Existing local_index_roots rows missing source/remote/seed_version are preserved and repaired",
+        "Existing local_index_exclusions rows missing source/kind are preserved and repaired",
+        "Source-dependent indexes are created after the additive repair"
+      ]
+    },
+    {
+      "id": "managed_python_core_crons",
+      "title": "Core background crons prefer the NEXO-managed Python runtime",
+      "status": "complete",
+      "evidence_required": [
+        "macOS LaunchAgents use the managed runtime Python when available",
+        "Linux timers and WSL host Local Memory tasks use the same resolver",
+        "NEXO_RUNTIME_PYTHON is exported to managed cron environments"
+      ]
+    },
+    {
+      "id": "roots_v2_contract_preserved",
+      "title": "Local Memory roots v2 and file-type controls remain intact",
+      "status": "complete",
+      "evidence_required": [
+        "Default roots stay conservative and preserve email/user content",
+        "Explicit user includes still override default skipped-tree rules",
+        "File-type include/exclude overrides remain configurable"
+      ]
+    },
+    {
+      "id": "public_release_surfaces",
+      "title": "Public release surfaces and integration artifacts are aligned for v7.25.6",
+      "status": "complete",
+      "evidence_required": [
+        "README, llms, homepage, blog index, blog post, changelog page, and sitemap reference v7.25.6",
+        "Claude plugin, ClawHub skill, and OpenClaw package metadata reference 7.25.6",
+        "Release smoke and readiness checks validate the v7.25.6 contract before tag publish"
+      ]
+    }
+  ]
+}

--- a/scripts/run_v7_25_smoke.py
+++ b/scripts/run_v7_25_smoke.py
@@ -13,9 +13,23 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-DEFAULT_OUTPUT = ROOT / "release-contracts" / "smoke" / "v7.25.5.json"
+DEFAULT_OUTPUT = ROOT / "release-contracts" / "smoke" / "v7.25.6.json"
 
 SMOKE_GROUPS = [
+    {
+        "id": "local_index_legacy_sidecar_migration",
+        "description": "Existing Local Memory sidecar DBs repair legacy v2 columns before source-dependent indexes",
+        "targets": [
+            "tests/test_local_context.py::test_local_context_repairs_legacy_sidecar_v2_columns_before_source_indexes",
+        ],
+    },
+    {
+        "id": "managed_python_core_crons",
+        "description": "Core cron LaunchAgents prefer the NEXO-managed Python runtime",
+        "targets": [
+            "tests/test_cron_sync.py::test_build_plist_uses_managed_runtime_python",
+        ],
+    },
     {
         "id": "local_index_roots_v2",
         "description": "Local Memory roots v2 starts conservative, preserves email/user content, and supports explicit includes",
@@ -46,12 +60,12 @@ SMOKE_GROUPS = [
     },
     {
         "id": "release_surface_contract",
-        "description": "Release-facing public surfaces and contract metadata stay aligned for v7.25.5",
+        "description": "Release-facing public surfaces and contract metadata stay aligned for v7.25.6",
         "args": [
             "scripts/verify_release_readiness.py",
             "--ci",
             "--contract",
-            "release-contracts/v7.25.5.json",
+            "release-contracts/v7.25.6.json",
             "--require-contract-complete",
         ],
     },

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -19,6 +19,12 @@
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://nexo-brain.com/blog/nexo-7-25-6/</loc>
+    <lastmod>2026-05-24</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://nexo-brain.com/blog/nexo-7-25-5/</loc>
     <lastmod>2026-05-24</lastmod>
     <changefreq>weekly</changefreq>

--- a/src/crons/sync.py
+++ b/src/crons/sync.py
@@ -150,6 +150,41 @@ RETIRED_CORE_FILES = (
 )
 
 
+def _resolve_core_python_bin() -> str:
+    """Prefer the NEXO-managed Python for core cron execution."""
+    candidates = [
+        os.environ.get("NEXO_RUNTIME_PYTHON", ""),
+        os.environ.get("NEXO_PYTHON", ""),
+        str(RUNTIME_ROOT / ".venv" / "bin" / "python3"),
+        str(RUNTIME_ROOT / ".venv" / "bin" / "python"),
+        str(_runtime_code_dir() / ".venv" / "bin" / "python3"),
+        str(_runtime_code_dir() / ".venv" / "bin" / "python"),
+    ]
+    if platform.system() == "Darwin":
+        candidates.extend(
+            [
+                "/Library/Frameworks/Python.framework/Versions/3.12/bin/python3",
+                "/opt/homebrew/bin/python3.12",
+                "/usr/local/bin/python3.12",
+                "/opt/homebrew/bin/python3",
+                "/usr/local/bin/python3",
+                "/usr/bin/python3",
+            ]
+        )
+    else:
+        candidates.extend(["/usr/bin/python3", "/usr/local/bin/python3", "python3"])
+
+    for candidate in candidates:
+        if not candidate:
+            continue
+        expanded = Path(str(candidate)).expanduser()
+        if expanded.exists():
+            return str(expanded)
+        if os.sep not in str(candidate) and shutil.which(str(candidate)):
+            return str(candidate)
+    return "python3"
+
+
 def _runtime_scripts_dir() -> Path:
     new = RUNTIME_ROOT / "core" / "scripts"
     legacy = RUNTIME_ROOT / "scripts"
@@ -407,21 +442,10 @@ def build_plist(cron: dict) -> dict:
     if subdir_src.is_dir():
         _copy_into_runtime(subdir_src)
 
+    python_bin = _resolve_core_python_bin()
     if script_type == "shell":
         program_args = ["/bin/bash", wrapper_path, cron_id, "/bin/bash", script_path]
     else:
-        # Find python3
-        python_candidates = [
-            "/opt/homebrew/bin/python3",
-            "/usr/local/bin/python3",
-            "/Library/Frameworks/Python.framework/Versions/3.12/bin/python3",
-            "/usr/bin/python3",
-        ]
-        python_bin = "python3"
-        for p in python_candidates:
-            if Path(p).exists():
-                python_bin = p
-                break
         program_args = ["/bin/bash", wrapper_path, cron_id, python_bin, script_path]
 
     plist = {
@@ -436,6 +460,7 @@ def build_plist(cron: dict) -> dict:
             "NEXO_CODE": str(_runtime_code_dir()),
             "NEXO_SOURCE_CODE": str(SOURCE_ROOT),
             "NEXO_MANAGED_CORE_CRON": "1",
+            "NEXO_RUNTIME_PYTHON": python_bin,
             "PYTHONUNBUFFERED": "1",
         },
     }
@@ -505,6 +530,7 @@ def _linux_crontab_entry(cron: dict, exec_cmd: str, stdout_log: Path, stderr_log
             "HOME": Path.home(),
             "NEXO_HOME": NEXO_HOME,
             "NEXO_CODE": _runtime_code_dir(),
+            "NEXO_RUNTIME_PYTHON": _resolve_core_python_bin(),
             "PYTHONUNBUFFERED": "1",
         }.items()
     )
@@ -578,12 +604,13 @@ def _sync_wsl_windows_host_local_index_task(dry_run: bool = False) -> dict:
         log("WARNING: WSL_DISTRO_NAME missing; local-index host task not installed.")
         return {"ok": False, "skipped": True, "reason": "wsl_distro_missing"}
 
-    python_bin = "/usr/bin/python3" if Path("/usr/bin/python3").exists() else "python3"
+    python_bin = _resolve_core_python_bin()
     script_path = _runtime_code_dir() / "scripts" / "nexo-local-index.py"
     command = (
         f"cd {shlex.quote(str(Path.home()))} && "
         f"NEXO_HOME={shlex.quote(str(NEXO_HOME))} "
         f"NEXO_CODE={shlex.quote(str(_runtime_code_dir()))} "
+        f"NEXO_RUNTIME_PYTHON={shlex.quote(python_bin)} "
         f"{shlex.quote(python_bin)} {shlex.quote(str(script_path))}"
     )
     wsl_args = " ".join(
@@ -835,11 +862,7 @@ def sync_linux(dry_run: bool = False):
 
     log(f"Manifest: {len(manifest_crons)} core crons")
 
-    python_bin = "/usr/bin/python3"
-    for p in ["/usr/bin/python3", "/usr/local/bin/python3"]:
-        if Path(p).exists():
-            python_bin = p
-            break
+    python_bin = _resolve_core_python_bin()
 
     enable_units: list[str] = []
     crontab_entries: list[str] = []
@@ -878,6 +901,7 @@ Type={service_type}
 ExecStart={exec_cmd}
 Environment=NEXO_HOME={NEXO_HOME}
 Environment=NEXO_CODE={_runtime_code_dir()}
+Environment=NEXO_RUNTIME_PYTHON={python_bin}
 Environment=HOME={Path.home()}
 StandardOutput=append:{stdout_log}
 StandardError=append:{stderr_log}

--- a/src/db/_schema.py
+++ b/src/db/_schema.py
@@ -1767,6 +1767,7 @@ def _m62_memory_observations_fts_trigger_fix(conn):
 
 def _m63_local_context_layer(conn):
     """Local Context Layer storage for on-device memory indexing."""
+    _m63_repair_legacy_local_context_columns(conn)
     conn.executescript(
         """
         CREATE TABLE IF NOT EXISTS local_index_roots (
@@ -1993,6 +1994,35 @@ def _m63_local_context_layer(conn):
             ON local_embeddings(chunk_id);
         """
     )
+
+
+def _table_exists(conn, table: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=? LIMIT 1",
+        (table,),
+    ).fetchone()
+    return bool(row)
+
+
+def _m63_repair_legacy_local_context_columns(conn):
+    """Add v2 columns before m63 creates indexes that reference them.
+
+    Existing sidecar DBs can already have m63-era tables without the v2
+    columns. CREATE TABLE IF NOT EXISTS will not alter those tables, so index
+    creation must be preceded by additive repairs.
+    """
+    if _table_exists(conn, "local_index_roots"):
+        _migrate_add_column(conn, "local_index_roots", "source", "TEXT NOT NULL DEFAULT 'legacy'")
+        _migrate_add_column(conn, "local_index_roots", "remote", "INTEGER NOT NULL DEFAULT 0")
+        _migrate_add_column(conn, "local_index_roots", "seed_version", "INTEGER NOT NULL DEFAULT 1")
+    if _table_exists(conn, "local_index_exclusions"):
+        _migrate_add_column(conn, "local_index_exclusions", "source", "TEXT NOT NULL DEFAULT 'legacy'")
+        _migrate_add_column(conn, "local_index_exclusions", "kind", "TEXT NOT NULL DEFAULT 'folder'")
+    if _table_exists(conn, "local_index_file_type_rules"):
+        _migrate_add_column(conn, "local_index_file_type_rules", "source", "TEXT NOT NULL DEFAULT 'legacy'")
+        _migrate_add_column(conn, "local_index_file_type_rules", "priority", "INTEGER NOT NULL DEFAULT 0")
+        _migrate_add_column(conn, "local_index_file_type_rules", "reason", "TEXT NOT NULL DEFAULT ''")
+        _migrate_add_column(conn, "local_index_file_type_rules", "updated_at", "REAL NOT NULL DEFAULT 0")
 
 
 def _m64_local_context_live_dirs(conn):

--- a/tests/test_cron_sync.py
+++ b/tests/test_cron_sync.py
@@ -10,6 +10,36 @@ from pathlib import Path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
 
+def test_build_plist_uses_managed_runtime_python(tmp_path, monkeypatch):
+    from crons import sync as cron_sync
+
+    source_root = tmp_path / "repo-src"
+    runtime_root = tmp_path / "nexo-home"
+    (source_root / "scripts").mkdir(parents=True)
+    (runtime_root / "runtime" / "logs").mkdir(parents=True)
+    managed_python = runtime_root / ".venv" / "bin" / "python3"
+    managed_python.parent.mkdir(parents=True)
+    managed_python.write_text("#!/bin/sh\nexit 0\n")
+
+    (source_root / "local_index.py").write_text("print('ok')\n")
+    wrapper = source_root / "scripts" / "nexo-cron-wrapper.sh"
+    wrapper.write_text("#!/bin/bash\nexit 0\n")
+    wrapper.chmod(0o755)
+
+    monkeypatch.delenv("NEXO_RUNTIME_PYTHON", raising=False)
+    monkeypatch.delenv("NEXO_PYTHON", raising=False)
+    monkeypatch.setattr(cron_sync, "SOURCE_ROOT", source_root)
+    monkeypatch.setattr(cron_sync, "RUNTIME_ROOT", runtime_root)
+    monkeypatch.setenv("NEXO_HOME", str(runtime_root))
+    monkeypatch.setattr(cron_sync, "NEXO_HOME", runtime_root)
+    monkeypatch.setattr(cron_sync, "LOG_DIR", runtime_root / "runtime" / "logs")
+
+    plist = cron_sync.build_plist({"id": "local-index", "script": "local_index.py"})
+
+    assert plist["ProgramArguments"][3] == str(managed_python)
+    assert plist["EnvironmentVariables"]["NEXO_RUNTIME_PYTHON"] == str(managed_python)
+
+
 def test_build_plist_runs_from_runtime_root(tmp_path, monkeypatch):
     from crons import sync as cron_sync
 

--- a/tests/test_local_context.py
+++ b/tests/test_local_context.py
@@ -24,6 +24,57 @@ def test_local_context_migration_tables_exist():
     assert row is not None
 
 
+def test_local_context_repairs_legacy_sidecar_v2_columns_before_source_indexes():
+    close_local_context_db()
+    db_path = local_context_db_path()
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    raw = sqlite3.connect(db_path)
+    try:
+        raw.executescript(
+            """
+            CREATE TABLE local_index_roots (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                root_path TEXT NOT NULL UNIQUE,
+                display_path TEXT NOT NULL,
+                mode TEXT NOT NULL DEFAULT 'normal',
+                depth INTEGER NOT NULL DEFAULT 2,
+                status TEXT NOT NULL DEFAULT 'active',
+                last_scan_at REAL,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL
+            );
+            CREATE TABLE local_index_exclusions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                path TEXT NOT NULL UNIQUE,
+                display_path TEXT NOT NULL,
+                reason TEXT NOT NULL DEFAULT 'user',
+                created_at REAL NOT NULL
+            );
+            INSERT INTO local_index_roots(root_path, display_path, mode, depth, status, created_at, updated_at)
+            VALUES ('/legacy-root', '/legacy-root', 'normal', 2, 'active', 1, 1);
+            INSERT INTO local_index_exclusions(path, display_path, reason, created_at)
+            VALUES ('/legacy-root/System', '/legacy-root/System', 'legacy', 1);
+            """
+        )
+        raw.commit()
+    finally:
+        raw.close()
+
+    conn = get_local_context_db()
+
+    root_columns = {row["name"] for row in conn.execute("PRAGMA table_info(local_index_roots)").fetchall()}
+    exclusion_columns = {row["name"] for row in conn.execute("PRAGMA table_info(local_index_exclusions)").fetchall()}
+    assert {"source", "remote", "seed_version"}.issubset(root_columns)
+    assert {"source", "kind"}.issubset(exclusion_columns)
+
+    root = conn.execute("SELECT source, remote, seed_version FROM local_index_roots WHERE root_path='/legacy-root'").fetchone()
+    exclusion = conn.execute("SELECT source, kind FROM local_index_exclusions WHERE path='/legacy-root/System'").fetchone()
+    assert dict(root) == {"source": "legacy", "remote": 0, "seed_version": 1}
+    assert dict(exclusion) == {"source": "legacy", "kind": "folder"}
+    assert conn.execute("SELECT 1 FROM sqlite_master WHERE type='index' AND name='idx_local_index_roots_source'").fetchone()
+    assert conn.execute("SELECT 1 FROM sqlite_master WHERE type='index' AND name='idx_local_index_exclusions_source'").fetchone()
+
+
 def test_local_context_migrates_legacy_rows_out_of_main_db():
     main = get_db()
     main.execute(


### PR DESCRIPTION
## Summary
- repair legacy Local Memory sidecar root/exclusion columns before creating source-dependent indexes
- prefer the NEXO-managed Python runtime for core cron LaunchAgents, Linux timers, and WSL Local Memory host task
- bump Brain to 7.25.6 and align release surfaces, contract, and smoke artifact

## Verification
- python3 -m pytest -q tests/test_cron_sync.py
- python3 -m pytest -q tests/test_local_context.py
- python3 scripts/verify_release_readiness.py --ci --contract release-contracts/v7.25.6.json --require-contract-complete --require-smoke
- python3 scripts/run_v7_25_smoke.py