### PR TITLE
Cognitive OS Ola 0 — critical cognition + reliability fixes (Brain 7.31.14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [7.31.14] - 2026-06-14
+
+### Fixed - Cognitive OS Ola 0: critical cognition + reliability bugs
+
+- **Cron-fleet drift can no longer be caused by a test run.** `crons/sync.py` wrote (and removed) real `~/Library/LaunchAgents` plists *before* checking `launchctl_side_effects_allowed()`, so a pytest run (temp `NEXO_HOME`, real `HOME`) rewrote the operator's real consolidation plists with temp-dir paths — one reboot from silently killing the whole nightly cron fleet (deep-sleep, decay, evolution, synthesis, …). The guard now gates the plist write/removal and the LaunchAgents `mkdir`; intentional installs (real runtime or `NEXO_ALLOW_EPHEMERAL_INSTALL=1`) are unaffected.
+- **Spreading activation is process-stable again.** `cognitive/_search._canonical_co_id` used the builtin `hash()` (salted per process via `PYTHONHASHSEED`), so co-activation links written in one MCP process never matched the same memory in the next (~6× distinct ids per memory), silently degrading associative recall. It now uses `blake2b` for a deterministic id across processes and runs.
+- **`guard_context` no longer fakes evidence.** The pre-answer `guard_context` source returned `evidence_refs=["guard_context:requested"]` with no real check, silently satisfying the critical-tier required-source / gap gate for release/server/billing/legal. It now performs a real file-conditioned-learning lookup and fails closed (never fabricates evidence).
+- **Auto error→learning capture works.** `hooks/auto_capture._auto_learning_add` called a non-existent `tools_learnings.add_learning` (AttributeError swallowed), so every correction-triggered auto-learning silently failed to persist. It now calls the real `handle_learning_add`.
+- **The answer-contract (verify/ask/defer) gate can be fulfilled.** `g1_enforcer` keyed fulfillment on a `confidence_checks` table that no code ever created or wrote, so verify contracts were structurally unfulfillable. Added migration `m82` and `handle_confidence_check` now persists a row per call.
+- **Approval-paused workflows survive resume.** The portable-context resume bundle filtered `workflow_runs` by a non-canonical `needs_approval` status (canonical is `waiting_approval`), dropping approval-paused runs from the next session's resume.
+
 ## [7.31.13] - 2026-06-14
 
 ### Fixed - offline wheel bundle / cross-platform installs

--- a/docs/specs/2026-06-14-silent-repair-before-ui.md
+++ b/docs/specs/2026-06-14-silent-repair-before-ui.md
@@ -1,0 +1,185 @@
+# Silent Repair Before UI - Technical Spec
+
+Created: 2026-06-14
+Owner: NEXO Brain / Desktop
+Status: implementation-ready draft
+Related followup: NF-DS-D2DD7E22
+
+## Decision
+
+NEXO should attempt safe repairs before showing a user-facing prompt. The UI is
+reserved for cases where the agent/runtime cannot continue without the user's
+explicit consent, credentials, permissions, payment authority, or acceptance of
+destructive risk.
+
+The repair layer is not a second supervisor. It is a bounded preflight and
+recovery contract used by Desktop, Brain jobs, followup-runner, email-monitor
+and other local automations before they escalate to Francisco.
+
+## Goals
+
+- Reduce avoidable alerts for routine local failures.
+- Keep the operator out of low-risk maintenance work.
+- Make every automatic repair auditable.
+- Prevent silent action where consent or irreversible risk is required.
+- Add regression tests so "repair first" does not become "hide failures".
+
+## Non-Goals
+
+- No silent login, account creation, payment, purchase or subscription change.
+- No silent permission granting in macOS, Windows, browser, cloud or provider
+  dashboards.
+- No destructive action such as delete, purge, revoke, rotate, force-push,
+  production DB mutation, customer message or public publish.
+- No repair on Nora/Maria infrastructure unless the current user message gives
+  explicit permission for that resource.
+- No bypass of provider security flows, OAuth consent screens, 2FA or legal
+  acceptance.
+
+## Repair Classes
+
+### Safe Automatic Repair
+
+Allowed without UI when all conditions are true:
+
+- The action is local or already within the running process authority.
+- The action is reversible or idempotent.
+- The expected result is machine-verifiable.
+- The action does not change billing, credentials, public content, customer
+  state, external permissions or production data.
+- The action writes a compact audit event with input symptom, action, result
+  and evidence.
+
+Examples:
+
+- Restart a local helper process that is already managed by NEXO.
+- Recreate a missing local cache directory.
+- Retry a failed local index job with a smaller batch.
+- Clear a stale lock after verifying the owning PID is gone.
+- Reconnect to an MCP/runtime endpoint after confirming the configured port.
+- Refresh local capability/catalog metadata.
+- Re-run a deterministic health check after a transient failure.
+
+### Prompt Required
+
+The UI must interrupt and ask before action when any condition is true:
+
+- Login, OAuth, 2FA, session re-authentication or provider account access is
+  required.
+- A macOS/Windows/browser permission must be granted or changed.
+- The action can incur cost, consume paid credits, start a paid VM, buy a
+  number/domain/certificate, or change billing configuration.
+- The action is destructive, public, customer-visible, externally delivered or
+  hard to roll back.
+- The action needs a secret that is not already available in the secure store.
+- The system has conflicting evidence or cannot verify the target state.
+
+Examples:
+
+- Ask for Full Disk Access, Accessibility, microphone, camera or automation
+  permission.
+- Request a Cloudflare, Stripe, OpenAI, Twilio or Chrome Web Store credential.
+- Start paid infrastructure that is currently stopped.
+- Publish a Chrome Web Store release, send an email to a customer, rotate a
+  live key, delete DB rows, purge files or alter DNS.
+
+## Runtime Contract
+
+Every repair attempt uses this envelope:
+
+```json
+{
+  "schema_version": 1,
+  "repair_id": "uuid",
+  "surface": "desktop|brain|followup-runner|email-monitor|cron",
+  "symptom": "short_machine_label",
+  "risk_class": "safe_auto|prompt_required|blocked",
+  "preconditions": [],
+  "action": "short_action_label",
+  "target": "local process/cache/file/runtime endpoint",
+  "evidence_before": [],
+  "evidence_after": [],
+  "result": "repaired|unchanged|failed|prompt_required",
+  "operator_message": null
+}
+```
+
+Rules:
+
+- `risk_class=safe_auto` may execute without UI.
+- `risk_class=prompt_required` must return a UI payload and execute nothing.
+- `risk_class=blocked` records the blocker and executes nothing.
+- `operator_message` stays null for successful automatic repairs unless a
+  concise later report is useful.
+- Failed automatic repair may retry once if the second attempt has a distinct
+  deterministic action. After that it escalates with evidence.
+
+## UI Contract
+
+Desktop shows a prompt only for `prompt_required` and unrepaired failures. The
+prompt must state:
+
+- what is blocked
+- what permission/credential/cost/risk is needed
+- what NEXO already tried
+- the exact action button
+- the safe alternative, if any
+
+No prompt should ask Francisco to run terminal commands when NEXO can perform
+the safe preparation itself.
+
+## Audit And Storage
+
+Successful and failed repairs are logged to the normal operational ledger. The
+minimum durable fields are:
+
+- timestamp UTC
+- session id or job id
+- surface
+- symptom
+- action
+- result
+- evidence references
+- whether user attention was required
+
+The log must not include secrets, raw customer content, OAuth tokens, provider
+keys or full private payloads.
+
+## Regression Tests
+
+Add tests at the repair policy boundary, not just happy paths:
+
+- Safe local stale lock is removed only when PID is absent.
+- Missing cache directory is recreated and logged.
+- Runtime reconnect is attempted once, then escalates with evidence.
+- Login-required provider response returns `prompt_required` and does not retry
+  in a loop.
+- Missing credential returns `prompt_required`; it does not create flat secret
+  files.
+- Cost action returns `prompt_required`; it does not start paid infrastructure.
+- Destructive action returns `prompt_required`; it does not delete or mutate.
+- Nora/Maria target without current explicit permission returns
+  `prompt_required` or `blocked`.
+- Audit event redacts secrets and private payloads.
+
+## Acceptance Criteria
+
+- A shared repair policy module classifies safe automatic repairs versus prompt
+  required cases.
+- At least Desktop startup, followup-runner and email-monitor use the policy
+  before surfacing routine local failures.
+- Automatic repairs produce evidence events.
+- UI prompts appear only for login, permission, cost, destructive/public action,
+  missing credential, unresolved conflict or unrepaired failure.
+- Regression tests cover all cases above and fail closed.
+
+## Rollout
+
+Phase 1: Brain/followup-runner policy module and tests.
+
+Phase 2: Desktop startup and health panel integration.
+
+Phase 3: Email-monitor and scheduled automations.
+
+Phase 4: Operator-facing summary in Home only for repeated repairs, unrepaired
+failures or prompts that require a real decision.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexo-brain",
-  "version": "7.31.13",
+  "version": "7.31.14",
   "mcpName": "io.github.wazionapps/nexo",
   "description": "NEXO Brain — Shared brain for AI agents. Persistent memory, semantic RAG, natural forgetting, metacognitive guard, trust scoring, 150+ MCP tools. Works with Claude Code, Codex, Claude Desktop & any MCP client. 100% local, free.",
   "homepage": "https://nexo-brain.com",

--- a/src/cognitive/_search.py
+++ b/src/cognitive/_search.py
@@ -784,8 +784,19 @@ CO_ACTIVATION_MIN_STRENGTH = 0.1
 
 
 def _canonical_co_id(store: str, mid: int) -> int:
-    """Create a canonical hash ID for co-activation tracking."""
-    return hash(f"{store}:{mid}") % (2**31)
+    """Create a canonical, PROCESS-STABLE hash ID for co-activation tracking.
+
+    MUST be deterministic across processes. Python's builtin hash() is salted
+    per process (PYTHONHASHSEED), so co-activation links written in one MCP
+    process never matched the same memory's id in the next — fragmenting the
+    associative graph (observed ~6x distinct ids per memory) and silently
+    degrading spreading activation to within-a-single-process-lifetime. blake2b
+    is stable across processes and runs.
+    """
+    import hashlib
+
+    digest = hashlib.blake2b(f"{store}:{mid}".encode("utf-8"), digest_size=8).digest()
+    return int.from_bytes(digest, "big") % (2**31)
 
 
 def record_co_activation(memory_ids: list[tuple[str, int]]):

--- a/src/crons/sync.py
+++ b/src/crons/sync.py
@@ -727,12 +727,17 @@ def install_plist(label: str, plist: dict, plist_path: Path, dry_run: bool):
         log(f"  DRY-RUN: would install {plist_path.name}")
         return
 
+    # Ephemeral/test runtimes (temp NEXO_HOME or HOME, e.g. a pytest run) must
+    # NOT touch the operator's real ~/Library/LaunchAgents. The guard is checked
+    # BEFORE writing the plist file: otherwise a test run rewrites the real
+    # plists with temp-dir ProgramArguments, and one reboot/reload silently
+    # kills the whole consolidation cron fleet (cron-fleet-drift incident).
+    if not launchctl_side_effects_allowed():
+        log(f"  Skipped plist write in ephemeral runtime: {plist_path.name}")
+        return
+
     with open(plist_path, "wb") as f:
         plistlib.dump(plist, f)
-
-    if not launchctl_side_effects_allowed():
-        log(f"  Installed but skipped launchctl in ephemeral runtime: {plist_path.name}")
-        return
 
     result = reload_launchagent_plist(plist_path, label=label)
     if result.get("action") == "skipped-ephemeral-runtime":
@@ -751,8 +756,8 @@ def unload_plist(plist_path: Path, dry_run: bool):
         return
 
     if not launchctl_side_effects_allowed():
-        plist_path.unlink(missing_ok=True)
-        log(f"  Removed without launchctl in ephemeral runtime: {plist_path.name}")
+        # Ephemeral/test runtime: never delete the operator's real plists.
+        log(f"  Skipped plist removal in ephemeral runtime: {plist_path.name}")
         return
 
     result = unload_launchagent_plist(plist_path)
@@ -830,7 +835,9 @@ def sync(dry_run: bool = False):
         return
 
     LOG_DIR.mkdir(parents=True, exist_ok=True)
-    LAUNCH_AGENTS_DIR.mkdir(parents=True, exist_ok=True)
+    # In an ephemeral/test runtime, do not even create the real LaunchAgents dir.
+    if launchctl_side_effects_allowed():
+        LAUNCH_AGENTS_DIR.mkdir(parents=True, exist_ok=True)
 
     manifest_crons = load_manifest()
     manifest_ids = {c["id"] for c in manifest_crons}

--- a/src/db/_schema.py
+++ b/src/db/_schema.py
@@ -3081,6 +3081,37 @@ def _m81_core_rules_product_metadata(conn):
     conn.execute("CREATE INDEX IF NOT EXISTS idx_core_rules_protected ON core_rules(protected, is_active)")
 
 
+def _m82_confidence_checks(conn):
+    """Persist nexo_confidence_check calls so the answer-contract gate works.
+
+    The G1 enforcer (hooks/g1_enforcer.py) treats a verify/ask/defer contract as
+    fulfilled when a confidence_checks row exists for the session created after
+    the task opened. No code ever created or wrote this table, so verify
+    contracts were structurally unfulfillable. handle_confidence_check now writes
+    a row per call; created_at uses datetime('now') to match opened_at format.
+    """
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS confidence_checks (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT,
+            task_id TEXT,
+            goal_hash TEXT,
+            task_type TEXT,
+            area TEXT,
+            response_mode TEXT,
+            confidence INTEGER,
+            high_stakes INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT
+        )
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_confidence_checks_session "
+        "ON confidence_checks(session_id, created_at)"
+    )
+
+
 MIGRATIONS = [
     (1, "learnings_columns", _m1_learnings_columns),
     (2, "followups_reasoning", _m2_followups_reasoning),
@@ -3163,6 +3194,7 @@ MIGRATIONS = [
     (79, "operational_closure_links_readiness", _m79_operational_closure_links_readiness),
     (80, "opportunity_orchestrator", _m80_opportunity_orchestrator),
     (81, "core_rules_product_metadata", _m81_core_rules_product_metadata),
+    (82, "confidence_checks", _m82_confidence_checks),
 ]
 
 

--- a/src/hooks/auto_capture.py
+++ b/src/hooks/auto_capture.py
@@ -289,7 +289,7 @@ def _content_hash(fact_type: str, content: str) -> str:
 
 
 def _auto_learning_add(title: str, content: str) -> bool:
-    """Best-effort call to tools_learnings.add_learning.
+    """Best-effort call to tools_learnings.handle_learning_add.
 
     Returns True when the learning was stored, False otherwise. Failures
     are silent so the hook itself never breaks the user's prompt flow.
@@ -300,13 +300,19 @@ def _auto_learning_add(title: str, content: str) -> bool:
         return False
 
     try:
-        result = tools_learnings.add_learning(
+        # The public symbol is handle_learning_add. A prior call to a
+        # non-existent tools_learnings.add_learning raised AttributeError that
+        # was swallowed below, so EVERY auto-captured correction silently
+        # failed to persist a learning (error-capture / never-repeat broken).
+        result = tools_learnings.handle_learning_add(
             category="auto",
             title=title,
             content=content,
             priority="medium",
             reasoning="auto-captured from correction pattern in UserPromptSubmit/PostToolUse hook",
         )
+        if isinstance(result, str):
+            return not result.strip().upper().startswith("ERROR")
         if isinstance(result, dict):
             return bool(result.get("ok") or result.get("id") or result.get("learning_id"))
         return bool(result)

--- a/src/plugins/protocol.py
+++ b/src/plugins/protocol.py
@@ -1437,6 +1437,7 @@ def handle_confidence_check(
     unknowns: str = "[]",
     verification_step: str = "",
     stakes: str = "",
+    sid: str = "",
 ) -> str:
     """Return the metacognitive response mode: answer, verify, ask, or defer."""
     clean_goal = (goal or "").strip()
@@ -1465,6 +1466,37 @@ def handle_confidence_check(
         verification_step=(verification_step or "").strip(),
         stakes=(stakes or "").strip(),
     )
+    # Persist the check so the G1 answer-contract gate can detect fulfillment of
+    # verify/ask/defer contracts (this table was previously never written, so
+    # verify contracts were structurally unfulfillable). Best-effort: a failure
+    # here must never break the metacognitive answer — g1 simply re-nudges, a
+    # visible signal rather than a silent corruption.
+    try:
+        import hashlib
+        from db import get_db
+        from plugins.guard import _resolve_active_sid
+        conn = get_db()
+        resolved_sid = (sid or "").strip() or _resolve_active_sid(conn)
+        if resolved_sid:
+            conn.execute(
+                """INSERT INTO confidence_checks
+                   (session_id, task_id, goal_hash, task_type, area,
+                    response_mode, confidence, high_stakes, created_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))""",
+                (
+                    resolved_sid,
+                    "",
+                    hashlib.sha256(clean_goal.encode("utf-8")).hexdigest()[:16],
+                    clean_type,
+                    (area or "").strip(),
+                    str(result.get("mode") or ""),
+                    int(result.get("confidence") or 0),
+                    1 if result.get("high_stakes") else 0,
+                ),
+            )
+            conn.commit()
+    except Exception:
+        pass
     return json.dumps({"ok": True, **result}, ensure_ascii=False, indent=2)
 
 

--- a/src/pre_answer_router.py
+++ b/src/pre_answer_router.py
@@ -1987,15 +1987,48 @@ def _source_filesystem(request: SourceRequest) -> SourceResult:
 
 
 def _source_guard_context(request: SourceRequest) -> SourceResult:
-    # G01 cannot call the MCP guard from this pure core. Return the file scope
-    # so G15 can wire real guard context without changing the source plan.
-    if not request.files:
+    # Real guard verification: surface the file-conditioned blocking learnings
+    # for the requested files. Previously this returned fake evidence
+    # (evidence_refs=["guard_context:requested"], result_count=1) WITHOUT any
+    # check, which silently satisfied the critical-tier required-source / gap
+    # gate for release/server/billing/legal areas. Never fake evidence again.
+    files = [f.strip() for f in (request.files or "").split(",") if f.strip()]
+    if not files:
         return SourceResult(source="guard_context")
+    try:
+        from db import get_db
+        from plugins.guard import _load_conditioned_learnings
+        conn = get_db()
+        conditioned = _load_conditioned_learnings(conn, files)
+    except Exception:
+        # Fail-closed: do NOT fake evidence; report that verification could not run.
+        return SourceResult(
+            source="guard_context",
+            rendered="Guard verification could not run for: " + ", ".join(files),
+            result_count=0,
+        )
+    refs: list[str] = []
+    lines: list[str] = []
+    for filepath, entries in conditioned.items():
+        for entry in entries:
+            refs.append(f"learning:{entry.get('id')}")
+            lines.append(
+                f"- [{entry.get('priority', 'medium')}] {entry.get('title', '')} (applies_to {filepath})"
+            )
+    if lines:
+        return SourceResult(
+            source="guard_context",
+            rendered="Blocking/file-conditioned learnings:\n" + "\n".join(lines),
+            evidence_refs=refs,
+            result_count=len(refs),
+        )
+    # Guard ran and found nothing blocking — a real verified-clean result.
     return SourceResult(
         source="guard_context",
-        rendered=f"Guard context requested for files: {request.files}",
-        evidence_refs=["guard_context:requested"],
-        result_count=1,
+        rendered="Guard verified: no blocking file-conditioned learnings for "
+        + ", ".join(files),
+        evidence_refs=["guard_context:verified_clean"],
+        result_count=0,
     )
 
 

--- a/src/tools_sessions.py
+++ b/src/tools_sessions.py
@@ -317,7 +317,7 @@ def _session_portability_bundle(sid: str = "") -> dict:
         dict(row) for row in conn.execute(
             """SELECT run_id, goal_id, goal, workflow_kind, status, priority, next_action, current_step_key, updated_at
                FROM workflow_runs
-               WHERE session_id = ? AND status IN ('open', 'running', 'blocked', 'needs_approval')
+               WHERE session_id = ? AND status IN ('open', 'running', 'blocked', 'waiting_approval')
                ORDER BY updated_at DESC
                LIMIT 10""",
             (session_id,),

--- a/tests/test_auto_capture_correction_learning.py
+++ b/tests/test_auto_capture_correction_learning.py
@@ -53,7 +53,10 @@ def _stub_learnings(monkeypatch, *, ok=True):
         learning_calls.append(kwargs)
         return {"ok": ok, "id": 999 if ok else 0}
     fake_module = types.ModuleType("tools_learnings")
-    fake_module.add_learning = _add_learning
+    # NOTE: the real public symbol is handle_learning_add. A prior stub named
+    # this `add_learning`, masking a production bug where auto_capture called a
+    # non-existent tools_learnings.add_learning (AttributeError swallowed).
+    fake_module.handle_learning_add = _add_learning
     sys.modules["tools_learnings"] = fake_module
     return learning_calls
 

--- a/tests/test_cron_sync.py
+++ b/tests/test_cron_sync.py
@@ -559,7 +559,14 @@ def test_sync_script_runs_directly_from_runtime_root(tmp_path):
     assert "ModuleNotFoundError" not in result.stderr
 
 
-def test_sync_writes_plist_but_skips_launchctl_when_home_is_ephemeral(tmp_path, monkeypatch):
+def test_sync_skips_plist_write_when_home_is_ephemeral(tmp_path, monkeypatch):
+    """Regression (cron-fleet-drift, 2026-06-14): an ephemeral/test runtime
+    (temp HOME or NEXO_HOME, e.g. a pytest run) must NOT write LaunchAgent
+    plists into the operator's real ~/Library/LaunchAgents. The old behavior
+    wrote the plist with temp-dir ProgramArguments and merely 'skipped
+    launchctl', which still corrupts the on-disk plists so one reboot/reload
+    silently kills the whole consolidation cron fleet. The guard must skip the
+    file write itself, not only the launchctl reload."""
     from crons import sync as cron_sync
 
     home = tmp_path / "pytest-of-user" / "pytest-1" / "test_case0"
@@ -606,8 +613,60 @@ def test_sync_writes_plist_but_skips_launchctl_when_home_is_ephemeral(tmp_path, 
 
     cron_sync.sync()
 
-    assert (launch_agents_dir / "com.nexo.watchdog.plist").is_file()
+    # The real fix: NO plist is written to the (real) LaunchAgents dir, and
+    # launchctl is never invoked, in an ephemeral runtime.
+    assert not (launch_agents_dir / "com.nexo.watchdog.plist").exists()
     assert calls == []
+
+
+def test_sync_writes_plist_when_ephemeral_install_explicitly_allowed(tmp_path, monkeypatch):
+    """When side effects ARE allowed (real install, or NEXO_ALLOW_EPHEMERAL_INSTALL=1)
+    the plist write + launchctl reload proceed normally — the guard only blocks
+    accidental writes from ephemeral/test runtimes, not intentional installs."""
+    from crons import sync as cron_sync
+
+    home = tmp_path / "real-home"
+    launch_agents_dir = home / "Library" / "LaunchAgents"
+    runtime_root = home / "nexo"
+    source_root = tmp_path / "repo-src"
+    launch_agents_dir.mkdir(parents=True)
+    (runtime_root / "runtime" / "logs").mkdir(parents=True)
+    (source_root / "scripts").mkdir(parents=True)
+    script = source_root / "scripts" / "nexo-watchdog.sh"
+    script.write_text("#!/bin/bash\nexit 0\n")
+    script.chmod(0o755)
+    wrapper = source_root / "scripts" / "nexo-cron-wrapper.sh"
+    wrapper.write_text("#!/bin/bash\nexit 0\n")
+    wrapper.chmod(0o755)
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps({
+            "crons": [
+                {"id": "watchdog", "script": "scripts/nexo-watchdog.sh", "type": "shell", "interval_seconds": 1800}
+            ]
+        })
+    )
+
+    reload_calls: list = []
+
+    monkeypatch.setattr(cron_sync.platform, "system", lambda: "Darwin")
+    # Force the guard to "allowed" to deterministically exercise the install path
+    # regardless of which launchctl_side_effects_allowed implementation is loaded.
+    monkeypatch.setattr(cron_sync, "launchctl_side_effects_allowed", lambda: True)
+    monkeypatch.setattr(cron_sync, "LAUNCH_AGENTS_DIR", launch_agents_dir)
+    monkeypatch.setattr(cron_sync, "SOURCE_ROOT", source_root)
+    monkeypatch.setattr(cron_sync, "RUNTIME_ROOT", runtime_root)
+    monkeypatch.setattr(cron_sync, "NEXO_HOME", runtime_root)
+    monkeypatch.setattr(cron_sync, "LOG_DIR", runtime_root / "runtime" / "logs")
+    monkeypatch.setattr(cron_sync, "MANIFEST", manifest)
+    monkeypatch.setattr(cron_sync, "OPTIONALS_FILE", runtime_root / "config" / "optionals.json")
+    monkeypatch.setattr(cron_sync, "SCHEDULE_FILE", runtime_root / "config" / "schedule.json")
+    monkeypatch.setattr(cron_sync, "reload_launchagent_plist", lambda *a, **k: (reload_calls.append(True), {"ok": True})[1])
+
+    cron_sync.sync()
+
+    assert (launch_agents_dir / "com.nexo.watchdog.plist").is_file()
+    assert reload_calls == [True]
 
 
 def test_sync_linux_weekday_uses_launchd_convention(tmp_path, monkeypatch):

--- a/tests/test_ola0_critical_fixes.py
+++ b/tests/test_ola0_critical_fixes.py
@@ -1,0 +1,129 @@
+"""Regression tests for the Ola 0 critical fixes (2026-06-14).
+
+Covers: co-activation determinism, auto error->learning capture, the
+guard_context fake-evidence security hole, and the confidence_checks
+answer-contract fulfillment table.
+"""
+import hashlib
+import json
+
+
+# --- #1 co-activation: deterministic, process-stable id (not builtin hash) ---
+
+def test_canonical_co_id_is_process_stable_not_builtin_hash():
+    from cognitive._search import _canonical_co_id
+
+    expected = int.from_bytes(
+        hashlib.blake2b(b"stm:1", digest_size=8).digest(), "big"
+    ) % (2 ** 31)
+    assert _canonical_co_id("stm", 1) == expected
+    # stable on repeated calls and distinct per (store, mid)
+    assert _canonical_co_id("stm", 1) == _canonical_co_id("stm", 1)
+    assert _canonical_co_id("stm", 1) != _canonical_co_id("ltm", 1)
+
+
+# --- #3 auto error->learning capture (handle_learning_add, not add_learning) ---
+
+def test_auto_learning_add_persists_real_learning():
+    import tools_learnings
+    from hooks.auto_capture import _auto_learning_add
+    from db import get_db
+
+    # The public symbol must exist (the bug called a non-existent add_learning).
+    assert hasattr(tools_learnings, "handle_learning_add")
+    assert not hasattr(tools_learnings, "add_learning")
+
+    ok = _auto_learning_add(
+        "Ola0 auto-capture regression",
+        "verifies corrections persist a durable learning via handle_learning_add",
+    )
+    assert ok is True
+    rows = get_db().execute(
+        "SELECT COUNT(*) FROM learnings WHERE title = ?",
+        ("Ola0 auto-capture regression",),
+    ).fetchone()[0]
+    assert rows >= 1
+
+
+# --- #2 guard_context: never fake evidence; surface real conditioned learnings ---
+
+def test_guard_context_no_files_returns_empty():
+    import pre_answer_router as par
+
+    req = par.SourceRequest(query="", intent="modify_existing", files="")
+    res = par._source_guard_context(req)
+    assert res.result_count == 0
+    assert not res.evidence_refs
+
+
+def test_guard_context_does_not_fake_evidence_when_clean():
+    import pre_answer_router as par
+
+    req = par.SourceRequest(
+        query="", intent="modify_existing", files="/tmp/nexo_ola0/none.py"
+    )
+    res = par._source_guard_context(req)
+    # The old stub returned evidence_refs=["guard_context:requested"], result_count=1
+    # WITHOUT any check. That must never happen again.
+    assert "guard_context:requested" not in (res.evidence_refs or [])
+    assert res.result_count == 0
+    assert "verified" in res.rendered.lower()
+
+
+def test_guard_context_surfaces_real_conditioned_learning():
+    import tools_learnings
+    import pre_answer_router as par
+
+    target = "/tmp/nexo_ola0/guarded_file.py"
+    tools_learnings.handle_learning_add(
+        category="testing",
+        title="Ola0 guard conditioned rule",
+        content="must surface as guard_context evidence",
+        applies_to=target,
+        priority="high",
+    )
+    req = par.SourceRequest(query="", intent="modify_existing", files=target)
+    res = par._source_guard_context(req)
+    assert res.result_count >= 1
+    assert any(ref.startswith("learning:") for ref in res.evidence_refs)
+    assert "guard_context:requested" not in (res.evidence_refs or [])
+
+
+# --- #4 confidence_checks: handle_confidence_check persists; g1 detects fulfillment ---
+
+def test_confidence_check_persists_row_and_g1_detects_fulfillment():
+    from plugins import protocol
+    from hooks.g1_enforcer import _has_followup_event_since
+    from db import get_db
+
+    conn = get_db()
+    sid = "nexo-test-cc-ola0"
+    conn.execute(
+        "INSERT INTO sessions (sid, task, started_epoch, last_update_epoch) VALUES (?, ?, ?, ?)",
+        (sid, "ola0 cc test", 1.0, 2.0),
+    )
+    conn.commit()
+
+    out = json.loads(protocol.handle_confidence_check(
+        goal="Should I claim this is done without evidence?",
+        task_type="answer",
+        sid=sid,
+    ))
+    assert out["ok"] is True
+
+    n = conn.execute(
+        "SELECT COUNT(*) FROM confidence_checks WHERE session_id = ?", (sid,)
+    ).fetchone()[0]
+    assert n == 1
+
+    # g1 must now see the contract as fulfillable for this session.
+    assert _has_followup_event_since(conn, "confidence_checks", sid, "2000-01-01 00:00:00") is True
+
+
+def test_confidence_checks_table_exists_after_migrations():
+    from db import get_db
+
+    row = get_db().execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='confidence_checks'"
+    ).fetchone()
+    assert row is not None


### PR DESCRIPTION
## NEXO Cognitive OS — Ola 0: critical cognition + reliability fixes

Brain **7.31.14**. A read-only multi-agent audit (15 subsystem maps + 6 competitive benchmarks) surfaced ~130 gaps; this PR ships the **critical** subset, each verified with `file:line` + live-DB evidence. Full strategic report: `NEXO-Cognitive-OS-Spec-10-10.md`.

### Fixes
1. **Cron-fleet drift** (`crons/sync.py`) — `install_plist`/`unload_plist` touched the real `~/Library/LaunchAgents` *before* the ephemeral guard, so a pytest run (temp `NEXO_HOME`, real `HOME`) rewrote the operator's real consolidation plists with temp-dir paths — one reboot from silently killing the whole nightly fleet (deep-sleep/decay/evolution/synthesis). Gate the FS writes/removals + dir `mkdir` by `launchctl_side_effects_allowed()`. *(The already-corrupted live plists were repaired out-of-band.)*
2. **Spreading activation** (`cognitive/_search._canonical_co_id`) — builtin `hash()` is per-process salted, so co-activation links never matched the same memory across MCP processes (~6× id fragmentation). Use `blake2b` for a deterministic id.
3. **`guard_context` fake evidence** (`pre_answer_router`) — returned `evidence_refs=["guard_context:requested"]` with no real check, silently satisfying the critical-tier required-source/gap gate (release/server/billing/legal). Now a real file-conditioned-learning lookup; fail-closed, never fabricates.
4. **Auto error→learning capture** (`hooks/auto_capture`) — called a non-existent `tools_learnings.add_learning` (AttributeError swallowed) → corrections never persisted a learning. Call the real `handle_learning_add`.
5. **Answer-contract gate** (`db/_schema` m82 + `plugins/protocol`) — `confidence_checks` table was never created/written, so verify/ask/defer contracts were structurally unfulfillable. Create it + persist a row per `handle_confidence_check`.
6. **Approval-paused workflow resume** (`tools_sessions`) — `needs_approval` typo vs canonical `waiting_approval` dropped approval-paused runs from the resume bundle.

### Tests
- New `tests/test_ola0_critical_fixes.py` (7 cases) + updated `test_cron_sync` (encoded the buggy "write plist but skip launchctl" contract) + fixed the `auto_capture` test stub that masked bug #4.
- Full suite: **3320 passed**, 5 skipped, 1 xfailed, 4 xpassed. Client parity: **250 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
