### PR TITLE
ci(publish): raise timeout 30->60min so the grown suite can finish + publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
 
@@ -31,7 +31,7 @@ jobs:
         run: python3 scripts/verify_managed_mcp_lock.py
 
       - name: Run tests
-        run: PYTHONPATH=src pytest tests/ -v
+        run: PYTHONPATH=src pytest tests/ -q
 
       - name: Verify release readiness
         run: python3 scripts/verify_release_readiness.py --ci
@@ -39,7 +39,7 @@ jobs:
   publish:
     needs: test
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
The publish workflow's test job (pytest tests/ -v, 3324 tests) exceeds the 30min timeout on the shared CI runner (~2.5x slower than local ~12min), so v7.31.14 and v7.32.0 publish runs were cancelled before npm publish. Raise both job timeouts to 60min and use -q. Pure CI config.